### PR TITLE
changes needed for mom6 mct/nuopc validation

### DIFF
--- a/cime_config/namelist_definition_drv.xml
+++ b/cime_config/namelist_definition_drv.xml
@@ -442,7 +442,7 @@
     </values>
   </entry>
 
-  <entry id="logfilepostfix">
+  <entry id="logFilePostFix">
     <type>char</type>
     <category>expdef</category>
     <group>DRIVER_attributes</group>
@@ -454,7 +454,7 @@
     </values>
   </entry>
 
-  <entry id="outpathroot">
+  <entry id="outPathRoot">
     <type>char</type>
     <category>expdef</category>
     <group>DRIVER_attributes</group>
@@ -490,7 +490,7 @@
     </values>
   </entry>
 
-  <entry id="med_model">
+  <entry id="MED_model">
     <type>char</type>
     <category>nuopc</category>
     <group>ALLCOMP_attributes</group>
@@ -498,7 +498,7 @@
       <value cime_model="cesm">cesm</value>
     </values>
   </entry>
-  <entry id="atm_model" modify_via_xml="COMP_ATM">
+  <entry id="ATM_model" modify_via_xml="COMP_ATM">
     <type>char</type>
     <category>nuopc</category>
     <group>ALLCOMP_attributes</group>
@@ -506,7 +506,7 @@
       <value>$COMP_ATM</value>
     </values>
   </entry>
-  <entry id="ocn_model" modify_via_xml="COMP_OCN">
+  <entry id="OCN_model" modify_via_xml="COMP_OCN">
     <type>char</type>
     <category>nuopc</category>
     <group>ALLCOMP_attributes</group>
@@ -514,7 +514,7 @@
       <value>$COMP_OCN</value>
     </values>
   </entry>
-  <entry id="ice_model" modify_via_xml="COMP_ICE">
+  <entry id="ICE_model" modify_via_xml="COMP_ICE">
     <type>char</type>
     <category>nuopc</category>
     <group>ALLCOMP_attributes</group>
@@ -522,7 +522,7 @@
       <value>$COMP_ICE</value>
     </values>
   </entry>
-  <entry id="rof_model" modify_via_xml="COMP_ROF">
+  <entry id="ROF_model" modify_via_xml="COMP_ROF">
     <type>char</type>
     <category>nuopc</category>
     <group>ALLCOMP_attributes</group>
@@ -530,7 +530,7 @@
       <value>$COMP_ROF</value>
     </values>
   </entry>
-  <entry id="lnd_model" modify_via_xml="COMP_LND">
+  <entry id="LND_model" modify_via_xml="COMP_LND">
     <type>char</type>
     <category>nuopc</category>
     <group>ALLCOMP_attributes</group>
@@ -538,7 +538,7 @@
       <value>$COMP_LND</value>
     </values>
   </entry>
-  <entry id="glc_model" modify_via_xml="COMP_GLC">
+  <entry id="GLC_model" modify_via_xml="COMP_GLC">
     <type>char</type>
     <category>nuopc</category>
     <group>ALLCOMP_attributes</group>
@@ -546,7 +546,7 @@
       <value>$COMP_GLC</value>
     </values>
   </entry>
-  <entry id="wav_model" modify_via_xml="COMP_WAV">
+  <entry id="WAV_model" modify_via_xml="COMP_WAV">
     <type>char</type>
     <category>nuopc</category>
     <group>ALLCOMP_attributes</group>
@@ -807,6 +807,8 @@
     </desc>
     <values>
       <value>.true.</value>
+      <value atm_grid="T62">.false.</value>
+      <value atm_grid="TL319">.false.</value>
     </values>
   </entry>
 
@@ -1517,7 +1519,7 @@ n    </desc>
   <!-- FLDS attributes              -->
   <!-- =========================== -->
 
-  <entry id="scalarfieldname">
+  <entry id="ScalarFieldName">
     <type>char</type>
     <category>expdef</category>
     <group>ALLCOMP_attributes</group>
@@ -1529,7 +1531,7 @@ n    </desc>
     </values>
   </entry>
 
-  <entry id="scalarfieldcount">
+  <entry id="ScalarFieldCount">
     <type>integer</type>
     <category>expdef</category>
     <group>ALLCOMP_attributes</group>
@@ -1541,7 +1543,7 @@ n    </desc>
     </values>
   </entry>
 
-  <entry id="scalarfieldidxgridnx">
+  <entry id="ScalarFieldIdxGridNX">
     <type>integer</type>
     <category>expdef</category>
     <group>ALLCOMP_attributes</group>
@@ -1553,7 +1555,7 @@ n    </desc>
     </values>
   </entry>
 
-  <entry id="scalarfieldidxgridny">
+  <entry id="ScalarFieldIdxGridNY">
     <type>integer</type>
     <category>expdef</category>
     <group>ALLCOMP_attributes</group>
@@ -1565,7 +1567,7 @@ n    </desc>
     </values>
   </entry>
 
-  <entry id="scalarfieldidxnextswcday">
+  <entry id="ScalarFieldIdxNextSwCday">
     <type>integer</type>
     <category>expdef</category>
     <group>ALLCOMP_attributes</group>
@@ -1577,7 +1579,7 @@ n    </desc>
     </values>
   </entry>
 
-  <entry id="scalarfieldidxvalidglcinput">
+  <entry id="ScalarFieldIdxValidGlcInput">
     <type>integer</type>
     <category>expdef</category>
     <group>ALLCOMP_attributes</group>
@@ -1589,7 +1591,7 @@ n    </desc>
     </values>
   </entry>
 
-  <entry id="scalarfieldidxprecipfactor">
+  <entry id="ScalarFieldIdxPrecipFactor">
     <type>integer</type>
     <category>expdef</category>
     <group>ALLCOMP_attributes</group>

