### PR TITLE
fixes ESMF_DistGrid issue on stampede

### DIFF
--- a/mediator/med.F90
+++ b/mediator/med.F90
@@ -1069,8 +1069,7 @@ contains
                if (ChkErr(rc,__LINE__,u_FILE_u)) return
 
                ! Get deCount and dimCount
-               call ESMF_DistGridGet(elemDistGrid, deCount=deCount, dimCount=dimCount, &
-                     tileCount=tileCount, rc=rc)
+               call ESMF_DistGridGet(elemDistGrid, dimCount=dimCount, tileCount=tileCount, rc=rc)
                if (ChkErr(rc,__LINE__,u_FILE_u)) return
 
                ! Allocate regDecomp accord. to dimCount

--- a/mediator/med.F90
+++ b/mediator/med.F90
@@ -1068,19 +1068,29 @@ contains
                call ESMF_MeshGet(mesh, elementDistGrid=elemDistGrid, rc=rc)
                if (ChkErr(rc,__LINE__,u_FILE_u)) return
 
-               newelemDistGrid = ESMF_DistGridCreate(elemDistGrid, balanceflag=.true., rc=rc)
+               ! Get deCount and dimCount
+               call ESMF_DistGridGet(elemDistGrid, deCount=deCount, dimCount=dimCount, &
+                     tileCount=tileCount, rc=rc)
                if (ChkErr(rc,__LINE__,u_FILE_u)) return
 
-               ! call ESMF_MeshGet(mesh, nodalDistGrid=nodalDistGrid, rc=rc)
-               ! if (ChkErr(rc,__LINE__,u_FILE_u)) return
+               ! Allocate regDecomp accord. to dimCount
+               allocate(regDecompPTile(dimCount, tileCount))
+               regDecompPTile(:,:) = 1
+               regDecompPTile(1,1) = petCount
 
-               ! newnodalDistGrid = ESMF_DistGridCreate(nodalDistGrid, balanceflag=.true., rc=rc)
-               ! if (ChkErr(rc,__LINE__,u_FILE_u)) return
+               ! Allocate minIndexPTile and maxIndexPTile accord. to dimCount and tileCount
+               allocate(minIndexPTile(dimCount, tileCount), maxIndexPTile(dimCount, tileCount))
+
+               ! Get minIndexPTile and maxIndexPTile
+               call ESMF_DistGridGet(elemDistGrid, minIndexPTile=minIndexPTile, maxIndexPTile=maxIndexPTile, rc=rc)
+               if (ChkErr(rc,__LINE__,u_FILE_u)) return
+
+               ! Create new distgrid
+               newelemDistGrid = ESMF_DistGridCreate(minIndex=minIndexPTile(:,1), maxIndex= maxIndexPTile(:,1), &
+                                  regDecomp=regDecompPTile(:,1), rc=rc)
+               if (ChkErr(rc,__LINE__,u_FILE_u)) return
 
                ! Create a new Grid on the new DistGrid and swap it in the Field
-               ! newmesh = ESMF_MeshEmptyCreate(elementDistGrid=newelemDistGrid, nodalDistGrid=newnodalDistGrid, rc=rc)
-               ! if (ChkErr(rc,__LINE__,u_FILE_u)) return
-
                newmesh = ESMF_MeshEmptyCreate(elementDistGrid=newelemDistGrid, rc=rc)
                if (ChkErr(rc,__LINE__,u_FILE_u)) return
 
@@ -1111,6 +1121,9 @@ contains
                      if (ChkErr(rc,__LINE__,u_FILE_u)) return
                   endif
                enddo
+
+               ! local clean-up
+               deallocate(minIndexPTile, maxIndexPTile, regDecompPTile)
 
             else  ! geomtype
 

--- a/mediator/med_phases_aofluxes_mod.F90
+++ b/mediator/med_phases_aofluxes_mod.F90
@@ -217,6 +217,8 @@ contains
     character(*),parameter   :: subName =   '(med_aofluxes_init) '
     !-----------------------------------------------------------------------
 
