### PR TITLE
update for workflow change in cime, add error for runseq not found

### DIFF
--- a/cime_config/buildnml
+++ b/cime_config/buildnml
@@ -340,8 +340,10 @@ def _create_runseq(case, coupling_times):
             from runseq_B import runseq
         elif (comp_atm == 'fv3gfs' and comp_ocn == "mom" and comp_ice == 'cice'):
             from runseq_NEMS import runseq
-
-        runseq(case, coupling_times)
+        try:
+            runseq(case, coupling_times)
+        except Exception as e:
+            expect(False, "No run sequence found for compset {}".format(case.get_value("COMPSET")))
 
 ###############################################################################
 def compare_drv_flds_in(first, second, infile1, infile2):

--- a/cime_config/config_component.xml
+++ b/cime_config/config_component.xml
@@ -2441,18 +2441,27 @@
     <desc>External script to be run after model completion</desc>
   </entry>
 
+ <entry id="EXTERNAL_WORKFLOW">
+   <type>logical</type>
+   <valid_values>TRUE,FALSE</valid_values>
+   <default_value>FALSE</default_value>
+   <group>external_tools</group>
+   <file>env_run.xml</file>
+   <desc>whether the case uses an external workflow driver </desc>
+ </entry>
+
  <!-- Job Submission stuff -->
  <entry id="USER_REQUESTED_QUEUE">
    <type>char</type>
    <group>job_submission</group>
-   <file>env_batch.xml</file>
+   <file>env_workflow.xml</file>
    <desc>Store user override for queue</desc>
  </entry>
 
  <entry id="USER_REQUESTED_WALLTIME">
    <type>char</type>
    <group>job_submission</group>
-   <file>env_batch.xml</file>
+   <file>env_workflow.xml</file>
    <desc>Store user override for walltime</desc>
  </entry>
 
@@ -2461,7 +2470,7 @@
    <valid_values></valid_values>
    <default_value></default_value>
    <group>job_submission</group>
-   <file>env_batch.xml</file>
+   <file>env_workflow.xml</file>
    <desc>The machine queue in which to submit the job.  Default determined in config_machines.xml can be overwritten by testing</desc>
  </entry>
 
@@ -2470,7 +2479,7 @@
    <valid_values></valid_values>
    <default_value></default_value>
    <group>job_submission</group>
-   <file>env_batch.xml</file>
+   <file>env_workflow.xml</file>
    <desc>The machine wallclock setting.  Default determined in config_machines.xml can be overwritten by testing</desc>
  </entry>
 
@@ -2479,7 +2488,7 @@
     <valid_values></valid_values>
     <default_value></default_value>
     <group>job_submission</group>
-    <file>env_batch.xml</file>
+    <file>env_workflow.xml</file>
     <desc>Override the batch submit command this job. Do not include executable or dependencies</desc>
   </entry>
 
@@ -2487,7 +2496,7 @@
    <type>char</type>
    <default_value></default_value>
    <group>job_submission</group>
-   <file>env_batch.xml</file>
+   <file>env_workflow.xml</file>
    <desc>project for project-sensitive build and run paths, and job scripts</desc>
  </entry>
 
@@ -2495,7 +2504,7 @@
    <type>char</type>
    <default_value></default_value>
    <group>job_submission</group>
-   <file>env_batch.xml</file>
+   <file>env_workflow.xml</file>
    <desc>project to charge in scripts if different from PROJECT</desc>
  </entry>
 
@@ -2512,7 +2521,7 @@
    <valid_values>TRUE,FALSE</valid_values>
    <default_value>FALSE</default_value>
    <group>job_submission</group>
-   <file>env_batch.xml</file>
+   <file>env_workflow.xml</file>
    <desc>whether the PROJECT value is required on this machine</desc>
  </entry>
 


### PR DESCRIPTION
Change Description: Add support for env_workflow.xml 

Testing Completed:
(Minimum testing: CIME_DRIVER=nuopc scripts_regression_tests.py)
Tested against cime with some expected failures in Z_FullSystemTest:
FAIL SMS_D_Ln9_Mmpi-serial.f19_g16_rx1.A.cheyenne_intel . (no esmf serial library)

FAIL PRE.f19_f19.ADESP_TEST.cheyenne_intel 
FAIL PRE.f19_f19.ADESP.cheyenne_intel .                          (ERROR: No pause_active flag is set)

FAIL ERS.ne30_g16_rx1.A.cheyenne_intel.drv-y100k        (ESMF_Clock.F90:1695 ESMF_ClockSet() Value out of range  - Internal subroutine call returned Error)

FAIL DAE.ww3a.ADWAV.cheyenne_intel  Unrecognized line ('No initial run signal found for cycle 0

CIME HASH:  d7f56ac  