--- a/cime_config/runseq/runseq_CG.py
+++ b/cime_config/runseq/runseq_CG.py
@@ -13,77 +13,105 @@ def runseq(case, coupling_times):
 
     rundir    = case.get_value("RUNDIR")
     caseroot  = case.get_value("CASEROOT")
-#    cimeroot  = case.get_value("CIMEROOT")
     comp_wav  = case.get_value("COMP_WAV")
 
     atm_cpl_dt = coupling_times["atm_cpl_dt"]
     ocn_cpl_dt = coupling_times["ocn_cpl_dt"]
 
+    print "atm_cpl_dt = ",atm_cpl_dt
+    print "atm_cpl_dt = ",ocn_cpl_dt
     outfile   = open(os.path.join(caseroot, "CaseDocs", "nuopc.runseq"), "w")
 
+    # The following is for RASM_OPTION1
+
     if comp_wav == 'swav':
-        outfile.write ("runSeq::                               \n")
-        outfile.write ("@" + str(ocn_cpl_dt) + "               \n")
-        outfile.write ("  MED med_phases_prep_ocn_accum_avg    \n")
-        outfile.write ("  MED -> OCN :remapMethod=redist       \n")
-        if (atm_cpl_dt < ocn_cpl_dt):
-            outfile.write ("@" + str(atm_cpl_dt) + "           \n")
-        outfile.write ("    MED med_phases_prep_ocn_map        \n")
-        outfile.write ("    MED med_phases_aofluxes_run        \n")
-        outfile.write ("    MED med_phases_prep_ocn_merge      \n")
-        outfile.write ("    MED med_phases_prep_ocn_accum_fast \n")
-        outfile.write ("    MED med_phases_ocnalb_run          \n")
-        outfile.write ("    MED med_phases_prep_ice            \n")
-        outfile.write ("    MED -> ICE :remapMethod=redist     \n")
-        outfile.write ("    ICE                                \n")
-        outfile.write ("    ROF                                \n")
-        outfile.write ("    ATM                                \n")
-        outfile.write ("    ICE -> MED :remapMethod=redist     \n")
-        outfile.write ("    MED med_fraction_set               \n")
-        outfile.write ("    ROF -> MED :remapMethod=redist     \n")
-        outfile.write ("    ATM -> MED :remapMethod=redist     \n")
-        outfile.write ("    MED med_phases_history_write       \n")
-        outfile.write ("    MED med_phases_profile             \n")
-        if (atm_cpl_dt < ocn_cpl_dt):
-            outfile.write ("  @                                \n")
-        outfile.write ("  OCN                                  \n")
-        outfile.write ("  OCN -> MED :remapMethod=redist       \n")
-        outfile.write ("  MED med_phases_restart_write         \n")
-        outfile.write ("@                                      \n")
-        outfile.write ("::                                     \n")
+        outfile.write ("runSeq::                                \n")
+
+        if ocn_cpl_dt > atm_cpl_dt:
+            outfile.write ("@" + str(ocn_cpl_dt) + "            \n")
+            outfile.write ("  MED med_phases_prep_ocn_accum_avg \n")
+            outfile.write ("  MED -> OCN :remapMethod=redist    \n")
+            outfile.write ("@" + str(atm_cpl_dt) + "            \n")
+
+        if ocn_cpl_dt == atm_cpl_dt:
+            outfile.write ("@" + str(ocn_cpl_dt) + "            \n")
+
+        outfile.write ("  MED med_phases_prep_ocn_map           \n")
+        outfile.write ("  MED med_phases_aofluxes_run           \n")
+        outfile.write ("  MED med_phases_prep_ocn_merge         \n")
+        outfile.write ("  MED med_phases_prep_ocn_accum_fast    \n")
+        outfile.write ("  MED med_phases_ocnalb_run             \n")
+
+        if ocn_cpl_dt == atm_cpl_dt:
+            outfile.write ("  MED med_phases_prep_ocn_accum_avg \n")
+            outfile.write ("  MED -> OCN :remapMethod=redist    \n")
+
+        outfile.write ("  MED med_phases_prep_ice               \n")
+        outfile.write ("  MED -> ICE :remapMethod=redist        \n")
+
+        outfile.write ("  ICE                                   \n")
+        outfile.write ("  ROF                                   \n")
+        outfile.write ("  ATM                                   \n")
+
+        outfile.write ("  ICE -> MED :remapMethod=redist        \n")
+        outfile.write ("  MED med_fraction_set                  \n")
+
+        if (atm_cpl_dt == ocn_cpl_dt):
+            outfile.write ("  OCN                               \n")
+            outfile.write ("  OCN -> MED :remapMethod=redist    \n")
+
+        outfile.write ("  ROF -> MED :remapMethod=redist        \n")
+        outfile.write ("  ATM -> MED :remapMethod=redist        \n")
+
+        outfile.write ("  MED med_phases_history_write          \n")
+
+        if atm_cpl_dt == ocn_cpl_dt: 
+            outfile.write ("  MED med_phases_restart_write      \n")
+            outfile.write ("  MED med_phases_profile            \n")
+            outfile.write ("@                                   \n")
+            outfile.write ("::                                  \n")
+
+        if atm_cpl_dt < ocn_cpl_dt:
+            outfile.write ("@                                   \n")
+            outfile.write ("  OCN                               \n")
+            outfile.write ("  OCN -> MED :remapMethod=redist    \n")
+            outfile.write ("  MED med_phases_restart_write      \n")
+            outfile.write ("  MED med_phases_profile            \n")
+            outfile.write ("@                                   \n")
+            outfile.write ("::                                  \n")
 
     elif comp_wav == 'ww' or comp_wav == "dwav":