+    call t_startf('MED:'//subname)
+
     if (dbug_flag > 5) then
       call ESMF_LogWrite(trim(subname)//": called", ESMF_LOGMSG_INFO)
     endif


### PR DESCRIPTION
These commit allows to fix the issue related with ESMF_DistGrid on stampede

**Used hashes/branches:**
**To test CESM application:**
CIME: 6493b342
CAM: nuopc_cap_n31_cam6_1_008/components/cam
CICE: 472a2f29
CISM: 05a64177
CLM: 899b08a9
MOSART: mosart1_0_31_nuopc03
FMS: 3b8096b
CVMIX: 534fc38
MOM: 243bf86c
POP: f4c7f4d
WW3: 2ca8091
FVGFS: f9cd8d6b

**To test FV3 application:**
CIME: 979b021 (cmeps-cime repository)
FV3GFS: c79e18b
CICE: 472a2f2
FMS: 3b8096b
CVMIX: 534fc38
MOM: 243bf86c

**Test suite:**
**To test FV3 application:**
./create_newcase --compset UFS_S2S --res C384_t025 --case ufs.s2s.c384_t025.jan --driver nuopc --run-unsupported
cd ufs.s2s.c384_t025.jan/
./case.setup
./xmlchange DOUT_S=FALSE
./xmlchange STOP_N=1
./xmlchange RUN_REFDATE=2012-01-01
./xmlchange RUN_STARTDATE=2012-01-01
./xmlchange JOB_WALLCLOCK_TIME=00:30:00
./xmlchange NTASKS_CPL=480
./xmlchange NTASKS_ATM=480
./xmlchange ROOTPE_OCN=480
./xmlchange ROOTPE_ICE=840
qcmd -- ./case.build
./case.submit

**To test CESM application:**
qcmd -l walltime=4:00:00 -- ./create_test --xml-testlist ../src/drivers/nuopc/cime_config/testdefs/testlist_drv.xml --xml-machine cheyenne --xml-category nuopc --compare may23intel19 --baseline-root /glade/p/cesmdata/cseg/nuopc_baselines

**Test baseline:** may23intel19

**Test namelist changes:** N/A

**Test expected fails:**
Following tests fail due to the MOM restart problem:
ERR_Vnuopc_Ld5.f19_g16.BMOM.cheyenne_intel.allactive-nuopc_cap_io (Overall: FAIL) details:
    FAIL ERR_Vnuopc_Ld5.f19_g16.BMOM.cheyenne_intel.allactive-nuopc_cap_io COMPARE_base_rest
  ERS_Vnuopc_Ld5.T62_g16.CMOM.cheyenne_intel (Overall: FAIL) details:
    FAIL ERS_Vnuopc_Ld5.T62_g16.CMOM.cheyenne_intel COMPARE_base_rest
  ERS_Vnuopc_Ld5.T62_g16.GMOM.cheyenne_intel (Overall: FAIL) details:
    FAIL ERS_Vnuopc_Ld5.T62_g16.GMOM.cheyenne_intel COMPARE_base_rest 

**Following tests also fails:**
    FAIL ERS_Vnuopc_Ln9_N3.f19_g17_rx1.A.cheyenne_intel TPUTCOMP Error: Computation time increase > 25 pct from baseline
    FAIL SMS_Vnuopc_Ld1_N3.f19_g17_rx1.A.cheyenne_intel TPUTCOMP Error: Computation time increase > 25 pct from baseline
    FAIL SMS_Vnuopc_Ld5.f19_g16.BMOM.cheyenne_intel.allactive-nuopc_cap_io MEMCOMP Error: Memory usage increase > 10% from baseline 

In the cpl.r file, only one field (atmImp_Sa_topo) is not bit2bit identical.

Test status: [bit for bit, roundoff, climate changing]

Fixes [CIME Github issue #]

User interface changes?:

Update gh-pages html (Y/N)?:

Code review: