### PR TITLE
Fixes history file write in first cpl timestep

### DIFF
--- a/mediator/med.F90
+++ b/mediator/med.F90
@@ -27,6 +27,7 @@ module MED
   use shr_nuopc_time_mod    , only : set_stop_alarm     => shr_nuopc_time_set_component_stop_alarm
   use shr_nuopc_time_mod    , only : alarmInit          => shr_nuopc_time_alarmInit 
   use shr_nuopc_utils_mod   , only : memcheck           => shr_nuopc_memcheck
+  use med_phases_history_mod, only : histAlarmInit      => med_phases_history_alarm_init
 
   implicit none
   private
@@ -2072,6 +2073,9 @@ contains
          call ESMF_AlarmSet(glc_avg_alarm, clock=mediatorclock, rc=rc)
          if (ChkErr(rc,__LINE__,u_FILE_u)) return
       end if
+
+      ! Initialize med history file alarm
+      call histAlarmInit(gcomp, rc)
 
       call set_stop_alarm(gcomp, rc)
       if (ChkErr(rc,__LINE__,u_FILE_u)) return


### PR DESCRIPTION
Change Description: Currently, history file alarm is initialized within the first coupling timestep. That means, history files cannot be written until the second timestep because for alarms to turn on, time must advance. With this PR, history alarm gets initialized before run starts. This change fixes issue #31 

Testing Completed: CIME_DRIVER=nuopc scripts_regression_tests.py

CIME HASH: 2b02a76de27e1d9abefcfcb773a69ec58e437e00