-        outfile.write ("runSeq::                             \n")
-        outfile.write ("@" + str(atm_cpl_dt) + "             \n") # Assume that atm_cpl_dt >= ocn_cpl_dt
-        outfile.write ("  MED med_phases_prep_ocn_map        \n") # map to ocean (including wav)
-        outfile.write ("  MED med_phases_aofluxes_run        \n") # run atm/ocn flux calculation
-        outfile.write ("  MED med_phases_prep_ocn_merge      \n")
-        outfile.write ("  MED med_phases_prep_ocn_accum_fast \n")
-        outfile.write ("  MED med_phases_prep_ocn_accum_avg  \n")
-        outfile.write ("  MED med_phases_ocnalb_run          \n")
-        outfile.write ("  MED -> OCN :remapMethod=redist     \n")
-        outfile.write ("  MED med_phases_prep_ice            \n")
-        outfile.write ("  MED -> ICE :remapMethod=redist     \n")
-        outfile.write ("  MED med_phases_prep_wav            \n")
-        outfile.write ("  MED -> WAV :remapMethod=redist     \n")
-        outfile.write ("  ICE                                \n")
-        outfile.write ("  ROF                                \n")
-        outfile.write ("  WAV                                \n")
-        outfile.write ("  ATM                                \n")
-        outfile.write ("  ICE -> MED :remapMethod=redist     \n")
-        outfile.write ("  MED med_fraction_set               \n")
-        outfile.write ("  ROF -> MED :remapMethod=redist     \n")
-        outfile.write ("  WAV -> MED :remapMethod=redist     \n")
-        outfile.write ("  ATM -> MED :remapMethod=redist     \n")
-        outfile.write ("  @ocn_cpl_dt   #ocean coupling step \n")
-        outfile.write ("    OCN                              \n")
-        outfile.write ("  @                                  \n")
-        outfile.write ("  OCN -> MED :remapMethod=redist     \n")
-        outfile.write ("  MED med_phases_restart_write       \n")
-        outfile.write ("  MED med_phases_history_write       \n")
-        outfile.write ("  MED med_phases_profile             \n")
-        outfile.write ("@                                    \n")
-        outfile.write ("::                                   \n")
+        outfile.write ("runSeq::                                \n")
+        outfile.write ("@" + str(atm_cpl_dt) + "                \n") # Assume that atm_cpl_dt >= ocn_cpl_dt
+        outfile.write ("  MED med_phases_prep_ocn_map           \n") # map to ocean (including wav)
+        outfile.write ("  MED med_phases_aofluxes_run           \n") # run atm/ocn flux calculation
+        outfile.write ("  MED med_phases_prep_ocn_merge         \n")
+        outfile.write ("  MED med_phases_prep_ocn_accum_fast    \n")
+        outfile.write ("  MED med_phases_prep_ocn_accum_avg     \n")
+        outfile.write ("  MED med_phases_ocnalb_run             \n")
+        outfile.write ("  MED -> OCN :remapMethod=redist        \n")
+        outfile.write ("  MED med_phases_prep_ice               \n")
+        outfile.write ("  MED -> ICE :remapMethod=redist        \n")
+        outfile.write ("  MED med_phases_prep_wav               \n")
+        outfile.write ("  MED -> WAV :remapMethod=redist        \n")
+        outfile.write ("  ICE                                   \n")
+        outfile.write ("  ROF                                   \n")
+        outfile.write ("  WAV                                   \n")
+        outfile.write ("  ATM                                   \n")
+        outfile.write ("  ICE -> MED :remapMethod=redist        \n")
+        outfile.write ("  MED med_fraction_set                  \n")
+        outfile.write ("  ROF -> MED :remapMethod=redist        \n")
+        outfile.write ("  WAV -> MED :remapMethod=redist        \n")
+        outfile.write ("  ATM -> MED :remapMethod=redist        \n")
+        outfile.write ("  @ocn_cpl_dt   #ocean coupling step    \n")
+        outfile.write ("    OCN                                 \n")
+        outfile.write ("  @                                     \n")
+        outfile.write ("  OCN -> MED :remapMethod=redist        \n")
+        outfile.write ("  MED med_phases_restart_write          \n")
+        outfile.write ("  MED med_phases_history_write          \n")
+        outfile.write ("  MED med_phases_profile                \n")
+        outfile.write ("@                                       \n")
+        outfile.write ("::                                      \n")
 
     outfile.close()
     shutil.copy(os.path.join(caseroot, "CaseDocs", "nuopc.runseq"), rundir)

--- a/mediator/esmFldsExchange.F90
+++ b/mediator/esmFldsExchange.F90
@@ -1035,16 +1035,16 @@ contains
     else
        ! NEMS-orig (mom6) (send longwave net to ocn via custom merge)
        if ( fldchk(is_local%wrap%FBExp(compocn)        , 'Foxx_lwnet', rc=rc) .and. &
-                 fldchk(is_local%wrap%FBMed_aoflux_o        , 'Faox_lwup' , rc=rc) .and. &
-                 fldchk(is_local%wrap%FBImp(compatm,compatm), 'Faxa_lwdn' , rc=rc) .and. &
-                 fldchk(is_local%wrap%FBImp(compatm,compatm), 'Faxa_lwnet', rc=rc)) then
+            fldchk(is_local%wrap%FBMed_aoflux_o        , 'Faox_lwup' , rc=rc) .and. &
+            fldchk(is_local%wrap%FBImp(compatm,compatm), 'Faxa_lwdn' , rc=rc) .and. &
+            fldchk(is_local%wrap%FBImp(compatm,compatm), 'Faxa_lwnet', rc=rc)) then
           call addmap(fldListFr(compatm)%flds, 'Faxa_lwdn' , compocn, mapconsf, 'one'  , atm2ocn_fmap)
           call addmap(fldListFr(compatm)%flds, 'Faxa_lwnet', compocn, mapconsf, 'one'  , atm2ocn_fmap)
 
        ! CESM (mom6) (send longwave net to ocn via auto merge)
        else if ( fldchk(is_local%wrap%FBExp(compocn)        , 'Foxx_lwnet', rc=rc) .and. &
-            fldchk(is_local%wrap%FBMed_aoflux_o        , 'Faox_lwup' , rc=rc) .and. &
-            fldchk(is_local%wrap%FBImp(compatm,compatm), 'Faxa_lwdn' , rc=rc)) then
+                 fldchk(is_local%wrap%FBMed_aoflux_o        , 'Faox_lwup' , rc=rc) .and. &
+                 fldchk(is_local%wrap%FBImp(compatm,compatm), 'Faxa_lwdn' , rc=rc)) then
           call addmap(fldListFr(compatm)%flds, 'Faxa_lwdn', compocn, mapconsf, 'one'  , atm2ocn_fmap)
           call addmrg(fldListTo(compocn)%flds, 'Foxx_lwnet', &
                mrg_from1=compmed, mrg_fld1='Faox_lwup', mrg_type1='merge', mrg_fracname1='ofrac', &
@@ -1081,47 +1081,37 @@ contains
        call addfld(fldListTo(compocn)%flds, 'Foxx_swnet_idf')
     else
        ! Net shortwave ocean (custom calculation in prep_phases_ocn_mod.F90)
-       ! export swpent to ocn without bands
-       if ( fldchk(is_local%wrap%FBExp(compocn)        , 'Foxx_swnet', rc=rc) .and. &
-            fldchk(is_local%wrap%FBImp(compatm,compatm), 'Faxa_swvdr', rc=rc) .and. &
-            fldchk(is_local%wrap%FBImp(compatm,compatm), 'Faxa_swvdf', rc=rc) .and. &
-            fldchk(is_local%wrap%FBImp(compatm,compatm), 'Faxa_swndr', rc=rc) .and. &
-            fldchk(is_local%wrap%FBImp(compatm,compatm), 'Faxa_swndr', rc=rc)) then
-          call addmap(fldListFr(compatm)%flds, 'Faxa_swvdr', compocn, mapconsf, 'one', atm2ocn_fmap)
-          call addmap(fldListFr(compatm)%flds, 'Faxa_swvdf', compocn, mapconsf, 'one', atm2ocn_fmap)
-          call addmap(fldListFr(compatm)%flds, 'Faxa_swndr', compocn, mapconsf, 'one', atm2ocn_fmap)
-          call addmap(fldListFr(compatm)%flds, 'Faxa_swndf', compocn, mapconsf, 'one', atm2ocn_fmap)
 
-          ! import swpen from ice without bands
-          if (fldchk(is_local%wrap%FBImp(compice,compice), 'Fioi_swpen', rc=rc)) then
-             call addmap(fldListFr(compice)%flds, 'Fioi_swpen',  compocn, mapfcopy, 'unset', 'unset')
-          end if
+       ! import swpen from ice without bands
+       if (fldchk(is_local%wrap%FBImp(compice,compice), 'Fioi_swpen', rc=rc)) then
+          call addmap(fldListFr(compice)%flds, 'Fioi_swpen',  compocn, mapfcopy, 'unset', 'unset')
        end if
 
-       ! export swnet to ocn by bands
-       if ( fldchk(is_local%wrap%FBExp(compocn)        , 'Foxx_swnet_vdr', rc=rc) .and. &
-            fldchk(is_local%wrap%FBExp(compocn)        , 'Foxx_swnet_vdf', rc=rc) .and. &
-            fldchk(is_local%wrap%FBExp(compocn)        , 'Foxx_swnet_idr', rc=rc) .and. &
-            fldchk(is_local%wrap%FBExp(compocn)        , 'Foxx_swnet_idf', rc=rc) .and. &
-            fldchk(is_local%wrap%FBImp(compatm,compatm), 'Faxa_swvdr'    , rc=rc) .and. &
-            fldchk(is_local%wrap%FBImp(compatm,compatm), 'Faxa_swvdf'    , rc=rc) .and. &
-            fldchk(is_local%wrap%FBImp(compatm,compatm), 'Faxa_swndr'    , rc=rc) .and. &
-            fldchk(is_local%wrap%FBImp(compatm,compatm), 'Faxa_swndf'    , rc=rc)) then
+       ! import swpen from ice by bands
+       if ( fldchk(is_local%wrap%FBImp(compice,compice), 'Fioi_swpen_vdr', rc=rc) .and. &
+            fldchk(is_local%wrap%FBImp(compice,compice), 'Fioi_swpen_vdf', rc=rc) .and. &
+            fldchk(is_local%wrap%FBImp(compice,compice), 'Fioi_swpen_idr', rc=rc) .and. &
+            fldchk(is_local%wrap%FBImp(compice,compice), 'Fioi_swpen_idf', rc=rc)) then
+          call addmap(fldListFr(compice)%flds, 'Fioi_swpen_vdr', compocn, mapfcopy, 'unset', 'unset')
+          call addmap(fldListFr(compice)%flds, 'Fioi_swpen_vdf', compocn, mapfcopy, 'unset', 'unset')
+          call addmap(fldListFr(compice)%flds, 'Fioi_swpen_idr', compocn, mapfcopy, 'unset', 'unset')
+          call addmap(fldListFr(compice)%flds, 'Fioi_swpen_idf', compocn, mapfcopy, 'unset', 'unset')
+       end if
+
+       ! import sw from atm by bands
+       if ( fldchk(is_local%wrap%FBImp(compatm,compatm), 'Faxa_swvdr', rc=rc) .and. &
+            fldchk(is_local%wrap%FBImp(compatm,compatm), 'Faxa_swvdf', rc=rc) .and. &
+            fldchk(is_local%wrap%FBImp(compatm,compatm), 'Faxa_swndr', rc=rc) .and. &
+            fldchk(is_local%wrap%FBImp(compatm,compatm), 'Faxa_swndr', rc=rc) .and. &
+            (fldchk(is_local%wrap%FBExp(compocn), 'Foxx_swnet'    , rc=rc)) .or. &
+            (fldchk(is_local%wrap%FBExp(compocn), 'Foxx_swnet_vdr', rc=rc) .and. &
+             fldchk(is_local%wrap%FBExp(compocn), 'Foxx_swnet_vdf', rc=rc) .and. &
+             fldchk(is_local%wrap%FBExp(compocn), 'Foxx_swnet_idr', rc=rc) .and. &
+             fldchk(is_local%wrap%FBExp(compocn), 'Foxx_swnet_idf', rc=rc))) then
           call addmap(fldListFr(compatm)%flds, 'Faxa_swvdr', compocn, mapconsf, 'one', atm2ocn_fmap)
           call addmap(fldListFr(compatm)%flds, 'Faxa_swvdf', compocn, mapconsf, 'one', atm2ocn_fmap)
           call addmap(fldListFr(compatm)%flds, 'Faxa_swndr', compocn, mapconsf, 'one', atm2ocn_fmap)
           call addmap(fldListFr(compatm)%flds, 'Faxa_swndf', compocn, mapconsf, 'one', atm2ocn_fmap)
-
-          ! import swpen from ice by bands
-          if ( fldchk(is_local%wrap%FBImp(compice,compice), 'Fioi_swpen_vdr', rc=rc) .and. &
-               fldchk(is_local%wrap%FBImp(compice,compice), 'Fioi_swpen_vdf', rc=rc) .and. &
-               fldchk(is_local%wrap%FBImp(compice,compice), 'Fioi_swpen_idr', rc=rc) .and. &
-               fldchk(is_local%wrap%FBImp(compice,compice), 'Fioi_swpen_idf', rc=rc)) then
-             call addmap(fldListFr(compice)%flds, 'Fioi_swpen_vdr', compocn, mapfcopy, 'unset', 'unset')
-             call addmap(fldListFr(compice)%flds, 'Fioi_swpen_vdf', compocn, mapfcopy, 'unset', 'unset')
-             call addmap(fldListFr(compice)%flds, 'Fioi_swpen_idr', compocn, mapfcopy, 'unset', 'unset')
-             call addmap(fldListFr(compice)%flds, 'Fioi_swpen_idf', compocn, mapfcopy, 'unset', 'unset')
-          end if
        end if
     end if
 
@@ -1265,6 +1255,7 @@ contains
     ! to ocn: surface latent heat flux and evaporation water flux
     ! ---------------------------------------------------------------------
     if (phase == 'advertise') then
+
        call addfld(fldListFr(compatm)%flds, 'Faxa_lat' )
        call addfld(fldListMed_aoflux%flds , 'Faox_lat' )
        call addfld(fldListMed_aoflux%flds , 'Faox_evap')

--- a/mediator/fd.yaml
+++ b/mediator/fd.yaml
@@ -27,7 +27,7 @@
          atm/ocn surface latent heat flux
      #
      - standard_name: Faox_sen
-       alias: mean_sensi_heat_flx_atm_into_ocn 
+       alias: mean_sensi_heat_flx_atm_into_ocn
        canonical_units: W m-2
        description: mediator export
          atm/ocn surface sensible heat flux
@@ -58,7 +58,7 @@
      #
      - standard_name: Fall_evap_wiso
        canonical_units: kg m-2 s-1
-       description: land export 
+       description: land export
      #
      - standard_name: Fall_fco2_lnd
        canonical_units: moles m-2 s-1
@@ -121,7 +121,7 @@
      #
      - standard_name: Sl_ddvel
        canonical_units: cm/sec
-       description: land export 
+       description: land export
           dry deposition velocities from (1->80)
      #
      - standard_name: Sl_fv
@@ -602,7 +602,7 @@
        canonical_units: tbd
        description: atmosphere export (fv3 only)
 
-######### fv3 work
+######### fv3 work start
 
      - standard_name: Faxa_taux
        alias: mean_zonal_moment_flx_atm
@@ -906,28 +906,28 @@
      #
      # NOTE: the following alias requires a new name change for CICE export
      - standard_name: Fioi_swpen_vdr
-       alias: mean_net_sw_vis_dir_flx
+       alias: mean_sw_pen_to_ocn_vis_dir_flx
        canonical_units: W m-2
        description: sea-ice export to ocean
          flux of vis dir shortwave through ice to ocean
      #
      # NOTE: the following alias requires a new name change for CICE export
      - standard_name: Fioi_swpen_vdf
-       alias: mean_net_sw_vis_dif_flx
+       alias: mean_sw_pen_to_ocn_vis_dif_flx
        canonical_units: W m-2
        description: sea-ice export to ocean
          flux of vif dir shortwave through ice to ocean
      #
      # NOTE: the following alias requires a new name change for CICE export
      - standard_name: Fioi_swpen_idr
-       alias: mean_net_sw_ir_dir_flx
+       alias: mean_sw_pen_to_ocn_ir_dir_flx
        canonical_units: W m-2
        description: sea-ice export to ocean
          flux of ir dir shortwave through ice to ocean
      #
      # NOTE: the following alias requires a new name change for CICE export
      - standard_name: Fioi_swpen_idf
-       alias: mean_net_sw_ir_dif_flx
+       alias: mean_sw_pen_to_ocn_ir_dif_flx
        canonical_units: W m-2
        description: sea-ice export to ocean
          flux of ir dif shortwave through ice to ocean
@@ -1308,12 +1308,12 @@
      - standard_name: mean_runoff_rate
        canonical_units: kg m-2 s-1
        description: ocean import
-          total runoff to ocean 
+          total runoff to ocean
      #
      - standard_name: mean_runoff_heat_flux
        canonical_units: kg m-2 s-1
        description: ocean import
-          heat content of runoff 
+          heat content of runoff
      #
      - standard_name: mean_calving_rate
        canonical_units: kg m-2 s-1
@@ -1323,7 +1323,7 @@
      - standard_name: mean_calving_heat_flux
        canonical_units: kg m-2 s-1
        description: ocean import
-          heat content of calving 
+          heat content of calving
      #
      - standard_name: Foxx_rofi
        canonical_units: kg m-2 s-1
@@ -1394,7 +1394,7 @@
          meridional surface stress
      #
      - standard_name: Fioi_swpen_ifrac_n
-       alias: mean_sw_pen_to_ocn_ifrac_n 
+       alias: mean_sw_pen_to_ocn_ifrac_n
        canonical_units: W m-2
        description: ocean import
          net shortwave radiation penetrating into ice and ocean times ice fraction for thickness category 1

--- a/mediator/med.F90
+++ b/mediator/med.F90
@@ -22,6 +22,7 @@ module MED
   use shr_nuopc_methods_mod , only : FB_Reset           => shr_nuopc_methods_FB_Reset
   use shr_nuopc_methods_mod , only : FB_Copy            => shr_nuopc_methods_FB_Copy
   use shr_nuopc_methods_mod , only : FB_FldChk          => shr_nuopc_methods_FB_FldChk
+  use shr_nuopc_methods_mod , only : FB_diagnose        => shr_nuopc_methods_FB_diagnose
   use shr_nuopc_methods_mod , only : clock_timeprint    => shr_nuopc_methods_clock_timeprint
   use shr_nuopc_time_mod    , only : set_stop_alarm     => shr_nuopc_time_set_component_stop_alarm
   use shr_nuopc_time_mod    , only : alarmInit          => shr_nuopc_time_alarmInit 
@@ -1766,6 +1767,12 @@ contains
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
     call med_fraction_set(gcomp,rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
+
+    ! should this be added here?
+    if (is_local%wrap%comp_present(compocn)) then
+       call med_phases_ocnalb_run(gcomp, rc=rc)
+       if (ChkErr(rc,__LINE__,u_FILE_u)) return
+    end if
 
     !---------------------------------------
     ! Carry out data dependency for atm initialization if needed

--- a/mediator/med_io_mod.F90
+++ b/mediator/med_io_mod.F90
@@ -876,7 +876,7 @@ contains
        rcode = pio_def_var(io_file(lfile_ind),trim(dname),PIO_DOUBLE,varid)
        if (rcode==PIO_NOERR) then
           if (NUOPC_FieldDictionaryHasEntry(trim(dname))) then
-             call NUOPC_FieldDictionaryGetEntry(itemc, canonicalUnits=cunit, rc=rc)
+             call NUOPC_FieldDictionaryGetEntry(dname, canonicalUnits=cunit, rc=rc)
              if (chkerr(rc,__LINE__,u_FILE_u)) return
              rcode = pio_put_att(io_file(lfile_ind),varid,"units",trim(cunit))
           end if
@@ -942,7 +942,7 @@ contains
        rcode = pio_def_dim(io_file(lfile_ind),trim(dname)//'_nx',lnx,dimid(1))
        rcode = pio_def_var(io_file(lfile_ind),trim(dname),PIO_DOUBLE,dimid,varid)
        if (NUOPC_FieldDictionaryHasEntry(trim(dname))) then
-          call NUOPC_FieldDictionaryGetEntry(itemc, canonicalUnits=cunit, rc=rc)
+          call NUOPC_FieldDictionaryGetEntry(dname, canonicalUnits=cunit, rc=rc)
           if (chkerr(rc,__LINE__,u_FILE_u)) return
           rcode = pio_put_att(io_file(lfile_ind),varid,"units",trim(cunit))
        end if
@@ -1009,7 +1009,7 @@ contains
        rcode = pio_def_dim(io_file(lfile_ind),trim(dname)//'_len',lnx,dimid(1))
        rcode = pio_def_var(io_file(lfile_ind),trim(dname),PIO_CHAR,dimid,varid)
        if (NUOPC_FieldDictionaryHasEntry(trim(dname))) then
-          call NUOPC_FieldDictionaryGetEntry(itemc, canonicalUnits=cunit, rc=rc)
+          call NUOPC_FieldDictionaryGetEntry(dname, canonicalUnits=cunit, rc=rc)
           if (chkerr(rc,__LINE__,u_FILE_u)) return
        end if
        rcode = pio_put_att(io_file(lfile_ind),varid,"standard_name",trim(dname))

--- a/mediator/med_io_mod.F90
+++ b/mediator/med_io_mod.F90
@@ -742,12 +742,12 @@ contains
     if (present(file_ind)) lfile_ind=file_ind
 
     if (lwhead) then
-       call NUOPC_FieldDictionaryGetEntry(dname, canonicalUnits=cunit, rc=rc)
-       if (chkerr(rc,__LINE__,u_FILE_u)) return
-       !       rcode = pio_def_dim(io_file(lfile_ind),trim(dname)//'_nx',1,dimid(1))
-       !       rcode = pio_def_var(io_file(lfile_ind),trim(dname),PIO_INT,dimid,varid)
+       if (NUOPC_FieldDictionaryHasEntry(trim(dname))) then
+          call NUOPC_FieldDictionaryGetEntry(dname, canonicalUnits=cunit, rc=rc)
+          if (chkerr(rc,__LINE__,u_FILE_u)) return
+          rcode = pio_put_att(io_file(lfile_ind),varid,"units",trim(cunit))
+       end if
        rcode = pio_def_var(io_file(lfile_ind),trim(dname),PIO_INT,varid)
-       rcode = pio_put_att(io_file(lfile_ind),varid,"units",trim(cunit))
        rcode = pio_put_att(io_file(lfile_ind),varid,"standard_name",trim(dname))
        if (lwdata) call med_io_enddef(filename, file_ind=lfile_ind)
     endif
@@ -810,12 +810,14 @@ contains
     if (present(file_ind)) lfile_ind=file_ind
 
     if (lwhead) then
-       call NUOPC_FieldDictionaryGetEntry(dname, canonicalUnits=cunit, rc=rc)
-       if (chkerr(rc,__LINE__,u_FILE_u)) return
+       if (NUOPC_FieldDictionaryHasEntry(trim(dname))) then
+          call NUOPC_FieldDictionaryGetEntry(dname, canonicalUnits=cunit, rc=rc)
+          if (chkerr(rc,__LINE__,u_FILE_u)) return
+          rcode = pio_put_att(io_file(lfile_ind),varid,"units",trim(cunit))
+       end if
        lnx = size(idata)
        rcode = pio_def_dim(io_file(lfile_ind),trim(dname)//'_nx',lnx,dimid(1))
        rcode = pio_def_var(io_file(lfile_ind),trim(dname),PIO_INT,dimid,varid)
-       rcode = pio_put_att(io_file(lfile_ind),varid,"units",trim(cunit))
        rcode = pio_put_att(io_file(lfile_ind),varid,"standard_name",trim(dname))
        if (lwdata) call med_io_enddef(filename, file_ind=lfile_ind)
     endif

--- a/mediator/med_phases_aofluxes_mod.F90
+++ b/mediator/med_phases_aofluxes_mod.F90
@@ -505,7 +505,7 @@ contains
          aoflux%roce_16O, aoflux%roce_HDO, aoflux%roce_18O, &
          aoflux%evap, aoflux%evap_16O, aoflux%evap_HDO, aoflux%evap_18O, &
          aoflux%taux, aoflux%tauy, aoflux%tref, aoflux%qref, &
-         aoflux%duu10n, ustar_sv=aoflux%ustar, re_sv=aoflux%re, ssq_sv=aoflux%ssq, &
+         0, aoflux%duu10n, ustar_sv=aoflux%ustar, re_sv=aoflux%re, ssq_sv=aoflux%ssq, &
          missval = 0.0_r8)
 
     do n = 1,lsize

--- a/mediator/med_phases_history_mod.F90
+++ b/mediator/med_phases_history_mod.F90
@@ -205,9 +205,6 @@ contains
     else
        alarmisOn = .false.
     endif
-    !DEBUG
-    alarmisOn = .true.
-    !DEBUG
 
     ! Set average history output alarm TODO: fix the following
     ! if (.not. ESMF_AlarmIsCreated(AlarmHistAvg, rc=rc)) then

--- a/mediator/med_phases_history_mod.F90
+++ b/mediator/med_phases_history_mod.F90
@@ -205,6 +205,9 @@ contains
     else
        alarmisOn = .false.
     endif
+    !DEBUG
+    alarmisOn = .true.
+    !DEBUG
 
     ! Set average history output alarm TODO: fix the following
     ! if (.not. ESMF_AlarmIsCreated(AlarmHistAvg, rc=rc)) then
@@ -279,9 +282,39 @@ contains
                        nx=nx, ny=ny, nt=1, whead=whead, wdata=wdata, pre=trim(compname(n))//'Exp', rc=rc)
                    if (ChkErr(rc,__LINE__,u_FILE_u)) return
                 endif
+                if (ESMF_FieldBundleIsCreated(is_local%wrap%FBFrac(n),rc=rc)) then
+                   nx = is_local%wrap%nx(n)
+                   ny = is_local%wrap%ny(n)
+                   call med_io_write(hist_file, iam, is_local%wrap%FBFrac(n), &
+                       nx=nx, ny=ny, nt=1, whead=whead, wdata=wdata, pre='Med_frac_'//trim(compname(n)), rc=rc)
+                   if (ChkErr(rc,__LINE__,u_FILE_u)) return
+                end if
              endif
           enddo
-
+          if (ESMF_FieldBundleIsCreated(is_local%wrap%FBMed_ocnalb_o,rc=rc)) then
+             nx = is_local%wrap%nx(compocn)
+             ny = is_local%wrap%ny(compocn)
+             call med_io_write(hist_file, iam, is_local%wrap%FBMed_ocnalb_o, &
+                  nx=nx, ny=ny, nt=1, whead=whead, wdata=wdata, pre='Med_alb_ocn', rc=rc)
+          end if
+          if (ESMF_FieldBundleIsCreated(is_local%wrap%FBMed_aoflux_o,rc=rc)) then
+             nx = is_local%wrap%nx(compocn)
+             ny = is_local%wrap%ny(compocn)
+             call med_io_write(hist_file, iam, is_local%wrap%FBMed_aoflux_o, &
+                  nx=nx, ny=ny, nt=1, whead=whead, wdata=wdata, pre='Med_aoflux_ocn', rc=rc)
+          end if
+          if (ESMF_FieldBundleIsCreated(is_local%wrap%FBMed_ocnalb_a,rc=rc)) then
+             nx = is_local%wrap%nx(compatm)
+             ny = is_local%wrap%ny(compatm)
+             call med_io_write(hist_file, iam, is_local%wrap%FBMed_ocnalb_a, &
+                  nx=nx, ny=ny, nt=1, whead=whead, wdata=wdata, pre='Med_alb_atm', rc=rc)
+          end if
+          if (ESMF_FieldBundleIsCreated(is_local%wrap%FBMed_aoflux_a,rc=rc)) then
+             nx = is_local%wrap%nx(compatm)
+             ny = is_local%wrap%ny(compatm)
+             call med_io_write(hist_file, iam, is_local%wrap%FBMed_aoflux_a, &
+                  nx=nx, ny=ny, nt=1, whead=whead, wdata=wdata, pre='Med_aoflux_atm', rc=rc)
+          end if
        enddo
 
        call med_io_close(hist_file, iam, rc=rc)

--- a/mediator/med_phases_prep_ocn_mod.F90
+++ b/mediator/med_phases_prep_ocn_mod.F90
@@ -177,6 +177,8 @@ contains
     real(R8)        , parameter    :: const_lhvap = 2.501e6_R8  ! latent heat of evaporation ~ J/kg
     real(R8)        , parameter    :: albdif = 0.06_r8          ! 60 deg reference albedo, diffuse
     character(len=*), parameter    :: subname='(med_phases_prep_ocn_merge)'
+    ! Set the following to true if want to compare directly to MCT
+    logical :: compare_to_mct = .false.
     !---------------------------------------
 
     call t_startf('MED:'//subname)
@@ -346,6 +348,7 @@ contains
                    ifrac_scaled = ifrac(n) / (frac_sum)
                    ofrac_scaled = ofrac(n) / (frac_sum)
                 endif
+
                 ifracr_scaled = ifracr(n)
                 ofracr_scaled = ofracr(n)
                 frac_sum = ifracr(n) + ofracr(n)
@@ -364,25 +367,38 @@ contains
                 Foxx_swnet_afracr(n) = ofracr_scaled*(fswabsv + fswabsi) 
              end if
 
-             if (export_swnet_by_bands) then
-                if (import_swpen_by_bands) then
-                   ! use each individual band for swpen coming from the sea-ice
-                   Foxx_swnet_vdr(n) = Faxa_swvdr(n)*(1.0_R8-albvis_dir)*ofracr_scaled + Fioi_swpen_vdr(n)*ifrac_scaled
-                   Foxx_swnet_vdf(n) = Faxa_swvdf(n)*(1.0_R8-albvis_dif)*ofracr_scaled + Fioi_swpen_vdf(n)*ifrac_scaled
-                   Foxx_swnet_idr(n) = Faxa_swndr(n)*(1.0_R8-albnir_dir)*ofracr_scaled + Fioi_swpen_idr(n)*ifrac_scaled
-                   Foxx_swnet_idf(n) = Faxa_swndf(n)*(1.0_R8-albnir_dif)*ofracr_scaled + Fioi_swpen_idf(n)*ifrac_scaled
-                else
-                   ! scale total Foxx_swnet to get contributions from each band
-                   c1 = 0.285
-                   c2 = 0.285
-                   c3 = 0.215
-                   c4 = 0.215
-                   Foxx_swnet_vdr(n) = c1 * Foxx_swnet(n)
-                   Foxx_swnet_vdf(n) = c2 * Foxx_swnet(n)
-                   Foxx_swnet_idr(n) = c3 * Foxx_swnet(n)
-                   Foxx_swnet_idf(n) = c4 * Foxx_swnet(n)
+             ! To compare to mct
+             if (compare_to_mct) then
+                c1 = 0.285
+                c2 = 0.285
+                c3 = 0.215
+                c4 = 0.215
+                Foxx_swnet_vdr(n) = c1 * Foxx_swnet(n)
+                Foxx_swnet_vdf(n) = c2 * Foxx_swnet(n)
+                Foxx_swnet_idr(n) = c3 * Foxx_swnet(n)
+                Foxx_swnet_idf(n) = c4 * Foxx_swnet(n)
+             else
+                if (export_swnet_by_bands) then
+                   if (import_swpen_by_bands) then
+                      ! use each individual band for swpen coming from the sea-ice
+                      Foxx_swnet_vdr(n) = Faxa_swvdr(n)*(1.0_R8-albvis_dir)*ofracr_scaled + Fioi_swpen_vdr(n)*ifrac_scaled
+                      Foxx_swnet_vdf(n) = Faxa_swvdf(n)*(1.0_R8-albvis_dif)*ofracr_scaled + Fioi_swpen_vdf(n)*ifrac_scaled
+                      Foxx_swnet_idr(n) = Faxa_swndr(n)*(1.0_R8-albnir_dir)*ofracr_scaled + Fioi_swpen_idr(n)*ifrac_scaled
+                      Foxx_swnet_idf(n) = Faxa_swndf(n)*(1.0_R8-albnir_dif)*ofracr_scaled + Fioi_swpen_idf(n)*ifrac_scaled
+                   else
+                      ! scale total Foxx_swnet to get contributions from each band
+                      c1 = 0.285
+                      c2 = 0.285
+                      c3 = 0.215
+                      c4 = 0.215
+                      Foxx_swnet_vdr(n) = c1 * Foxx_swnet(n)
+                      Foxx_swnet_vdf(n) = c2 * Foxx_swnet(n)
+                      Foxx_swnet_idr(n) = c3 * Foxx_swnet(n)
+                      Foxx_swnet_idf(n) = c4 * Foxx_swnet(n)
+                   end if
                 end if
              end if
+             
           end if  ! if sea-ice is present
        end do
 


### PR DESCRIPTION
Change Description: changes needed for mom6 mct/nuopc validation

This PR adds the following:
- attributes of name and units to mediator history files
   these attributes now come from querying the NUOPC field dictionary and as a results the routines
   `shr_nuopc_fldList_AddMetadata` and `shr_nuopc_fldList_GetMeta` in `esmFlds` are not longer needed
- change  in `fd.yaml` of the alias names for the swpen coming from cice (these were duplicates and now have new names - as a result cice must also have a new hash)
- addition of new cart3d atm->ocn and atm->ice mapping that is triggered by the new config option `mapuv_with_cart3d`. This is currently to to .false. by default - but will be turned on as default in an upcoming tag.
- new run sequence for C and G compsets to match mct run sequence
- set of coldair_outbreak to .false. for T62 and TL319 datm forcing 

The above changes answers for DTESTS, C and G compsets.
Note that MOM restarts are now working!

Testing Completed: testlist_drv.xml - new baselines created are in jul09intel19/
(Minimum testing: CIME_DRIVER=nuopc scripts_regression_tests.py)

Externals coming soon!

CIME HASH: 
