### PR TITLE
moved shr_nuopc_xxx.F90 files back to the mediator/ directory with renaming

### DIFF
--- a/drivers/cime/ensemble_driver.F90
+++ b/drivers/cime/ensemble_driver.F90
@@ -8,7 +8,7 @@ module Ensemble_driver
   !-----------------------------------------------------------------------------
 
   use shr_kind_mod          , only : cl=>shr_kind_cl
-  use shr_nuopc_utils_mod   , only : chkerr => shr_nuopc_utils_ChkErr
+  use med_utils_mod         , only : chkerr => med_utils_ChkErr
   use med_constants_mod     , only : dbug_flag => med_constants_dbug_flag
   use med_internalstate_mod , only : mastertask
 
@@ -87,7 +87,7 @@ module Ensemble_driver
     use NUOPC_Driver          , only : NUOPC_DriverAddComp
     use esm                   , only : ESMSetServices => SetServices, ReadAttributes
    !use pio_interface         , only : PIOSetServices => SetServices
-    use shr_nuopc_time_mod    , only : shr_nuopc_time_clockInit
+    use med_time_mod          , only : med_time_clockInit
     use med_internalstate_mod , only : logunit  ! initialized here
     use shr_log_mod           , only : shrloglev=>shr_log_level, shrlogunit=> shr_log_unit
     use shr_file_mod          , only : shr_file_getUnit, shr_file_getLoglevel
@@ -259,7 +259,7 @@ module Ensemble_driver
           call shr_file_setLogUnit (logunit)
        endif
     enddo
-    call shr_nuopc_time_clockInit(ensemble_driver, driver, logunit, rc)
+    call med_time_clockInit(ensemble_driver, driver, logunit, rc)
     if (chkerr(rc,__LINE__,u_FILE_u)) return
 
     deallocate(petList)

--- a/drivers/cime/esm.F90
+++ b/drivers/cime/esm.F90
@@ -6,8 +6,8 @@ module ESM
 
   use ESMF                  , only : ESMF_Clock
   use shr_kind_mod          , only : r8=>shr_kind_r8, cl=>shr_kind_cl, cs=>shr_kind_cs
-  use shr_nuopc_utils_mod   , only : chkerr => shr_nuopc_utils_ChkErr
-  use shr_nuopc_utils_mod   , only : shr_nuopc_memcheck
+  use med_utils_mod         , only : chkerr => med_utils_ChkErr
+  use med_utils_mod         , only : med_memcheck
   use med_internalstate_mod , only : logunit, loglevel, mastertask, med_id
 
   implicit none
@@ -116,14 +116,12 @@ contains
     use NUOPC                 , only : NUOPC_CompAttributeAdd, NUOPC_CompAttributeSet
     use NUOPC_Driver          , only : NUOPC_DriverAddComp, NUOPC_DriverGetComp
 
-    use shr_nuopc_methods_mod , only : shr_nuopc_methods_Clock_TimePrint
     use shr_file_mod          , only : shr_file_setLogunit, shr_file_getunit
     use pio                   , only : pio_file_is_open, pio_closefile, file_desc_t
     use perf_mod              , only : t_initf
     use shr_mem_mod           , only : shr_mem_init
     use shr_file_mod          , only : shr_file_setLogunit, shr_file_getunit
     use shr_log_mod           , only : shrlogunit=> shr_log_unit
-    use shr_nuopc_methods_mod , only : shr_nuopc_methods_Clock_TimePrint
 
     ! input/output variables
     type(ESMF_GridComp)    :: driver
@@ -582,7 +580,7 @@ contains
 
     rc = ESMF_SUCCESS
     call ESMF_LogWrite(trim(subname)//": called", ESMF_LOGMSG_INFO)
-    call shr_nuopc_memcheck(subname, 0, mastertask)
+    call med_memcheck(subname, 0, mastertask)
 
     !----------------------------------------------------------
     ! Initialize options for reproducible sums

--- a/mediator/esmFlds.F90
+++ b/mediator/esmFlds.F90
@@ -52,21 +52,21 @@ module esmflds
   ! PUblic methods
   !-----------------------------------------------
 
-  public :: shr_nuopc_fldList_AddFld
-  public :: shr_nuopc_fldList_AddMap
-  public :: shr_nuopc_fldList_AddMrg
-  public :: shr_nuopc_fldList_GetFldNames
-  public :: shr_nuopc_fldList_GetNumFlds
-  public :: shr_nuopc_fldList_GetFldInfo
-  public :: shr_nuopc_fldList_Realize
-  public :: shr_nuopc_fldList_Document_Mapping
-  public :: shr_nuopc_fldList_Document_Merging
+  public :: med_fldList_AddFld
+  public :: med_fldList_AddMap
+  public :: med_fldList_AddMrg
+  public :: med_fldList_GetFldNames
+  public :: med_fldList_GetNumFlds
+  public :: med_fldList_GetFldInfo
+  public :: med_fldList_Realize
+  public :: med_fldList_Document_Mapping
+  public :: med_fldList_Document_Merging
 
   !-----------------------------------------------
   ! Types and instantiations that determine fields, mappings, mergings
   !-----------------------------------------------
 
-  type, public :: shr_nuopc_fldList_entry_type
+  type, public :: med_fldList_entry_type
      character(CS) :: stdname
      character(CS) :: shortname
 
@@ -79,31 +79,31 @@ module esmflds
      character(CS) :: merge_fields(ncomps)    = 'unset'
      character(CS) :: merge_types(ncomps)     = 'unset'
      character(CS) :: merge_fracnames(ncomps) = 'unset'
-  end type shr_nuopc_fldList_entry_type
+  end type med_fldList_entry_type
 
   ! The above would be the field name to merge from
   ! e.g. for Sa_z in lnd
   !    merge_field(compatm) = 'Sa_z'
   !    merge_type(comptm) = 'copy'  (could also have 'copy_with_weighting')
 
-  type, public :: shr_nuopc_fldList_type
-     type (shr_nuopc_fldList_entry_type), pointer :: flds(:)
-  end type shr_nuopc_fldList_type
+  type, public :: med_fldList_type
+     type (med_fldList_entry_type), pointer :: flds(:)
+  end type med_fldList_type
 
-  interface shr_nuopc_fldList_GetFldInfo ; module procedure &
-       shr_nuopc_fldList_GetFldInfo_general, &
-       shr_nuopc_fldList_GetFldInfo_stdname, &
-       shr_nuopc_fldList_GetFldInfo_merging
+  interface med_fldList_GetFldInfo ; module procedure &
+       med_fldList_GetFldInfo_general, &
+       med_fldList_GetFldInfo_stdname, &
+       med_fldList_GetFldInfo_merging
   end interface
 
   !-----------------------------------------------
   ! Instantiate derived types
   !-----------------------------------------------
-  type (shr_nuopc_fldList_type), public :: fldListTo(ncomps) ! advertise fields to components
-  type (shr_nuopc_fldList_type), public :: fldListFr(ncomps) ! advertise fields from components
+  type (med_fldList_type), public :: fldListTo(ncomps) ! advertise fields to components
+  type (med_fldList_type), public :: fldListFr(ncomps) ! advertise fields from components
 
-  type (shr_nuopc_fldList_type), public :: fldListMed_aoflux 
-  type (shr_nuopc_fldList_type), public :: fldListMed_ocnalb 
+  type (med_fldList_type), public :: fldListMed_aoflux 
+  type (med_fldList_type), public :: fldListMed_ocnalb 
 
   integer                    :: dbrc
   character(len=CL)          :: infostr
@@ -114,7 +114,7 @@ module esmflds
 contains
 !================================================================================
 
-  subroutine shr_nuopc_fldList_AddFld(flds, stdname, shortname)
+  subroutine med_fldList_AddFld(flds, stdname, shortname)
 
     ! ----------------------------------------------
     ! Add an entry to to the flds array
@@ -128,15 +128,15 @@ contains
     ! 5) point flds => newflds
     ! ----------------------------------------------
 
-    type(shr_nuopc_fldList_entry_type) , pointer                :: flds(:)
+    type(med_fldList_entry_type) , pointer                :: flds(:)
     character(len=*)                   , intent(in)             :: stdname
     character(len=*)                   , intent(in)  , optional :: shortname
 
     ! local variables
     integer :: n,oldsize,id
     logical :: found
-    type(shr_nuopc_fldList_entry_type), pointer :: newflds(:)
-    character(len=*), parameter :: subname='(shr_nuopc_fldList_AddFld)'
+    type(med_fldList_entry_type), pointer :: newflds(:)
+    character(len=*), parameter :: subname='(med_fldList_AddFld)'
     ! ----------------------------------------------
 
     if (associated(flds)) then
@@ -191,11 +191,11 @@ contains
        end if
     end if
 
-  end subroutine shr_nuopc_fldList_AddFld
+  end subroutine med_fldList_AddFld
 
   !================================================================================
 
-  subroutine shr_nuopc_fldList_AddMrg(flds, fldname, &
+  subroutine med_fldList_AddMrg(flds, fldname, &
        mrg_from1, mrg_fld1, mrg_type1, mrg_fracname1, &
        mrg_from2, mrg_fld2, mrg_type2, mrg_fracname2, &
        mrg_from3, mrg_fld3, mrg_type3, mrg_fracname3, &
@@ -209,7 +209,7 @@ contains
     use ESMF, only : ESMF_LOGMSG_INFO, ESMF_LOGMSG_ERROR 
 
     ! input/output variables
-    type(shr_nuopc_fldList_entry_type) , pointer                :: flds(:)
+    type(med_fldList_entry_type) , pointer                :: flds(:)
     character(len=*)                   , intent(in)             :: fldname
     integer                            , intent(in)  , optional :: mrg_from1
     character(len=*)                   , intent(in)  , optional :: mrg_fld1
@@ -231,7 +231,7 @@ contains
     ! local variables
     integer :: n, id
     integer :: rc
-    character(len=*), parameter :: subname='(shr_nuopc_fldList_MrgFld)'
+    character(len=*), parameter :: subname='(med_fldList_MrgFld)'
     ! ----------------------------------------------
 
     id = 0
@@ -283,16 +283,16 @@ contains
        end if
     end if
 
-  end subroutine shr_nuopc_fldList_AddMrg
+  end subroutine med_fldList_AddMrg
 
   !================================================================================
 
-  subroutine shr_nuopc_fldList_AddMap(flds, fldname, destcomp, maptype, mapnorm, mapfile)
+  subroutine med_fldList_AddMap(flds, fldname, destcomp, maptype, mapnorm, mapfile)
 
     use ESMF, only : ESMF_LOGMSG_ERROR, ESMF_FAILURE, ESMF_LogWrite, ESMF_LOGMSG_INFO
 
     ! intput/output variables
-    type(shr_nuopc_fldList_entry_type) , intent(inout) :: flds(:)
+    type(med_fldList_entry_type) , intent(inout) :: flds(:)
     character(len=*)                   , intent(in)    :: fldname
     integer                            , intent(in)    :: destcomp
     integer                            , intent(in)    :: maptype
@@ -302,7 +302,7 @@ contains
     ! local variables
     integer :: id, n
     integer :: rc
-    character(len=*),parameter  :: subname='(shr_nuopc_fldList_AddMap)'
+    character(len=*),parameter  :: subname='(med_fldList_AddMap)'
     ! ----------------------------------------------
 
     id = 0
@@ -340,11 +340,11 @@ contains
        flds(id)%mapnorm(destcomp) = 'unset'
     end if
 
-  end subroutine shr_nuopc_fldList_AddMap
+  end subroutine med_fldList_AddMap
 
   !================================================================================
 
-  subroutine shr_nuopc_fldList_Realize(state, fldList, flds_scalar_name, flds_scalar_num, &
+  subroutine med_fldList_Realize(state, fldList, flds_scalar_name, flds_scalar_num, &
        grid, mesh, tag, rc)
 
     use NUOPC             , only : NUOPC_GetStateMemberLists, NUOPC_IsConnected, NUOPC_Realize
@@ -358,7 +358,7 @@ contains
 
     ! input/output variables
     type(ESMF_State)            , intent(inout)            :: state
-    type(shr_nuopc_fldlist_type), intent(in)               :: fldList
+    type(med_fldlist_type), intent(in)               :: fldList
     character(len=*)            , intent(in)               :: flds_scalar_name
     integer                     , intent(in)               :: flds_scalar_num
     character(len=*)            , intent(in)               :: tag
@@ -377,7 +377,7 @@ contains
     character(ESMF_MAXSTR), pointer :: ConnectedList(:)
     character(ESMF_MAXSTR), pointer :: NameSpaceList(:)
     character(ESMF_MAXSTR), pointer :: itemNameList(:)
-    character(len=*),parameter  :: subname='(shr_nuopc_fldList_Realize)'
+    character(len=*),parameter  :: subname='(med_fldList_Realize)'
     ! ----------------------------------------------
 
     rc = ESMF_SUCCESS
@@ -541,52 +541,52 @@ contains
 
     end subroutine SetScalarField
 
-  end subroutine shr_nuopc_fldList_Realize
+  end subroutine med_fldList_Realize
 
   !================================================================================
 
-  subroutine shr_nuopc_fldList_GetFldInfo_general(fldList, fldindex, stdname, shortname)
+  subroutine med_fldList_GetFldInfo_general(fldList, fldindex, stdname, shortname)
     ! ----------------------------------------------
     ! Get field info
     ! ----------------------------------------------
-    type(shr_nuopc_fldList_type) , intent(in)  :: fldList
+    type(med_fldList_type) , intent(in)  :: fldList
     integer                      , intent(in)  :: fldindex
     character(len=*)             , intent(out) :: stdname
     character(len=*)             , intent(out) :: shortname
 
     ! local variables
-    character(len=*), parameter :: subname='(shr_nuopc_fldList_GetFldInfo_general)'
+    character(len=*), parameter :: subname='(med_fldList_GetFldInfo_general)'
     ! ----------------------------------------------
 
     stdname   = fldList%flds(fldindex)%stdname
     shortname = fldList%flds(fldindex)%shortname
 
-  end subroutine shr_nuopc_fldList_GetFldInfo_general
+  end subroutine med_fldList_GetFldInfo_general
 
   !================================================================================
 
-  subroutine shr_nuopc_fldList_GetFldInfo_stdname(fldList, fldindex, stdname)
+  subroutine med_fldList_GetFldInfo_stdname(fldList, fldindex, stdname)
     ! ----------------------------------------------
     ! Get field info
     ! ----------------------------------------------
-    type(shr_nuopc_fldList_type) , intent(in)  :: fldList
+    type(med_fldList_type) , intent(in)  :: fldList
     integer                      , intent(in)  :: fldindex
     character(len=*)             , intent(out) :: stdname
 
     ! local variables
-    character(len=*), parameter :: subname='(shr_nuopc_fldList_GetFldInfo_stdname)'
+    character(len=*), parameter :: subname='(med_fldList_GetFldInfo_stdname)'
     ! ----------------------------------------------
 
     stdname   = fldList%flds(fldindex)%stdname
-  end subroutine shr_nuopc_fldList_GetFldInfo_stdname
+  end subroutine med_fldList_GetFldInfo_stdname
 
   !================================================================================
 
-  subroutine shr_nuopc_fldList_GetFldInfo_merging(fldList, fldindex, compsrc, merge_field, merge_type, merge_fracname)
+  subroutine med_fldList_GetFldInfo_merging(fldList, fldindex, compsrc, merge_field, merge_type, merge_fracname)
     ! ----------------------------------------------
     ! Get field merge info
     ! ----------------------------------------------
-    type(shr_nuopc_fldList_type) , intent(in)  :: fldList
+    type(med_fldList_type) , intent(in)  :: fldList
     integer                      , intent(in)  :: fldindex
     integer                      , intent(in)  :: compsrc
     character(len=*)             , intent(out) :: merge_field
@@ -594,38 +594,38 @@ contains
     character(len=*)             , intent(out) :: merge_fracname
 
     ! local variables
-    character(len=*), parameter :: subname='(shr_nuopc_fldList_GetFldInfo_merging)'
+    character(len=*), parameter :: subname='(med_fldList_GetFldInfo_merging)'
     ! ----------------------------------------------
 
     merge_field    = fldList%flds(fldindex)%merge_fields(compsrc)
     merge_type     = fldList%flds(fldindex)%merge_types(compsrc)
     merge_fracname = fldList%flds(fldindex)%merge_fracnames(compsrc)
-  end subroutine shr_nuopc_fldList_GetFldInfo_merging
+  end subroutine med_fldList_GetFldInfo_merging
 
   !================================================================================
 
-  integer function shr_nuopc_fldList_GetNumFlds(fldList)
+  integer function med_fldList_GetNumFlds(fldList)
 
     ! input/output variables
-    type(shr_nuopc_fldList_type), intent(in)  :: fldList
+    type(med_fldList_type), intent(in)  :: fldList
     ! ----------------------------------------------
 
     if (associated(fldList%flds)) then
-       shr_nuopc_fldList_GetNumFlds = size(fldList%flds)
+       med_fldList_GetNumFlds = size(fldList%flds)
     else
-       shr_nuopc_fldList_GetNumFlds = 0
+       med_fldList_GetNumFlds = 0
     end if
 
-  end function shr_nuopc_fldList_GetNumFlds
+  end function med_fldList_GetNumFlds
 
   !================================================================================
 
-  subroutine shr_nuopc_fldList_GetFldNames(flds, fldnames, rc)
+  subroutine med_fldList_GetFldNames(flds, fldnames, rc)
 
     use ESMF, only : ESMF_LOGMSG_INFO, ESMF_FAILURE, ESMF_SUCCESS, ESMF_LogWrite
 
     ! input/output variables
-    type(shr_nuopc_fldList_entry_type) , pointer     :: flds(:)
+    type(med_fldList_entry_type) , pointer     :: flds(:)
     character(len=*)                   , pointer     :: fldnames(:)
     integer, optional                  , intent(out) :: rc
 
@@ -640,17 +640,17 @@ contains
           fldnames(n) = trim(flds(n)%shortname)
        end do
     else
-       call ESMF_LogWrite("shr_nuopc_fldList_GetFldNames: ERROR either flds or fldnames have not been allocate ", &
+       call ESMF_LogWrite("med_fldList_GetFldNames: ERROR either flds or fldnames have not been allocate ", &
             ESMF_LOGMSG_INFO, rc=rc)
        rc = ESMF_FAILURE
        return
     end if
 
-  end subroutine shr_nuopc_fldList_GetFldNames
+  end subroutine med_fldList_GetFldNames
 
   !================================================================================
 
-  subroutine shr_nuopc_fldList_Document_Mapping(logunit, med_coupling_active)
+  subroutine med_fldList_Document_Mapping(logunit, med_coupling_active)
 
     ! input/output variables
     integer, intent(in)  :: logunit
@@ -671,7 +671,7 @@ contains
     character(len=CL) :: mrgstr
     character(len=CL) :: cvalue
     logical           :: init_mrgstr
-    character(len=*),parameter :: subname = '(shr_nuopc_fldList_Document_Mapping)'
+    character(len=*),parameter :: subname = '(med_fldList_Document_Mapping)'
     !-----------------------------------------------------------
 
     !---------------------------------------
@@ -741,11 +741,11 @@ contains
 100 format(a)
 101 format(3x,a)
 
-  end subroutine shr_nuopc_fldList_Document_Mapping
+  end subroutine med_fldList_Document_Mapping
 
   !================================================================================
 
-  subroutine shr_nuopc_fldList_Document_Merging(logunit, med_coupling_active)
+  subroutine med_fldList_Document_Merging(logunit, med_coupling_active)
 
     !---------------------------------------
     ! Document merging to target destination fields 
@@ -768,7 +768,7 @@ contains
     character(len=CS) :: string
     character(len=CL) :: mrgstr
     logical           :: init_mrgstr
-    character(len=*),parameter :: subname = '(shr_nuopc_fldList_Document_Mapping)'
+    character(len=*),parameter :: subname = '(med_fldList_Document_Mapping)'
     !-----------------------------------------------------------
 
     write(logunit,*)
@@ -822,9 +822,8 @@ contains
              write(logunit,'(a)') trim(mrgstr)
           end if
        end do ! end loop over nf
-       !write(logunit,*)' '
     end do  ! end loop over ndst
 
-  end subroutine shr_nuopc_fldList_Document_Merging
+  end subroutine med_fldList_Document_Merging
 
 end module esmflds

--- a/mediator/esmFldsExchange.F90
+++ b/mediator/esmFldsExchange.F90
@@ -23,13 +23,13 @@ contains
     use ESMF
     use NUOPC
     use med_constants_mod     , only : CX, CS, CL
-    use shr_nuopc_utils_mod   , only : chkerr => shr_nuopc_utils_chkerr
-    use shr_nuopc_methods_mod , only : fldchk => shr_nuopc_methods_FB_FldChk
+    use med_utils_mod         , only : chkerr => med_utils_chkerr
+    use med_methods_mod       , only : fldchk => med_methods_FB_FldChk
     use med_internalstate_mod , only : InternalState
-    use esmFlds               , only : shr_nuopc_fldList_type
-    use esmFlds               , only : addfld => shr_nuopc_fldList_AddFld
-    use esmFlds               , only : addmap => shr_nuopc_fldList_AddMap
-    use esmFlds               , only : addmrg => shr_nuopc_fldList_AddMrg
+    use esmFlds               , only : med_fldList_type
+    use esmFlds               , only : addfld => med_fldList_AddFld
+    use esmFlds               , only : addmap => med_fldList_AddMap
+    use esmFlds               , only : addmrg => med_fldList_AddMrg
     use esmflds               , only : compmed, compatm, complnd, compocn
     use esmflds               , only : compice, comprof, compwav, compglc, ncomps
     use esmflds               , only : mapbilnr, mapconsf, mapconsd, mappatch

--- a/mediator/med_fraction_mod.F90
+++ b/mediator/med_fraction_mod.F90
@@ -112,17 +112,17 @@ module med_fraction_mod
   !
   !-----------------------------------------------------------------------------
 
-  use esmFlds               , only : ncomps
-  use med_constants_mod     , only : R8
-  use med_constants_mod     , only : dbug_flag      => med_constants_dbug_flag
-  use med_constants_mod     , only : czero          => med_constants_czero
-  use shr_nuopc_utils_mod   , only : chkErr         => shr_nuopc_utils_ChkErr
-  use shr_nuopc_methods_mod , only : FB_init        => shr_nuopc_methods_FB_init
-  use shr_nuopc_methods_mod , only : FB_reset       => shr_nuopc_methods_FB_reset
-  use shr_nuopc_methods_mod , only : FB_getFldPtr   => shr_nuopc_methods_FB_getFldPtr
-  use shr_nuopc_methods_mod , only : FB_FieldRegrid => shr_nuopc_methods_FB_FieldRegrid
-  use shr_nuopc_methods_mod , only : FB_diagnose    => shr_nuopc_methods_FB_diagnose
-  use shr_nuopc_methods_mod , only : FB_fldChk      => shr_nuopc_methods_FB_fldChk
+  use med_constants_mod , only : R8
+  use med_constants_mod , only : dbug_flag      => med_constants_dbug_flag
+  use med_constants_mod , only : czero          => med_constants_czero
+  use med_utils_mod     , only : chkErr         => med_utils_ChkErr
+  use med_methods_mod   , only : FB_init        => med_methods_FB_init
+  use med_methods_mod   , only : FB_reset       => med_methods_FB_reset
+  use med_methods_mod   , only : FB_getFldPtr   => med_methods_FB_getFldPtr
+  use med_methods_mod   , only : FB_FieldRegrid => med_methods_FB_FieldRegrid
+  use med_methods_mod   , only : FB_diagnose    => med_methods_FB_diagnose
+  use med_methods_mod   , only : FB_fldChk      => med_methods_FB_fldChk
+  use esmFlds           , only : ncomps
 
   implicit none
   private

--- a/mediator/med_io_mod.F90
+++ b/mediator/med_io_mod.F90
@@ -13,10 +13,10 @@ module med_io_mod
   use med_constants_mod     , only : R4, R8, I8, CL 
   use med_constants_mod     , only : dbug_flag    => med_constants_dbug_flag
   use med_internalstate_mod , only : logunit, med_id
-  use shr_nuopc_methods_mod , only : FB_getFieldN => shr_nuopc_methods_FB_getFieldN
-  use shr_nuopc_methods_mod , only : FB_getFldPtr => shr_nuopc_methods_FB_getFldPtr
-  use shr_nuopc_methods_mod , only : FB_getNameN  => shr_nuopc_methods_FB_getNameN
-  use shr_nuopc_utils_mod   , only : chkerr       => shr_nuopc_utils_ChkErr
+  use med_methods_mod       , only : FB_getFieldN => med_methods_FB_getFieldN
+  use med_methods_mod       , only : FB_getFldPtr => med_methods_FB_getFldPtr
+  use med_methods_mod       , only : FB_getNameN  => med_methods_FB_getNameN
+  use med_utils_mod         , only : chkerr       => med_utils_ChkErr
 
   implicit none
   private

--- a/mediator/med_methods_mod.F90
+++ b/mediator/med_methods_mod.F90
@@ -1,4 +1,4 @@
-module shr_nuopc_methods_mod
+module med_methods_mod
 
   !-----------------------------------------------------------------------------
   ! Generic operation methods used by the Mediator Component.
@@ -14,27 +14,27 @@ module shr_nuopc_methods_mod
   use med_constants_mod  , only : dbug_flag => med_constants_dbug_flag
   use med_constants_mod  , only : czero => med_constants_czero
   use med_constants_mod  , only : spval_init => med_constants_spval_init
-  use shr_nuopc_utils_mod, only : ChkErr => shr_nuopc_utils_ChkErr
+  use med_utils_mod      , only : ChkErr => med_utils_ChkErr
 
   implicit none
   private
 
-  interface shr_nuopc_methods_FB_accum ; module procedure &
-    shr_nuopc_methods_FB_accumFB2FB
+  interface med_methods_FB_accum ; module procedure &
+    med_methods_FB_accumFB2FB
   end interface
 
-  interface shr_nuopc_methods_FB_copy ; module procedure &
-    shr_nuopc_methods_FB_copyFB2FB
+  interface med_methods_FB_copy ; module procedure &
+    med_methods_FB_copyFB2FB
   end interface
 
-  interface shr_nuopc_methods_FieldPtr_compare ; module procedure &
-    shr_nuopc_methods_FieldPtr_compare1, &
-    shr_nuopc_methods_FieldPtr_compare2
+  interface med_methods_FieldPtr_compare ; module procedure &
+    med_methods_FieldPtr_compare1, &
+    med_methods_FieldPtr_compare2
   end interface
 
-  interface shr_nuopc_methods_UpdateTimestamp; module procedure &
-    shr_nuopc_methods_State_UpdateTimestamp, &
-    shr_nuopc_methods_Field_UpdateTimestamp
+  interface med_methods_UpdateTimestamp; module procedure &
+    med_methods_State_UpdateTimestamp, &
+    med_methods_Field_UpdateTimestamp
   end interface
 
   ! used/reused in module
@@ -46,64 +46,64 @@ module shr_nuopc_methods_mod
   character(*)      , parameter         :: u_FILE_u = &
        __FILE__
 
-  public shr_nuopc_methods_FB_copy
-  public shr_nuopc_methods_FB_accum
-  public shr_nuopc_methods_FB_average
-  public shr_nuopc_methods_FB_init
-  public shr_nuopc_methods_FB_init_pointer
-  public shr_nuopc_methods_FB_reset
-  public shr_nuopc_methods_FB_clean
-  public shr_nuopc_methods_FB_diagnose
-  public shr_nuopc_methods_FB_FldChk
-  public shr_nuopc_methods_FB_GetFldPtr
-  public shr_nuopc_methods_FB_getNameN
-  public shr_nuopc_methods_FB_getFieldN
-  public shr_nuopc_methods_FB_getFieldByName
-  public shr_nuopc_methods_FB_FieldRegrid
-  public shr_nuopc_methods_FB_getNumflds
-  public shr_nuopc_methods_FB_Field_diagnose
-  public shr_nuopc_methods_Field_diagnose
-  public shr_nuopc_methods_State_reset
-  public shr_nuopc_methods_State_diagnose
-  public shr_nuopc_methods_State_GeomPrint
-  public shr_nuopc_methods_State_GeomWrite
-  public shr_nuopc_methods_State_GetFldPtr
-  public shr_nuopc_methods_State_SetScalar
-  public shr_nuopc_methods_State_GetScalar
-  public shr_nuopc_methods_State_GetNumFields
-  public shr_nuopc_methods_State_getFieldN
-  public shr_nuopc_methods_State_FldDebug
-  public shr_nuopc_methods_Field_GeomPrint
-  public shr_nuopc_methods_Clock_TimePrint
-  public shr_nuopc_methods_UpdateTimestamp
-  public shr_nuopc_methods_Distgrid_Match
-  public shr_nuopc_methods_FieldPtr_compare
-  public shr_nuopc_methods_States_GetSharedFlds
+  public med_methods_FB_copy
+  public med_methods_FB_accum
+  public med_methods_FB_average
+  public med_methods_FB_init
+  public med_methods_FB_init_pointer
+  public med_methods_FB_reset
+  public med_methods_FB_clean
+  public med_methods_FB_diagnose
+  public med_methods_FB_FldChk
+  public med_methods_FB_GetFldPtr
+  public med_methods_FB_getNameN
+  public med_methods_FB_getFieldN
+  public med_methods_FB_getFieldByName
+  public med_methods_FB_FieldRegrid
+  public med_methods_FB_getNumflds
+  public med_methods_FB_Field_diagnose
+  public med_methods_Field_diagnose
+  public med_methods_State_reset
+  public med_methods_State_diagnose
+  public med_methods_State_GeomPrint
+  public med_methods_State_GeomWrite
+  public med_methods_State_GetFldPtr
+  public med_methods_State_SetScalar
+  public med_methods_State_GetScalar
+  public med_methods_State_GetNumFields
+  public med_methods_State_getFieldN
+  public med_methods_State_FldDebug
+  public med_methods_Field_GeomPrint
+  public med_methods_Clock_TimePrint
+  public med_methods_UpdateTimestamp
+  public med_methods_Distgrid_Match
+  public med_methods_FieldPtr_compare
+  public med_methods_States_GetSharedFlds
 
-  private shr_nuopc_methods_Grid_Write
-  private shr_nuopc_methods_Grid_Print
-  private shr_nuopc_methods_Mesh_Print
-  private shr_nuopc_methods_Mesh_Write
-  private shr_nuopc_methods_Field_GetFldPtr
-  private shr_nuopc_methods_Field_GeomWrite
-  private shr_nuopc_methods_Field_UpdateTimestamp
-  private shr_nuopc_methods_FB_GeomPrint
-  private shr_nuopc_methods_FB_GeomWrite
-  private shr_nuopc_methods_FB_RWFields
-  private shr_nuopc_methods_FB_SetFldPtr
-  private shr_nuopc_methods_FB_copyFB2FB
-  private shr_nuopc_methods_FB_accumFB2FB
-  private shr_nuopc_methods_State_UpdateTimestamp
-  private shr_nuopc_methods_State_getNameN
-  private shr_nuopc_methods_State_getFieldByName
-  private shr_nuopc_methods_State_SetFldPtr
-  private shr_nuopc_methods_Array_diagnose
+  private med_methods_Grid_Write
+  private med_methods_Grid_Print
+  private med_methods_Mesh_Print
+  private med_methods_Mesh_Write
+  private med_methods_Field_GetFldPtr
+  private med_methods_Field_GeomWrite
+  private med_methods_Field_UpdateTimestamp
+  private med_methods_FB_GeomPrint
+  private med_methods_FB_GeomWrite
+  private med_methods_FB_RWFields
+  private med_methods_FB_SetFldPtr
+  private med_methods_FB_copyFB2FB
+  private med_methods_FB_accumFB2FB
+  private med_methods_State_UpdateTimestamp
+  private med_methods_State_getNameN
+  private med_methods_State_getFieldByName
+  private med_methods_State_SetFldPtr
+  private med_methods_Array_diagnose
 
 !-----------------------------------------------------------------------------
 contains
 !-----------------------------------------------------------------------------
 
-  subroutine shr_nuopc_methods_FB_RWFields(mode,fname,FB,flag,rc)
+  subroutine med_methods_FB_RWFields(mode,fname,FB,flag,rc)
 
     ! ----------------------------------------------
     ! Read or Write Field Bundles
@@ -122,7 +122,7 @@ contains
     character(len=ESMF_MAXSTR) :: name
     integer                    :: fieldcount, n
     logical                    :: fexists
-    character(len=*), parameter :: subname='(shr_nuopc_methods_FB_RWFields)'
+    character(len=*), parameter :: subname='(med_methods_FB_RWFields)'
     ! ----------------------------------------------
 
     rc = ESMF_SUCCESS
@@ -137,7 +137,7 @@ contains
       call ESMF_FieldBundleWrite(FB, fname, &
         singleFile=.true., status=ESMF_FILESTATUS_REPLACE, iofmt=ESMF_IOFMT_NETCDF, rc=rc)
       if (chkerr(rc,__LINE__,u_FILE_u)) return
-      call shr_nuopc_methods_FB_diagnose(FB, 'write '//trim(fname), rc)
+      call med_methods_FB_diagnose(FB, 'write '//trim(fname), rc)
 
     elseif (mode == 'read') then
       inquire(file=fname,exist=fexists)
@@ -155,7 +155,7 @@ contains
         call ESMF_FieldBundleGet(FB, fieldCount=fieldCount, rc=rc)
         if (chkerr(rc,__LINE__,u_FILE_u)) return
         do n = 1,fieldCount
-          call shr_nuopc_methods_FB_getFieldByName(FB, name, field, rc)
+          call med_methods_FB_getFieldByName(FB, name, field, rc)
           if (chkerr(rc,__LINE__,u_FILE_u)) return
           call ESMF_FieldRead (field, fname, iofmt=ESMF_IOFMT_NETCDF, rc=rc)
           if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
@@ -163,7 +163,7 @@ contains
                ' WARNING missing field '//trim(name))
         enddo
 
-        call shr_nuopc_methods_FB_diagnose(FB, 'read '//trim(fname), rc)
+        call med_methods_FB_diagnose(FB, 'read '//trim(fname), rc)
 	if (present(flag)) flag = .true.
       endif
 
@@ -175,11 +175,11 @@ contains
       call ESMF_LogWrite(trim(subname)//trim(fname)//": done", ESMF_LOGMSG_INFO)
     endif
 
-  end subroutine shr_nuopc_methods_FB_RWFields
+  end subroutine med_methods_FB_RWFields
 
   !-----------------------------------------------------------------------------
 
-  subroutine shr_nuopc_methods_FB_init_pointer(StateIn, FBout, flds_scalar_name, name, rc)
+  subroutine med_methods_FB_init_pointer(StateIn, FBout, flds_scalar_name, name, rc)
 
     ! ----------------------------------------------
     ! Create FBout from StateIn mesh and pointer
@@ -214,7 +214,7 @@ contains
     real(R8), pointer  :: dataptr1d(:)
     real(R8), pointer  :: dataptr2d(:,:)
     character(ESMF_MAXSTR), allocatable :: lfieldNameList(:)
-    character(len=*), parameter :: subname='(shr_nuopc_methods_FB_init_pointer)'
+    character(len=*), parameter :: subname='(med_methods_FB_init_pointer)'
     ! ----------------------------------------------
 
     ! Create empty FBout
@@ -322,11 +322,11 @@ contains
        call ESMF_LogWrite(trim(subname)//": FBout from input State and field pointers", ESMF_LOGMSG_INFO, rc=rc)
     end if
 
-  end subroutine shr_nuopc_methods_FB_init_pointer
+  end subroutine med_methods_FB_init_pointer
 
   !-----------------------------------------------------------------------------
 
-  subroutine shr_nuopc_methods_FB_init(FBout, flds_scalar_name, fieldNameList, FBgeom, STgeom, FBflds, STflds, name, rc)
+  subroutine med_methods_FB_init(FBout, flds_scalar_name, fieldNameList, FBgeom, STgeom, FBflds, STflds, name, rc)
 
     ! ----------------------------------------------
     ! Create FBout from fieldNameList, FBflds, STflds, FBgeom or STgeom in that order or priority
@@ -365,7 +365,7 @@ contains
     integer, allocatable   :: gridToFieldMap(:)
     logical                :: isPresent
     character(ESMF_MAXSTR), allocatable :: lfieldNameList(:)
-    character(len=*), parameter :: subname='(shr_nuopc_methods_FB_init)'
+    character(len=*), parameter :: subname='(med_methods_FB_init)'
     ! ----------------------------------------------
 
     if (dbug_flag > 10) then
@@ -493,13 +493,13 @@ contains
 
       ! Look at only the first field in either the FBgeom and STgeom to get the mesh
       if (present(FBgeom)) then
-        call shr_nuopc_methods_FB_getFieldN(FBgeom, 1, lfield, rc=rc)
+        call med_methods_FB_getFieldN(FBgeom, 1, lfield, rc=rc)
         if (chkerr(rc,__LINE__,u_FILE_u)) return
         if (dbug_flag > 5) then
            call ESMF_LogWrite(trim(subname)//":"//trim(lname)//" mesh from FBgeom", ESMF_LOGMSG_INFO)
         end if
       elseif (present(STgeom)) then
-        call shr_nuopc_methods_State_getFieldN(STgeom, 1, lfield, rc=rc)
+        call med_methods_State_getFieldN(STgeom, 1, lfield, rc=rc)
         if (chkerr(rc,__LINE__,u_FILE_u)) return
         if (dbug_flag > 5) then
            call ESMF_LogWrite(trim(subname)//":"//trim(lname)//" mesh from STgeom", ESMF_LOGMSG_INFO)
@@ -546,10 +546,10 @@ contains
 
              ! ungridded dimensions might be present in the input states or field bundles
              if (present(FBflds)) then
-                call shr_nuopc_methods_FB_getFieldN(FBflds, n, lfield, rc=rc)
+                call med_methods_FB_getFieldN(FBflds, n, lfield, rc=rc)
                 if (chkerr(rc,__LINE__,u_FILE_u)) return
              elseif (present(STflds)) then
-                call shr_nuopc_methods_State_getFieldN(STflds, n, lfield, rc=rc)
+                call med_methods_State_getFieldN(STflds, n, lfield, rc=rc)
                 if (chkerr(rc,__LINE__,u_FILE_u)) return
              end if
 
@@ -609,18 +609,18 @@ contains
 
     deallocate(lfieldNameList)
 
-    call shr_nuopc_methods_FB_reset(FBout, value=spval_init, rc=rc)
+    call med_methods_FB_reset(FBout, value=spval_init, rc=rc)
     if (chkerr(rc,__LINE__,u_FILE_u)) return
 
     if (dbug_flag > 10) then
       call ESMF_LogWrite(trim(subname)//": done", ESMF_LOGMSG_INFO)
     endif
 
-  end subroutine shr_nuopc_methods_FB_init
+  end subroutine med_methods_FB_init
 
   !-----------------------------------------------------------------------------
 
-  subroutine shr_nuopc_methods_FB_getNameN(FB, fieldnum, fieldname, rc)
+  subroutine med_methods_FB_getNameN(FB, fieldnum, fieldname, rc)
 
     ! ----------------------------------------------
     ! Get name of field number fieldnum in input field bundle FB
@@ -637,7 +637,7 @@ contains
     ! local variables
     integer                         :: fieldCount
     character(ESMF_MAXSTR) ,pointer :: lfieldnamelist(:)
-    character(len=*),parameter      :: subname='(shr_nuopc_methods_FB_getNameN)'
+    character(len=*),parameter      :: subname='(med_methods_FB_getNameN)'
     ! ----------------------------------------------
 
     if (dbug_flag > 10) then
@@ -668,11 +668,11 @@ contains
       call ESMF_LogWrite(trim(subname)//": done", ESMF_LOGMSG_INFO)
     endif
 
-  end subroutine shr_nuopc_methods_FB_getNameN
+  end subroutine med_methods_FB_getNameN
 
   !-----------------------------------------------------------------------------
 
-  subroutine shr_nuopc_methods_FB_getFieldN(FB, fieldnum, field, rc)
+  subroutine med_methods_FB_getFieldN(FB, fieldnum, field, rc)
 
     ! ----------------------------------------------
     ! Get field with number fieldnum in input field bundle FB
@@ -688,7 +688,7 @@ contains
 
     ! local variables
     character(len=ESMF_MAXSTR) :: name
-    character(len=*),parameter :: subname='(shr_nuopc_methods_FB_getFieldN)'
+    character(len=*),parameter :: subname='(med_methods_FB_getFieldN)'
     ! ----------------------------------------------
 
     if (dbug_flag > 10) then
@@ -696,7 +696,7 @@ contains
     endif
     rc = ESMF_SUCCESS
 
-    call shr_nuopc_methods_FB_getNameN(FB, fieldnum, name, rc)
+    call med_methods_FB_getNameN(FB, fieldnum, name, rc)
     if (chkerr(rc,__LINE__,u_FILE_u)) return
 
     call ESMF_FieldBundleGet(FB, fieldName=name, field=field, rc=rc)
@@ -706,11 +706,11 @@ contains
       call ESMF_LogWrite(trim(subname)//": done", ESMF_LOGMSG_INFO)
     endif
 
-  end subroutine shr_nuopc_methods_FB_getFieldN
+  end subroutine med_methods_FB_getFieldN
 
   !-----------------------------------------------------------------------------
 
-  subroutine shr_nuopc_methods_FB_getFieldByName(FB, fieldname, field, rc)
+  subroutine med_methods_FB_getFieldByName(FB, fieldname, field, rc)
 
     ! ----------------------------------------------
     ! Get field associated with fieldname out of FB
@@ -725,7 +725,7 @@ contains
     integer               , intent(out)   :: rc
 
     ! local variables
-    character(len=*),parameter :: subname='(shr_nuopc_methods_FB_getFieldByName)'
+    character(len=*),parameter :: subname='(med_methods_FB_getFieldByName)'
     ! ----------------------------------------------
 
     if (dbug_flag > 10) then
@@ -740,11 +740,11 @@ contains
       call ESMF_LogWrite(trim(subname)//": done", ESMF_LOGMSG_INFO)
     endif
 
-  end subroutine shr_nuopc_methods_FB_getFieldByName
+  end subroutine med_methods_FB_getFieldByName
 
   !-----------------------------------------------------------------------------
 
-  subroutine shr_nuopc_methods_State_getNameN(State, fieldnum, fieldname, rc)
+  subroutine med_methods_State_getNameN(State, fieldnum, fieldname, rc)
 
     ! ----------------------------------------------
     ! Get field number fieldnum name out of State
@@ -760,7 +760,7 @@ contains
     ! local variables
     integer                         :: fieldCount
     character(ESMF_MAXSTR) ,pointer :: lfieldnamelist(:)
-    character(len=*),parameter      :: subname='(shr_nuopc_methods_State_getNameN)'
+    character(len=*),parameter      :: subname='(med_methods_State_getNameN)'
     ! ----------------------------------------------
 
     if (dbug_flag > 10) then
@@ -791,11 +791,11 @@ contains
       call ESMF_LogWrite(trim(subname)//": done", ESMF_LOGMSG_INFO)
     endif
 
-  end subroutine shr_nuopc_methods_State_getNameN
+  end subroutine med_methods_State_getNameN
 
   !-----------------------------------------------------------------------------
 
-  subroutine shr_nuopc_methods_State_getNumFields(State, fieldnum, rc)
+  subroutine med_methods_State_getNumFields(State, fieldnum, rc)
 
     ! ----------------------------------------------
     ! Get field number fieldnum name out of State
@@ -814,7 +814,7 @@ contains
     type(ESMF_Field), pointer          :: fieldList(:)
     type(ESMF_StateItem_Flag), pointer :: itemTypeList(:)
     logical, parameter                 :: use_NUOPC_method = .true.
-    character(len=*),parameter         :: subname='(shr_nuopc_methods_State_getNumFields)'
+    character(len=*),parameter         :: subname='(med_methods_State_getNumFields)'
     ! ----------------------------------------------
 
     if (dbug_flag > 10) then
@@ -856,11 +856,11 @@ contains
       call ESMF_LogWrite(trim(subname)//": done", ESMF_LOGMSG_INFO)
     endif
 
-  end subroutine shr_nuopc_methods_State_getNumFields
+  end subroutine med_methods_State_getNumFields
 
   !-----------------------------------------------------------------------------
 
-  subroutine shr_nuopc_methods_State_getFieldN(State, fieldnum, field, rc)
+  subroutine med_methods_State_getFieldN(State, fieldnum, field, rc)
 
     ! ----------------------------------------------
     ! Get field number fieldnum in State
@@ -875,7 +875,7 @@ contains
 
     ! local variables
     character(len=ESMF_MAXSTR) :: name
-    character(len=*),parameter :: subname='(shr_nuopc_methods_State_getFieldN)'
+    character(len=*),parameter :: subname='(med_methods_State_getFieldN)'
     ! ----------------------------------------------
 
     if (dbug_flag > 10) then
@@ -883,7 +883,7 @@ contains
     endif
     rc = ESMF_SUCCESS
 
-    call shr_nuopc_methods_State_getNameN(State, fieldnum, name, rc)
+    call med_methods_State_getNameN(State, fieldnum, name, rc)
     if (chkerr(rc,__LINE__,u_FILE_u)) return
 
     call ESMF_StateGet(State, itemName=name, field=field, rc=rc)
@@ -892,11 +892,11 @@ contains
       call ESMF_LogWrite(trim(subname)//": done", ESMF_LOGMSG_INFO)
     endif
 
-  end subroutine shr_nuopc_methods_State_getFieldN
+  end subroutine med_methods_State_getFieldN
 
   !-----------------------------------------------------------------------------
 
-  subroutine shr_nuopc_methods_State_getFieldByName(State, fieldname, field, rc)
+  subroutine med_methods_State_getFieldByName(State, fieldname, field, rc)
     ! ----------------------------------------------
     ! Get field associated with fieldname from State
     ! ----------------------------------------------
@@ -908,7 +908,7 @@ contains
     integer         , intent(out)   :: rc
 
     ! local variables
-    character(len=*),parameter :: subname='(shr_nuopc_methods_State_getFieldByName)'
+    character(len=*),parameter :: subname='(med_methods_State_getFieldByName)'
     ! ----------------------------------------------
 
     if (dbug_flag > 10) then
@@ -923,11 +923,11 @@ contains
       call ESMF_LogWrite(trim(subname)//": done", ESMF_LOGMSG_INFO)
     endif
 
-  end subroutine shr_nuopc_methods_State_getFieldByName
+  end subroutine med_methods_State_getFieldByName
 
   !-----------------------------------------------------------------------------
 
-  subroutine shr_nuopc_methods_FB_clean(FB, rc)
+  subroutine med_methods_FB_clean(FB, rc)
     ! ----------------------------------------------
     ! Destroy fields in FB and FB
     ! ----------------------------------------------
@@ -943,7 +943,7 @@ contains
     integer                         :: fieldCount
     character(ESMF_MAXSTR) ,pointer :: lfieldnamelist(:)
     type(ESMF_Field)                :: field
-    character(len=*),parameter      :: subname='(shr_nuopc_methods_FB_clean)'
+    character(len=*),parameter      :: subname='(med_methods_FB_clean)'
     ! ----------------------------------------------
 
     call ESMF_LogWrite(trim(subname)//": called", ESMF_LOGMSG_INFO)
@@ -967,11 +967,11 @@ contains
     deallocate(lfieldnamelist)
     call ESMF_LogWrite(trim(subname)//": done", ESMF_LOGMSG_INFO)
 
-  end subroutine shr_nuopc_methods_FB_clean
+  end subroutine med_methods_FB_clean
 
   !-----------------------------------------------------------------------------
 
-  subroutine shr_nuopc_methods_FB_reset(FB, value, rc)
+  subroutine med_methods_FB_reset(FB, value, rc)
     ! ----------------------------------------------
     ! Set all fields to value in FB
     ! If value is not provided, reset to 0.0
@@ -989,7 +989,7 @@ contains
     integer                         :: fieldCount
     character(ESMF_MAXSTR) ,pointer :: lfieldnamelist(:)
     real(R8)              :: lvalue
-    character(len=*),parameter      :: subname='(shr_nuopc_methods_FB_reset)'
+    character(len=*),parameter      :: subname='(med_methods_FB_reset)'
     ! ----------------------------------------------
 
     if (dbug_flag > 10) then
@@ -1009,7 +1009,7 @@ contains
     if (chkerr(rc,__LINE__,u_FILE_u)) return
 
     do n = 1, fieldCount
-      call shr_nuopc_methods_FB_SetFldPtr(FB, lfieldnamelist(n), lvalue, rc=rc)
+      call med_methods_FB_SetFldPtr(FB, lfieldnamelist(n), lvalue, rc=rc)
       if (chkerr(rc,__LINE__,u_FILE_u)) return
     enddo
 
@@ -1019,11 +1019,11 @@ contains
       call ESMF_LogWrite(trim(subname)//": done", ESMF_LOGMSG_INFO)
     endif
 
-  end subroutine shr_nuopc_methods_FB_reset
+  end subroutine med_methods_FB_reset
 
   !-----------------------------------------------------------------------------
 
-  subroutine shr_nuopc_methods_FB_FieldRegrid(FBin,fldin,FBout,fldout,RH,rc,zeroregion)
+  subroutine med_methods_FB_FieldRegrid(FBin,fldin,FBout,fldout,RH,rc,zeroregion)
 
     ! ----------------------------------------------
     ! Regrid a field in a field bundle to another field in a field bundle
@@ -1051,7 +1051,7 @@ contains
     logical                :: checkflag = .false.
     character(len=8)       :: filename
     type(ESMF_Region_Flag) :: localzr
-    character(len=*),parameter :: subname='(shr_nuopc_methods_FB_FieldRegrid)'
+    character(len=*),parameter :: subname='(med_methods_FB_FieldRegrid)'
     ! ----------------------------------------------
 #ifdef DEBUG
     checkflag = .true.
@@ -1066,13 +1066,13 @@ contains
 
     call ESMF_LogWrite(trim(subname)//": called", ESMF_LOGMSG_INFO)
 
-    if (shr_nuopc_methods_FB_FldChk(FBin , trim(fldin) , rc=rc) .and. &
-         shr_nuopc_methods_FB_FldChk(FBout, trim(fldout), rc=rc)) then
+    if (med_methods_FB_FldChk(FBin , trim(fldin) , rc=rc) .and. &
+         med_methods_FB_FldChk(FBout, trim(fldout), rc=rc)) then
 
-       call shr_nuopc_methods_FB_getFieldByName(FBin, trim(fldin), field1, rc=rc)
+       call med_methods_FB_getFieldByName(FBin, trim(fldin), field1, rc=rc)
        if (chkerr(rc,__LINE__,u_FILE_u)) return
 
-       call shr_nuopc_methods_FB_getFieldByName(FBout, trim(fldout), field2, rc=rc)
+       call med_methods_FB_getFieldByName(FBout, trim(fldout), field2, rc=rc)
        if (chkerr(rc,__LINE__,u_FILE_u)) return
 
        call ESMF_FieldRegrid(field1, field2, routehandle=RH, &
@@ -1087,11 +1087,11 @@ contains
     call ESMF_LogWrite(trim(subname)//": done", ESMF_LOGMSG_INFO)
     call t_stopf(subname)
 
-   end subroutine shr_nuopc_methods_FB_FieldRegrid
+   end subroutine med_methods_FB_FieldRegrid
 
   !-----------------------------------------------------------------------------
 
-  subroutine shr_nuopc_methods_State_reset(State, value, rc)
+  subroutine med_methods_State_reset(State, value, rc)
 
     ! ----------------------------------------------
     ! Set all fields to value in State
@@ -1110,7 +1110,7 @@ contains
     integer                         :: fieldCount
     character(ESMF_MAXSTR) ,pointer :: lfieldnamelist(:)
     real(R8)              :: lvalue
-    character(len=*),parameter      :: subname='(shr_nuopc_methods_State_reset)'
+    character(len=*),parameter      :: subname='(med_methods_State_reset)'
     ! ----------------------------------------------
 
     if (dbug_flag > 10) then
@@ -1130,7 +1130,7 @@ contains
     if (chkerr(rc,__LINE__,u_FILE_u)) return
 
     do n = 1, fieldCount
-      call shr_nuopc_methods_State_SetFldPtr(State, lfieldnamelist(n), lvalue, rc=rc)
+      call med_methods_State_SetFldPtr(State, lfieldnamelist(n), lvalue, rc=rc)
       if (chkerr(rc,__LINE__,u_FILE_u)) return
     enddo
 
@@ -1140,11 +1140,11 @@ contains
       call ESMF_LogWrite(trim(subname)//": done", ESMF_LOGMSG_INFO)
     endif
 
-  end subroutine shr_nuopc_methods_State_reset
+  end subroutine med_methods_State_reset
 
   !-----------------------------------------------------------------------------
 
-  subroutine shr_nuopc_methods_FB_average(FB, count, rc)
+  subroutine med_methods_FB_average(FB, count, rc)
 
     ! ----------------------------------------------
     ! Set all fields to zero in FB
@@ -1163,7 +1163,7 @@ contains
     character(ESMF_MAXSTR) ,pointer :: lfieldnamelist(:)
     real(R8), pointer               :: dataPtr1(:)
     real(R8), pointer               :: dataPtr2(:,:)
-    character(len=*),parameter      :: subname='(shr_nuopc_methods_FB_average)'
+    character(len=*),parameter      :: subname='(med_methods_FB_average)'
     ! ----------------------------------------------
 
     if (dbug_flag > 10) then
@@ -1177,7 +1177,7 @@ contains
           call ESMF_LogWrite(trim(subname)//": WARNING count is 0", ESMF_LOGMSG_INFO)
        end if
        !call ESMF_LogWrite(trim(subname)//": WARNING count is 0 set avg to spval", ESMF_LOGMSG_INFO)
-       !call shr_nuopc_methods_FB_reset(FB, value=spval, rc=rc)
+       !call med_methods_FB_reset(FB, value=spval, rc=rc)
        !if (chkerr(rc,__LINE__,u_FILE_u)) return
 
     else
@@ -1188,7 +1188,7 @@ contains
       call ESMF_FieldBundleGet(FB, fieldNameList=lfieldnamelist, rc=rc)
       if (chkerr(rc,__LINE__,u_FILE_u)) return
       do n = 1, fieldCount
-        call shr_nuopc_methods_FB_GetFldPtr(FB, lfieldnamelist(n), dataPtr1, dataPtr2, lrank, rc=rc)
+        call med_methods_FB_GetFldPtr(FB, lfieldnamelist(n), dataPtr1, dataPtr2, lrank, rc=rc)
         if (chkerr(rc,__LINE__,u_FILE_u)) return
 
         if (lrank == 0) then
@@ -1217,11 +1217,11 @@ contains
       call ESMF_LogWrite(trim(subname)//": done", ESMF_LOGMSG_INFO)
     endif
 
-  end subroutine shr_nuopc_methods_FB_average
+  end subroutine med_methods_FB_average
 
   !-----------------------------------------------------------------------------
 
-  subroutine shr_nuopc_methods_FB_diagnose(FB, string, rc)
+  subroutine med_methods_FB_diagnose(FB, string, rc)
     ! ----------------------------------------------
     ! Diagnose status of FB
     ! ----------------------------------------------
@@ -1239,7 +1239,7 @@ contains
     character(len=CL)               :: lstring
     real(R8), pointer               :: dataPtr1d(:)
     real(R8), pointer               :: dataPtr2d(:,:)
-    character(len=*), parameter     :: subname='(shr_nuopc_methods_FB_diagnose)'
+    character(len=*), parameter     :: subname='(med_methods_FB_diagnose)'
     ! ----------------------------------------------
 
     call ESMF_LogWrite(trim(subname)//": called", ESMF_LOGMSG_INFO)
@@ -1261,7 +1261,7 @@ contains
 
     ! For each field in the bundle, get its memory location and print out the field
     do n = 1, fieldCount
-       call shr_nuopc_methods_FB_GetFldPtr(FB, lfieldnamelist(n), &
+       call med_methods_FB_GetFldPtr(FB, lfieldnamelist(n), &
             fldptr1=dataPtr1d, fldptr2=dataPtr2d, rank=lrank, rc=rc)
        if (chkerr(rc,__LINE__,u_FILE_u)) return
 
@@ -1298,11 +1298,11 @@ contains
 
     call ESMF_LogWrite(trim(subname)//": done", ESMF_LOGMSG_INFO)
 
-  end subroutine shr_nuopc_methods_FB_diagnose
+  end subroutine med_methods_FB_diagnose
 
   !-----------------------------------------------------------------------------
 
-  subroutine shr_nuopc_methods_Array_diagnose(array, string, rc)
+  subroutine med_methods_Array_diagnose(array, string, rc)
 
     ! ----------------------------------------------
     ! Diagnose status of Array
@@ -1318,7 +1318,7 @@ contains
     ! local variables
     character(len=CS) :: lstring
     real(R8), pointer :: dataPtr3d(:,:,:)
-    character(len=*),parameter  :: subname='(shr_nuopc_methods_Array_diagnose)'
+    character(len=*),parameter  :: subname='(med_methods_Array_diagnose)'
     ! ----------------------------------------------
 
     if (dbug_flag > 10) then
@@ -1348,11 +1348,11 @@ contains
       call ESMF_LogWrite(trim(subname)//": done", ESMF_LOGMSG_INFO)
     endif
 
-  end subroutine shr_nuopc_methods_Array_diagnose
+  end subroutine med_methods_Array_diagnose
 
   !-----------------------------------------------------------------------------
 
-  subroutine shr_nuopc_methods_State_diagnose(State, string, rc)
+  subroutine med_methods_State_diagnose(State, string, rc)
     ! ----------------------------------------------
     ! Diagnose status of State
     ! ----------------------------------------------
@@ -1370,7 +1370,7 @@ contains
     character(len=CS)               :: lstring
     real(R8), pointer               :: dataPtr1d(:)
     real(R8), pointer               :: dataPtr2d(:,:)
-    character(len=*),parameter      :: subname='(shr_nuopc_methods_State_diagnose)'
+    character(len=*),parameter      :: subname='(med_methods_State_diagnose)'
     ! ----------------------------------------------
 
     if (dbug_flag > 5) then
@@ -1391,7 +1391,7 @@ contains
 
     do n = 1, fieldCount
 
-       call shr_nuopc_methods_State_GetFldPtr(State, lfieldnamelist(n), &
+       call med_methods_State_GetFldPtr(State, lfieldnamelist(n), &
             fldptr1=dataPtr1d, fldptr2=dataPtr2d, rank=lrank, rc=rc)
        if (chkerr(rc,__LINE__,u_FILE_u)) return
 
@@ -1432,11 +1432,11 @@ contains
       call ESMF_LogWrite(trim(subname)//": done", ESMF_LOGMSG_INFO)
    endif
 
-  end subroutine shr_nuopc_methods_State_diagnose
+  end subroutine med_methods_State_diagnose
 
   !-----------------------------------------------------------------------------
 
-  subroutine shr_nuopc_methods_FB_Field_diagnose(FB, fieldname, string, rc)
+  subroutine med_methods_FB_Field_diagnose(FB, fieldname, string, rc)
 
     ! ----------------------------------------------
     ! Diagnose status of State
@@ -1455,7 +1455,7 @@ contains
     character(len=CS) :: lstring
     real(R8), pointer :: dataPtr1d(:)
     real(R8), pointer :: dataPtr2d(:,:)
-    character(len=*),parameter      :: subname='(shr_nuopc_methods_FB_FieldDiagnose)'
+    character(len=*),parameter      :: subname='(med_methods_FB_FieldDiagnose)'
     ! ----------------------------------------------
 
     if (dbug_flag > 10) then
@@ -1468,7 +1468,7 @@ contains
        lstring = trim(string)
     endif
 
-    call shr_nuopc_methods_FB_GetFldPtr(FB, fieldname, dataPtr1d, dataPtr2d, lrank, rc=rc)
+    call med_methods_FB_GetFldPtr(FB, fieldname, dataPtr1d, dataPtr2d, lrank, rc=rc)
     if (chkerr(rc,__LINE__,u_FILE_u)) return
 
     if (lrank == 0) then
@@ -1498,11 +1498,11 @@ contains
       call ESMF_LogWrite(trim(subname)//": done", ESMF_LOGMSG_INFO)
     endif
 
-  end subroutine shr_nuopc_methods_FB_Field_diagnose
+  end subroutine med_methods_FB_Field_diagnose
 
   !-----------------------------------------------------------------------------
 
-  subroutine shr_nuopc_methods_Field_diagnose(field, fieldname, string, rc)
+  subroutine med_methods_Field_diagnose(field, fieldname, string, rc)
 
     ! ----------------------------------------------
     ! Diagnose Field
@@ -1521,7 +1521,7 @@ contains
     character(len=CS)          :: lstring
     real(R8), pointer          :: dataPtr1d(:)
     real(R8), pointer          :: dataPtr2d(:,:)
-    character(len=*),parameter :: subname='(shr_nuopc_methods_FB_FieldDiagnose)'
+    character(len=*),parameter :: subname='(med_methods_FB_FieldDiagnose)'
     ! ----------------------------------------------
 
     if (dbug_flag > 10) then
@@ -1568,11 +1568,11 @@ contains
       call ESMF_LogWrite(trim(subname)//": done", ESMF_LOGMSG_INFO)
     endif
 
-  end subroutine shr_nuopc_methods_Field_diagnose
+  end subroutine med_methods_Field_diagnose
 
   !-----------------------------------------------------------------------------
 
-  subroutine shr_nuopc_methods_FB_copyFB2FB(FBout, FBin, rc)
+  subroutine med_methods_FB_copyFB2FB(FBout, FBin, rc)
 
     ! ----------------------------------------------
     ! Copy common field names from FBin to FBout
@@ -1583,24 +1583,24 @@ contains
     type(ESMF_FieldBundle), intent(inout) :: FBout
     type(ESMF_FieldBundle), intent(in)    :: FBin
     integer               , intent(out)   :: rc
-    character(len=*), parameter :: subname='(shr_nuopc_methods_FB_copyFB2FB)'
+    character(len=*), parameter :: subname='(med_methods_FB_copyFB2FB)'
     ! ----------------------------------------------
 
     call ESMF_LogWrite(trim(subname)//": called", ESMF_LOGMSG_INFO)
     rc = ESMF_SUCCESS
 
-    call shr_nuopc_methods_FB_accum(FBout, FBin, copy=.true., rc=rc)
+    call med_methods_FB_accum(FBout, FBin, copy=.true., rc=rc)
     if (chkerr(rc,__LINE__,u_FILE_u)) return
 
     if (dbug_flag > 10) then
       call ESMF_LogWrite(trim(subname)//": done", ESMF_LOGMSG_INFO)
     endif
 
-  end subroutine shr_nuopc_methods_FB_copyFB2FB
+  end subroutine med_methods_FB_copyFB2FB
 
   !-----------------------------------------------------------------------------
 
-  subroutine shr_nuopc_methods_FB_accumFB2FB(FBout, FBin, copy, rc)
+  subroutine med_methods_FB_accumFB2FB(FBout, FBin, copy, rc)
 
     ! ----------------------------------------------
     ! Accumulate common field names from FBin to FBout
@@ -1623,7 +1623,7 @@ contains
     logical                         :: lcopy
     real(R8), pointer               :: dataPtri1(:)  , dataPtro1(:)
     real(R8), pointer               :: dataPtri2(:,:), dataPtro2(:,:)
-    character(len=*), parameter     :: subname='(shr_nuopc_methods_FB_accumFB2FB)'
+    character(len=*), parameter     :: subname='(med_methods_FB_accumFB2FB)'
     ! ----------------------------------------------
 
     if (dbug_flag > 10) then
@@ -1646,14 +1646,14 @@ contains
       call ESMF_FieldBundleGet(FBin, fieldName=lfieldnamelist(n), isPresent=exists, rc=rc)
       if (chkerr(rc,__LINE__,u_FILE_u)) return
       if (exists) then
-        call shr_nuopc_methods_FB_GetFldPtr(FBin,  lfieldnamelist(n), dataPtri1, dataPtri2, lranki, rc=rc)
+        call med_methods_FB_GetFldPtr(FBin,  lfieldnamelist(n), dataPtri1, dataPtri2, lranki, rc=rc)
         if (chkerr(rc,__LINE__,u_FILE_u)) return
-        call shr_nuopc_methods_FB_GetFldPtr(FBout, lfieldnamelist(n), dataPtro1, dataPtro2, lranko, rc=rc)
+        call med_methods_FB_GetFldPtr(FBout, lfieldnamelist(n), dataPtro1, dataPtro2, lranko, rc=rc)
         if (chkerr(rc,__LINE__,u_FILE_u)) return
 
         if (lranki == 1 .and. lranko == 1) then
 
-          if (.not.shr_nuopc_methods_FieldPtr_Compare(dataPtro1, dataPtri1, subname, rc)) then
+          if (.not.med_methods_FieldPtr_Compare(dataPtro1, dataPtri1, subname, rc)) then
             call ESMF_LogWrite(trim(subname)//": ERROR in dataPtr1 size ", ESMF_LOGMSG_ERROR)
             rc = ESMF_FAILURE
             return
@@ -1671,7 +1671,7 @@ contains
 
         elseif (lranki == 2 .and. lranko == 2) then
 
-          if (.not.shr_nuopc_methods_FieldPtr_Compare(dataPtro2, dataPtri2, subname, rc)) then
+          if (.not.med_methods_FieldPtr_Compare(dataPtro2, dataPtri2, subname, rc)) then
             call ESMF_LogWrite(trim(subname)//": ERROR in dataPtr2 size ", ESMF_LOGMSG_ERROR)
             rc = ESMF_FAILURE
             return
@@ -1711,11 +1711,11 @@ contains
       call ESMF_LogWrite(trim(subname)//": done", ESMF_LOGMSG_INFO)
     endif
 
-  end subroutine shr_nuopc_methods_FB_accumFB2FB
+  end subroutine med_methods_FB_accumFB2FB
 
   !-----------------------------------------------------------------------------
 
-  logical function shr_nuopc_methods_FB_FldChk(FB, fldname, rc)
+  logical function med_methods_FB_FldChk(FB, fldname, rc)
 
     ! ----------------------------------------------
     ! Determine if field with fldname is in input field bundle
@@ -1730,7 +1730,7 @@ contains
     integer               , intent(out) :: rc
 
     ! local variables
-    character(len=*), parameter :: subname='(shr_nuopc_methods_FB_FldChk)'
+    character(len=*), parameter :: subname='(med_methods_FB_FldChk)'
     ! ----------------------------------------------
 
     if (dbug_flag > 10) then
@@ -1740,12 +1740,12 @@ contains
 
     ! If field bundle is not created then set return to .false.
     if (.not. ESMF_FieldBundleIsCreated(FB)) then
-       shr_nuopc_methods_FB_FldChk = .false.
+       med_methods_FB_FldChk = .false.
        return
     end if
 
     ! If field bundle is created determine if fldname is present in field bundle
-    shr_nuopc_methods_FB_FldChk = .false.
+    med_methods_FB_FldChk = .false.
 
     call ESMF_FieldBundleGet(FB, fieldName=trim(fldname), isPresent=isPresent, rc=rc)
     if (chkerr(rc,__LINE__,u_FILE_u)) then
@@ -1754,18 +1754,18 @@ contains
        return
     endif
     if (isPresent) then
-       shr_nuopc_methods_FB_FldChk = .true.
+       med_methods_FB_FldChk = .true.
     endif
 
     if (dbug_flag > 10) then
       call ESMF_LogWrite(trim(subname)//": done", ESMF_LOGMSG_INFO)
     endif
 
-  end function shr_nuopc_methods_FB_FldChk
+  end function med_methods_FB_FldChk
 
   !-----------------------------------------------------------------------------
 
-  subroutine shr_nuopc_methods_Field_GetFldPtr(field, fldptr1, fldptr2, rank, abort, rc)
+  subroutine med_methods_Field_GetFldPtr(field, fldptr1, fldptr2, rank, abort, rc)
 
     ! ----------------------------------------------
     ! for a field, determine rank and return fldptr1 or fldptr2
@@ -1788,7 +1788,7 @@ contains
     type(ESMF_Mesh) :: lmesh
     integer         :: lrank, nnodes, nelements
     logical         :: labort
-    character(len=*), parameter :: subname='(shr_nuopc_methods_Field_GetFldPtr)'
+    character(len=*), parameter :: subname='(med_methods_Field_GetFldPtr)'
     ! ----------------------------------------------
 
     if (dbug_flag > 10) then
@@ -1888,11 +1888,11 @@ contains
       call ESMF_LogWrite(trim(subname)//": done", ESMF_LOGMSG_INFO)
     endif
 
-  end subroutine shr_nuopc_methods_Field_GetFldPtr
+  end subroutine med_methods_Field_GetFldPtr
 
   !-----------------------------------------------------------------------------
 
-  subroutine shr_nuopc_methods_FB_GetFldPtr(FB, fldname, fldptr1, fldptr2, rank, field, rc)
+  subroutine med_methods_FB_GetFldPtr(FB, fldname, fldptr1, fldptr2, rank, field, rc)
 
     use ESMF , only : ESMF_FieldBundle, ESMF_FieldBundleGet, ESMF_Field
 
@@ -1911,7 +1911,7 @@ contains
     ! local variables
     type(ESMF_Field) :: lfield
     integer          :: lrank
-    character(len=*), parameter :: subname='(shr_nuopc_methods_FB_GetFldPtr)'
+    character(len=*), parameter :: subname='(med_methods_FB_GetFldPtr)'
     ! ----------------------------------------------
 
     if (dbug_flag > 10) then
@@ -1927,7 +1927,7 @@ contains
 
     rc = ESMF_SUCCESS
 
-    if (.not. shr_nuopc_methods_FB_FldChk(FB, trim(fldname), rc=rc)) then
+    if (.not. med_methods_FB_FldChk(FB, trim(fldname), rc=rc)) then
        call ESMF_LogWrite(trim(subname)//": ERROR field "//trim(fldname)//" not in FB ", &
             ESMF_LOGMSG_ERROR, line=__LINE__, file=u_FILE_u)
       rc = ESMF_FAILURE
@@ -1937,7 +1937,7 @@ contains
     call ESMF_FieldBundleGet(FB, fieldName=trim(fldname), field=lfield, rc=rc)
     if (chkerr(rc,__LINE__,u_FILE_u)) return
 
-    call shr_nuopc_methods_Field_GetFldPtr(lfield, &
+    call med_methods_Field_GetFldPtr(lfield, &
          fldptr1=fldptr1, fldptr2=fldptr2, rank=lrank, rc=rc)
     if (chkerr(rc,__LINE__,u_FILE_u)) return
 
@@ -1951,11 +1951,11 @@ contains
       call ESMF_LogWrite(trim(subname)//": done", ESMF_LOGMSG_INFO)
     endif
 
-  end subroutine shr_nuopc_methods_FB_GetFldPtr
+  end subroutine med_methods_FB_GetFldPtr
 
   !-----------------------------------------------------------------------------
 
-  subroutine shr_nuopc_methods_FB_SetFldPtr(FB, fldname, val, rc)
+  subroutine med_methods_FB_SetFldPtr(FB, fldname, val, rc)
 
     use ESMF, only : ESMF_FieldBundle, ESMF_Field
 
@@ -1969,7 +1969,7 @@ contains
     integer          :: lrank
     real(R8), pointer :: fldptr1(:)
     real(R8), pointer :: fldptr2(:,:)
-    character(len=*), parameter :: subname='(shr_nuopc_methods_FB_SetFldPtr)'
+    character(len=*), parameter :: subname='(med_methods_FB_SetFldPtr)'
     ! ----------------------------------------------
 
     if (dbug_flag > 10) then
@@ -1977,7 +1977,7 @@ contains
     endif
     rc = ESMF_SUCCESS
 
-    call shr_nuopc_methods_FB_GetFldPtr(FB, fldname, fldptr1, fldptr2, lrank, rc=rc)
+    call med_methods_FB_GetFldPtr(FB, fldname, fldptr1, fldptr2, lrank, rc=rc)
     if (chkerr(rc,__LINE__,u_FILE_u)) return
 
     if (lrank == 0) then
@@ -1997,11 +1997,11 @@ contains
       call ESMF_LogWrite(trim(subname)//": done", ESMF_LOGMSG_INFO)
     endif
 
-  end subroutine shr_nuopc_methods_FB_SetFldPtr
+  end subroutine med_methods_FB_SetFldPtr
 
   !-----------------------------------------------------------------------------
 
-  subroutine shr_nuopc_methods_State_GetFldPtr(ST, fldname, fldptr1, fldptr2, rank, rc)
+  subroutine med_methods_State_GetFldPtr(ST, fldname, fldptr1, fldptr2, rank, rc)
     ! ----------------------------------------------
     ! Get pointer to a state field
     ! ----------------------------------------------
@@ -2018,7 +2018,7 @@ contains
     ! local variables
     type(ESMF_Field)           :: lfield
     integer                    :: lrank
-    character(len=*), parameter :: subname='(shr_nuopc_methods_State_GetFldPtr)'
+    character(len=*), parameter :: subname='(med_methods_State_GetFldPtr)'
     ! ----------------------------------------------
 
     if (dbug_flag > 10) then
@@ -2037,7 +2037,7 @@ contains
     call ESMF_StateGet(ST, itemName=trim(fldname), field=lfield, rc=rc)
     if (chkerr(rc,__LINE__,u_FILE_u)) return
 
-    call shr_nuopc_methods_Field_GetFldPtr(lfield, &
+    call med_methods_Field_GetFldPtr(lfield, &
          fldptr1=fldptr1, fldptr2=fldptr2, rank=lrank, rc=rc)
     if (chkerr(rc,__LINE__,u_FILE_u)) return
 
@@ -2049,11 +2049,11 @@ contains
       call ESMF_LogWrite(trim(subname)//": done", ESMF_LOGMSG_INFO)
     endif
 
-  end subroutine shr_nuopc_methods_State_GetFldPtr
+  end subroutine med_methods_State_GetFldPtr
 
   !-----------------------------------------------------------------------------
 
-  subroutine shr_nuopc_methods_State_SetFldPtr(ST, fldname, val, rc)
+  subroutine med_methods_State_SetFldPtr(ST, fldname, val, rc)
 
     use ESMF, only : ESMF_State, ESMF_Field
 
@@ -2067,7 +2067,7 @@ contains
     integer          :: lrank
     real(R8), pointer :: fldptr1(:)
     real(R8), pointer :: fldptr2(:,:)
-    character(len=*), parameter :: subname='(shr_nuopc_methods_State_SetFldPtr)'
+    character(len=*), parameter :: subname='(med_methods_State_SetFldPtr)'
     ! ----------------------------------------------
 
     if (dbug_flag > 10) then
@@ -2075,7 +2075,7 @@ contains
     endif
     rc = ESMF_SUCCESS
 
-    call shr_nuopc_methods_State_GetFldPtr(ST, fldname, fldptr1, fldptr2, lrank, rc=rc)
+    call med_methods_State_GetFldPtr(ST, fldname, fldptr1, fldptr2, lrank, rc=rc)
     if (chkerr(rc,__LINE__,u_FILE_u)) return
 
     if (lrank == 0) then
@@ -2095,11 +2095,11 @@ contains
       call ESMF_LogWrite(trim(subname)//": done", ESMF_LOGMSG_INFO)
     endif
 
-  end subroutine shr_nuopc_methods_State_SetFldPtr
+  end subroutine med_methods_State_SetFldPtr
 
   !-----------------------------------------------------------------------------
 
-  logical function shr_nuopc_methods_FieldPtr_Compare1(fldptr1, fldptr2, cstring, rc)
+  logical function med_methods_FieldPtr_Compare1(fldptr1, fldptr2, cstring, rc)
 
     real(R8), pointer, intent(in)  :: fldptr1(:)
     real(R8), pointer, intent(in)  :: fldptr2(:)
@@ -2107,7 +2107,7 @@ contains
     integer                    , intent(out) :: rc
 
     ! local variables
-    character(len=*), parameter :: subname='(shr_nuopc_methods_FieldPtr_Compare1)'
+    character(len=*), parameter :: subname='(med_methods_FieldPtr_Compare1)'
     ! ----------------------------------------------
 
     if (dbug_flag > 10) then
@@ -2115,7 +2115,7 @@ contains
     endif
     rc = ESMF_SUCCESS
 
-    shr_nuopc_methods_FieldPtr_Compare1 = .false.
+    med_methods_FieldPtr_Compare1 = .false.
     if (lbound(fldptr2,1) /= lbound(fldptr1,1) .or. &
         ubound(fldptr2,1) /= ubound(fldptr1,1)) then
       call ESMF_LogWrite(trim(subname)//": ERROR in data size "//trim(cstring), ESMF_LOGMSG_ERROR, rc=rc)
@@ -2125,18 +2125,18 @@ contains
       write(msgString,*) trim(subname)//': fldptr2 ',lbound(fldptr2),ubound(fldptr2)
       call ESMF_LogWrite(trim(msgString), ESMF_LOGMSG_INFO)
     else
-      shr_nuopc_methods_FieldPtr_Compare1 = .true.
+      med_methods_FieldPtr_Compare1 = .true.
     endif
 
     if (dbug_flag > 10) then
       call ESMF_LogWrite(trim(subname)//": done", ESMF_LOGMSG_INFO)
     endif
 
-  end function shr_nuopc_methods_FieldPtr_Compare1
+  end function med_methods_FieldPtr_Compare1
 
   !-----------------------------------------------------------------------------
 
-  logical function shr_nuopc_methods_FieldPtr_Compare2(fldptr1, fldptr2, cstring, rc)
+  logical function med_methods_FieldPtr_Compare2(fldptr1, fldptr2, cstring, rc)
 
     real(R8), pointer, intent(in)  :: fldptr1(:,:)
     real(R8), pointer, intent(in)  :: fldptr2(:,:)
@@ -2144,7 +2144,7 @@ contains
     integer                    , intent(out) :: rc
 
     ! local variables
-    character(len=*), parameter :: subname='(shr_nuopc_methods_FieldPtr_Compare2)'
+    character(len=*), parameter :: subname='(med_methods_FieldPtr_Compare2)'
     ! ----------------------------------------------
 
     if (dbug_flag > 10) then
@@ -2152,7 +2152,7 @@ contains
     endif
     rc = ESMF_SUCCESS
 
-    shr_nuopc_methods_FieldPtr_Compare2 = .false.
+    med_methods_FieldPtr_Compare2 = .false.
     if (lbound(fldptr2,2) /= lbound(fldptr1,2) .or. &
         lbound(fldptr2,1) /= lbound(fldptr1,1) .or. &
         ubound(fldptr2,2) /= ubound(fldptr1,2) .or. &
@@ -2164,18 +2164,18 @@ contains
       write(msgString,*) trim(subname)//': fldptr1 ',lbound(fldptr1),ubound(fldptr1)
       call ESMF_LogWrite(trim(msgString), ESMF_LOGMSG_INFO)
     else
-      shr_nuopc_methods_FieldPtr_Compare2 = .true.
+      med_methods_FieldPtr_Compare2 = .true.
     endif
 
     if (dbug_flag > 10) then
       call ESMF_LogWrite(trim(subname)//": done", ESMF_LOGMSG_INFO)
     endif
 
-  end function shr_nuopc_methods_FieldPtr_Compare2
+  end function med_methods_FieldPtr_Compare2
 
   !-----------------------------------------------------------------------------
 
-  subroutine shr_nuopc_methods_State_GeomPrint(state, string, rc)
+  subroutine med_methods_State_GeomPrint(state, string, rc)
 
     use ESMF, only : ESMF_State, ESMF_Field, ESMF_StateGet
 
@@ -2185,7 +2185,7 @@ contains
 
     type(ESMF_Field)  :: lfield
     integer           :: fieldcount
-    character(len=*),parameter  :: subname='(shr_nuopc_methods_State_GeomPrint)'
+    character(len=*),parameter  :: subname='(med_methods_State_GeomPrint)'
     ! ----------------------------------------------
 
     if (dbug_flag > 10) then
@@ -2197,9 +2197,9 @@ contains
     if (chkerr(rc,__LINE__,u_FILE_u)) return
 
     if (fieldCount > 0) then
-      call shr_nuopc_methods_State_GetFieldN(state, 1, lfield, rc=rc)
+      call med_methods_State_GetFieldN(state, 1, lfield, rc=rc)
       if (chkerr(rc,__LINE__,u_FILE_u)) return
-      call shr_nuopc_methods_Field_GeomPrint(lfield, string, rc)
+      call med_methods_Field_GeomPrint(lfield, string, rc)
       if (chkerr(rc,__LINE__,u_FILE_u)) return
     else
       call ESMF_LogWrite(trim(subname)//":"//trim(string)//": no fields", ESMF_LOGMSG_INFO)
@@ -2209,11 +2209,11 @@ contains
       call ESMF_LogWrite(trim(subname)//": done", ESMF_LOGMSG_INFO)
     endif
 
-  end subroutine shr_nuopc_methods_State_GeomPrint
+  end subroutine med_methods_State_GeomPrint
 
   !-----------------------------------------------------------------------------
 
-  subroutine shr_nuopc_methods_FB_GeomPrint(FB, string, rc)
+  subroutine med_methods_FB_GeomPrint(FB, string, rc)
 
     use ESMF, only : ESMF_FieldBundle, ESMF_Field, ESMF_FieldBundleGet
 
@@ -2223,7 +2223,7 @@ contains
 
     type(ESMF_Field)  :: lfield
     integer           :: fieldcount
-    character(len=*),parameter  :: subname='(shr_nuopc_methods_FB_GeomPrint)'
+    character(len=*),parameter  :: subname='(med_methods_FB_GeomPrint)'
     ! ----------------------------------------------
 
     if (dbug_flag > 10) then
@@ -2236,7 +2236,7 @@ contains
 
     if (fieldCount > 0) then
 
-      call shr_nuopc_methods_Field_GeomPrint(lfield, string, rc)
+      call med_methods_Field_GeomPrint(lfield, string, rc)
       if (chkerr(rc,__LINE__,u_FILE_u)) return
     else
       call ESMF_LogWrite(trim(subname)//":"//trim(string)//": no fields", ESMF_LOGMSG_INFO)
@@ -2246,11 +2246,11 @@ contains
       call ESMF_LogWrite(trim(subname)//": done", ESMF_LOGMSG_INFO)
     endif
 
-  end subroutine shr_nuopc_methods_FB_GeomPrint
+  end subroutine med_methods_FB_GeomPrint
 
   !-----------------------------------------------------------------------------
 
-  subroutine shr_nuopc_methods_Field_GeomPrint(field, string, rc)
+  subroutine med_methods_Field_GeomPrint(field, string, rc)
 
     use ESMF, only : ESMF_Field, ESMF_Grid, ESMF_Mesh
     use ESMF, only : ESMF_FieldGet, ESMF_GEOMTYPE_MESH, ESMF_GEOMTYPE_GRID, ESMF_FIELDSTATUS_EMPTY
@@ -2266,7 +2266,7 @@ contains
     integer           :: lrank
     real(R8), pointer :: dataPtr1(:)
     real(R8), pointer :: dataPtr2(:,:)
-    character(len=*),parameter  :: subname='(shr_nuopc_methods_Field_GeomPrint)'
+    character(len=*),parameter  :: subname='(med_methods_Field_GeomPrint)'
     ! ----------------------------------------------
 
     if (dbug_flag > 10) then
@@ -2289,16 +2289,16 @@ contains
     if (geomtype == ESMF_GEOMTYPE_GRID) then
       call ESMF_FieldGet(field, grid=lgrid, rc=rc)
       if (chkerr(rc,__LINE__,u_FILE_u)) return
-      call shr_nuopc_methods_Grid_Print(lgrid, string, rc)
+      call med_methods_Grid_Print(lgrid, string, rc)
       if (chkerr(rc,__LINE__,u_FILE_u)) return
     elseif (geomtype == ESMF_GEOMTYPE_MESH) then
       call ESMF_FieldGet(field, mesh=lmesh, rc=rc)
       if (chkerr(rc,__LINE__,u_FILE_u)) return
-      call shr_nuopc_methods_Mesh_Print(lmesh, string, rc)
+      call med_methods_Mesh_Print(lmesh, string, rc)
       if (chkerr(rc,__LINE__,u_FILE_u)) return
     endif
 
-    call shr_nuopc_methods_Field_GetFldPtr(field, &
+    call med_methods_Field_GetFldPtr(field, &
          fldptr1=dataPtr1, fldptr2=dataPtr2, rank=lrank, abort=.false., rc=rc)
     if (chkerr(rc,__LINE__,u_FILE_u)) return
 
@@ -2329,11 +2329,11 @@ contains
       call ESMF_LogWrite(trim(subname)//": done", ESMF_LOGMSG_INFO)
     endif
 
-  end subroutine shr_nuopc_methods_Field_GeomPrint
+  end subroutine med_methods_Field_GeomPrint
 
   !-----------------------------------------------------------------------------
 
-  subroutine shr_nuopc_methods_Mesh_Print(mesh, string, rc)
+  subroutine med_methods_Mesh_Print(mesh, string, rc)
 
     use ESMF, only: ESMF_Mesh, ESMF_DistGrid, ESMF_MeshGet, ESMF_DistGridGet
     use ESMF, only: ESMF_DELayoutGet, ESMF_DELayout
@@ -2352,7 +2352,7 @@ contains
     integer, allocatable        :: minIndexPTile(:,:), maxIndexPTile(:,:)
     type(ESMF_MeshStatus_Flag)  :: meshStatus
     logical                     :: elemDGPresent, nodeDGPresent
-    character(len=*),parameter  :: subname='(shr_nuopc_methods_Mesh_Print)'
+    character(len=*),parameter  :: subname='(med_methods_Mesh_Print)'
     ! ----------------------------------------------
 
     if (dbug_flag > 10) then
@@ -2500,11 +2500,11 @@ contains
       call ESMF_LogWrite(trim(subname)//": done", ESMF_LOGMSG_INFO)
     endif
 
-  end subroutine shr_nuopc_methods_Mesh_Print
+  end subroutine med_methods_Mesh_Print
 
   !-----------------------------------------------------------------------------
 
-  subroutine shr_nuopc_methods_Grid_Print(grid, string, rc)
+  subroutine med_methods_Grid_Print(grid, string, rc)
 
     use ESMF, only : ESMF_Grid, ESMF_DistGrid, ESMF_StaggerLoc
     use ESMF, only : ESMF_GridGet, ESMF_DistGridGet, ESMF_GridGetCoord
@@ -2525,7 +2525,7 @@ contains
     real(R8), pointer :: fldptr1(:)
     real(R8), pointer :: fldptr2(:,:)
     integer                     :: n1,n2,n3
-    character(len=*),parameter  :: subname='(shr_nuopc_methods_Grid_Print)'
+    character(len=*),parameter  :: subname='(med_methods_Grid_Print)'
     ! ----------------------------------------------
 
     if (dbug_flag > 10) then
@@ -2640,10 +2640,10 @@ contains
       call ESMF_LogWrite(trim(subname)//": done", ESMF_LOGMSG_INFO)
     endif
 
-  end subroutine shr_nuopc_methods_Grid_Print
+  end subroutine med_methods_Grid_Print
 
 !-----------------------------------------------------------------------------
-  subroutine shr_nuopc_methods_Clock_TimePrint(clock,string,rc)
+  subroutine med_methods_Clock_TimePrint(clock,string,rc)
 
     use ESMF , only : ESMF_Clock, ESMF_Time, ESMF_TimeInterval
     use ESMF , only : ESMF_ClockGet, ESMF_TimeGet, ESMF_TimeIntervalGet
@@ -2658,7 +2658,7 @@ contains
     type(ESMF_TimeInterval) :: timeStep
     character(len=CS)       :: timestr
     character(len=CL)       :: lstring
-    character(len=*), parameter :: subname='(shr_nuopc_methods_Clock_TimePrint)'
+    character(len=*), parameter :: subname='(med_methods_Clock_TimePrint)'
     ! ----------------------------------------------
 
     rc = ESMF_SUCCESS
@@ -2701,11 +2701,11 @@ contains
       call ESMF_LogWrite(trim(subname)//": done", ESMF_LOGMSG_INFO)
     endif
 
-  end subroutine shr_nuopc_methods_Clock_TimePrint
+  end subroutine med_methods_Clock_TimePrint
 
   !-----------------------------------------------------------------------------
 
-  subroutine shr_nuopc_methods_Mesh_Write(mesh, string, rc)
+  subroutine med_methods_Mesh_Write(mesh, string, rc)
 
     use ESMF, only : ESMF_Mesh, ESMF_MeshGet, ESMF_Array, ESMF_ArrayWrite, ESMF_DistGrid
 
@@ -2720,7 +2720,7 @@ contains
     type(ESMF_Array)    :: array
     real(R8), pointer   :: rawdata(:)
     real(R8), pointer   :: coord(:)
-    character(len=*),parameter  :: subname='(shr_nuopc_methods_Mesh_Write)'
+    character(len=*),parameter  :: subname='(med_methods_Mesh_Write)'
     ! ----------------------------------------------
 
     rc = ESMF_SUCCESS
@@ -2749,7 +2749,7 @@ contains
       array = ESMF_ArrayCreate(distgrid, farrayPtr=coord, name=name, rc=rc)
       if (chkerr(rc,__LINE__,u_FILE_u)) return
 
-      call shr_nuopc_methods_Array_diagnose(array, string=trim(string)//"_"//trim(name), rc=rc)
+      call med_methods_Array_diagnose(array, string=trim(string)//"_"//trim(name), rc=rc)
       if (chkerr(rc,__LINE__,u_FILE_u)) return
 
       call ESMF_ArrayWrite(array, trim(string)//"_"//trim(name)//".nc", overwrite=.true., rc=rc)
@@ -2779,7 +2779,7 @@ contains
       array = ESMF_ArrayCreate(distgrid, farrayPtr=coord, name=name, rc=rc)
       if (chkerr(rc,__LINE__,u_FILE_u)) return
 
-      call shr_nuopc_methods_Array_diagnose(array, string=trim(string)//"_"//trim(name), rc=rc)
+      call med_methods_Array_diagnose(array, string=trim(string)//"_"//trim(name), rc=rc)
       if (chkerr(rc,__LINE__,u_FILE_u)) return
 
       call ESMF_ArrayWrite(array, trim(string)//"_"//trim(name)//".nc", overwrite=.true., rc=rc)
@@ -2796,11 +2796,11 @@ contains
       call ESMF_LogWrite(trim(subname)//": done", ESMF_LOGMSG_INFO)
     endif
 
-  end subroutine shr_nuopc_methods_Mesh_Write
+  end subroutine med_methods_Mesh_Write
 
   !-----------------------------------------------------------------------------
 
-  subroutine shr_nuopc_methods_State_GeomWrite(state, string, rc)
+  subroutine med_methods_State_GeomWrite(state, string, rc)
     use ESMF, only : ESMF_State, ESMF_Field, ESMF_StateGet
     type(ESMF_State), intent(in)  :: state
     character(len=*), intent(in)  :: string
@@ -2808,7 +2808,7 @@ contains
 
     type(ESMF_Field)  :: lfield
     integer           :: fieldcount
-    character(len=*),parameter  :: subname='(shr_nuopc_methods_State_GeomWrite)'
+    character(len=*),parameter  :: subname='(med_methods_State_GeomWrite)'
     ! ----------------------------------------------
 
     if (dbug_flag > 10) then
@@ -2820,9 +2820,9 @@ contains
     if (chkerr(rc,__LINE__,u_FILE_u)) return
 
     if (fieldCount > 0) then
-      call shr_nuopc_methods_State_getFieldN(state, 1, lfield, rc=rc)
+      call med_methods_State_getFieldN(state, 1, lfield, rc=rc)
       if (chkerr(rc,__LINE__,u_FILE_u)) return
-      call shr_nuopc_methods_Field_GeomWrite(lfield, string, rc)
+      call med_methods_Field_GeomWrite(lfield, string, rc)
       if (chkerr(rc,__LINE__,u_FILE_u)) return
     else
       call ESMF_LogWrite(trim(subname)//":"//trim(string)//": no fields", ESMF_LOGMSG_INFO)
@@ -2832,11 +2832,11 @@ contains
       call ESMF_LogWrite(trim(subname)//": done", ESMF_LOGMSG_INFO)
     endif
 
-  end subroutine shr_nuopc_methods_State_GeomWrite
+  end subroutine med_methods_State_GeomWrite
 
   !-----------------------------------------------------------------------------
 
-  subroutine shr_nuopc_methods_FB_GeomWrite(FB, string, rc)
+  subroutine med_methods_FB_GeomWrite(FB, string, rc)
     use ESMF, only : ESMF_Field, ESMF_FieldBundle, ESMF_FieldBundleGet
 
     type(ESMF_FieldBundle), intent(in)  :: FB
@@ -2845,7 +2845,7 @@ contains
 
     type(ESMF_Field)  :: lfield
     integer           :: fieldcount
-    character(len=*),parameter  :: subname='(shr_nuopc_methods_FB_GeomWrite)'
+    character(len=*),parameter  :: subname='(med_methods_FB_GeomWrite)'
     ! ----------------------------------------------
 
     if (dbug_flag > 10) then
@@ -2857,9 +2857,9 @@ contains
     if (chkerr(rc,__LINE__,u_FILE_u)) return
 
     if (fieldCount > 0) then
-      call shr_nuopc_methods_FB_getFieldN(FB, 1, lfield, rc=rc)
+      call med_methods_FB_getFieldN(FB, 1, lfield, rc=rc)
       if (chkerr(rc,__LINE__,u_FILE_u)) return
-      call shr_nuopc_methods_Field_GeomWrite(lfield, string, rc)
+      call med_methods_Field_GeomWrite(lfield, string, rc)
       if (chkerr(rc,__LINE__,u_FILE_u)) return
     else
       call ESMF_LogWrite(trim(subname)//":"//trim(string)//": no fields", ESMF_LOGMSG_INFO)
@@ -2869,11 +2869,11 @@ contains
       call ESMF_LogWrite(trim(subname)//": done", ESMF_LOGMSG_INFO)
     endif
 
-  end subroutine shr_nuopc_methods_FB_GeomWrite
+  end subroutine med_methods_FB_GeomWrite
 
   !-----------------------------------------------------------------------------
 
-  subroutine shr_nuopc_methods_Field_GeomWrite(field, string, rc)
+  subroutine med_methods_Field_GeomWrite(field, string, rc)
 
     use ESMF, only : ESMF_Field, ESMF_Grid, ESMF_Mesh, ESMF_FIeldGet, ESMF_FIELDSTATUS_EMPTY
     use ESMF, only : ESMF_GEOMTYPE_MESH, ESMF_GEOMTYPE_GRID
@@ -2886,7 +2886,7 @@ contains
     ! local variables
     type(ESMF_Grid)     :: lgrid
     type(ESMF_Mesh)     :: lmesh
-    character(len=*),parameter  :: subname='(shr_nuopc_methods_Field_GeomWrite)'
+    character(len=*),parameter  :: subname='(med_methods_Field_GeomWrite)'
     ! ----------------------------------------------
 
     if (dbug_flag > 10) then
@@ -2908,12 +2908,12 @@ contains
     if (geomtype == ESMF_GEOMTYPE_GRID) then
       call ESMF_FieldGet(field, grid=lgrid, rc=rc)
       if (chkerr(rc,__LINE__,u_FILE_u)) return
-      call shr_nuopc_methods_Grid_Write(lgrid, string, rc)
+      call med_methods_Grid_Write(lgrid, string, rc)
       if (chkerr(rc,__LINE__,u_FILE_u)) return
     elseif (geomtype == ESMF_GEOMTYPE_MESH) then
       call ESMF_FieldGet(field, mesh=lmesh, rc=rc)
       if (chkerr(rc,__LINE__,u_FILE_u)) return
-      call shr_nuopc_methods_Mesh_Write(lmesh, string, rc)
+      call med_methods_Mesh_Write(lmesh, string, rc)
       if (chkerr(rc,__LINE__,u_FILE_u)) return
     endif
 
@@ -2921,11 +2921,11 @@ contains
       call ESMF_LogWrite(trim(subname)//": done", ESMF_LOGMSG_INFO)
     endif
 
-  end subroutine shr_nuopc_methods_Field_GeomWrite
+  end subroutine med_methods_Field_GeomWrite
 
   !-----------------------------------------------------------------------------
 
-  subroutine shr_nuopc_methods_Grid_Write(grid, string, rc)
+  subroutine med_methods_Grid_Write(grid, string, rc)
 
     use ESMF              , only : ESMF_Grid, ESMF_Array, ESMF_GridGetCoord, ESMF_ArraySet
     use ESMF              , only : ESMF_ArrayWrite, ESMF_GridGetItem, ESMF_GridGetCoord
@@ -2940,7 +2940,7 @@ contains
     ! local
     type(ESMF_Array)  :: array
     character(len=CS) :: name
-    character(len=*),parameter  :: subname='(shr_nuopc_methods_Grid_Write)'
+    character(len=*),parameter  :: subname='(med_methods_Grid_Write)'
     ! ----------------------------------------------
 
     rc = ESMF_SUCCESS
@@ -2960,7 +2960,7 @@ contains
       call ESMF_ArraySet(array, name=name, rc=rc)
       if (chkerr(rc,__LINE__,u_FILE_u)) return
 
-      call shr_nuopc_methods_Array_diagnose(array, string=trim(string)//"_"//trim(name), rc=rc)
+      call med_methods_Array_diagnose(array, string=trim(string)//"_"//trim(name), rc=rc)
       if (chkerr(rc,__LINE__,u_FILE_u)) return
 
       call ESMF_ArrayWrite(array, trim(string)//"_"//trim(name)//".nc", overwrite=.true., rc=rc)
@@ -2973,7 +2973,7 @@ contains
       call ESMF_ArraySet(array, name=name, rc=rc)
       if (chkerr(rc,__LINE__,u_FILE_u)) return
 
-      call shr_nuopc_methods_Array_diagnose(array, string=trim(string)//"_"//trim(name), rc=rc)
+      call med_methods_Array_diagnose(array, string=trim(string)//"_"//trim(name), rc=rc)
       if (chkerr(rc,__LINE__,u_FILE_u)) return
 
       call ESMF_ArrayWrite(array, trim(string)//"_"//trim(name)//".nc", overwrite=.true., rc=rc)
@@ -2991,7 +2991,7 @@ contains
         call ESMF_ArraySet(array, name=name, rc=rc)
         if (chkerr(rc,__LINE__,u_FILE_u)) return
 
-        call shr_nuopc_methods_Array_diagnose(array, string=trim(string)//"_"//trim(name), rc=rc)
+        call med_methods_Array_diagnose(array, string=trim(string)//"_"//trim(name), rc=rc)
         if (chkerr(rc,__LINE__,u_FILE_u)) return
 
         call ESMF_ArrayWrite(array, trim(string)//"_"//trim(name)//".nc", overwrite=.true., rc=rc)
@@ -3004,7 +3004,7 @@ contains
         call ESMF_ArraySet(array, name=name, rc=rc)
         if (chkerr(rc,__LINE__,u_FILE_u)) return
 
-        call shr_nuopc_methods_Array_diagnose(array, string=trim(string)//"_"//trim(name), rc=rc)
+        call med_methods_Array_diagnose(array, string=trim(string)//"_"//trim(name), rc=rc)
         if (chkerr(rc,__LINE__,u_FILE_u)) return
 
         call ESMF_ArrayWrite(array, trim(string)//"_"//trim(name)//".nc", overwrite=.true., rc=rc)
@@ -3024,7 +3024,7 @@ contains
       call ESMF_ArraySet(array, name=name, rc=rc)
       if (chkerr(rc,__LINE__,u_FILE_u)) return
 
-      call shr_nuopc_methods_Array_diagnose(array, string=trim(string)//"_"//trim(name), rc=rc)
+      call med_methods_Array_diagnose(array, string=trim(string)//"_"//trim(name), rc=rc)
       if (chkerr(rc,__LINE__,u_FILE_u)) return
 
       call ESMF_ArrayWrite(array, trim(string)//"_"//trim(name)//".nc", overwrite=.true., rc=rc)
@@ -3043,7 +3043,7 @@ contains
       call ESMF_ArraySet(array, name=name, rc=rc)
       if (chkerr(rc,__LINE__,u_FILE_u)) return
 
-      call shr_nuopc_methods_Array_diagnose(array, string=trim(string)//trim(name), rc=rc)
+      call med_methods_Array_diagnose(array, string=trim(string)//trim(name), rc=rc)
       if (chkerr(rc,__LINE__,u_FILE_u)) return
 
       call ESMF_ArrayWrite(array, trim(string)//"_"//trim(name)//".nc", overwrite=.true., rc=rc)
@@ -3054,11 +3054,11 @@ contains
       call ESMF_LogWrite(trim(subname)//": done", ESMF_LOGMSG_INFO)
     endif
 
-  end subroutine shr_nuopc_methods_Grid_Write
+  end subroutine med_methods_Grid_Write
 
   !-----------------------------------------------------------------------------
 
-  logical function shr_nuopc_methods_Distgrid_Match(distGrid1, distGrid2, rc)
+  logical function med_methods_Distgrid_Match(distGrid1, distGrid2, rc)
     use ESMF, only : ESMF_DistGrid, ESMF_DistGridGet
     ! Arguments
     type(ESMF_DistGrid), intent(in)     :: distGrid1
@@ -3071,7 +3071,7 @@ contains
     integer, allocatable            :: minIndexPTile1(:,:), minIndexPTile2(:,:)
     integer, allocatable            :: maxIndexPTile1(:,:), maxIndexPTile2(:,:)
     integer, allocatable            :: elementCountPTile1(:), elementCountPTile2(:)
-    character(len=*), parameter :: subname='(shr_nuopc_methods_Distgrid_Match)'
+    character(len=*), parameter :: subname='(med_methods_Distgrid_Match)'
     ! ----------------------------------------------
 
     if (dbug_flag > 10) then
@@ -3079,7 +3079,7 @@ contains
     endif
 
     if(present(rc)) rc = ESMF_SUCCESS
-    shr_nuopc_methods_Distgrid_Match = .true.
+    med_methods_Distgrid_Match = .true.
 
     call ESMF_DistGridGet(distGrid1, &
       dimCount=dimCount1, tileCount=tileCount1, rc=rc)
@@ -3090,7 +3090,7 @@ contains
     if (chkerr(rc,__LINE__,u_FILE_u)) return
 
     if ( dimCount1 /= dimCount2) then
-      shr_nuopc_methods_Distgrid_Match = .false.
+      med_methods_Distgrid_Match = .false.
       if (dbug_flag > 1) then
         call ESMF_LogWrite(trim(subname)//": Grid dimCount MISMATCH ", &
           ESMF_LOGMSG_INFO)
@@ -3098,7 +3098,7 @@ contains
     endif
 
     if ( tileCount1 /= tileCount2) then
-      shr_nuopc_methods_Distgrid_Match = .false.
+      med_methods_Distgrid_Match = .false.
       if (dbug_flag > 1) then
         call ESMF_LogWrite(trim(subname)//": Grid tileCount MISMATCH ", &
           ESMF_LOGMSG_INFO)
@@ -3125,7 +3125,7 @@ contains
     if (chkerr(rc,__LINE__,u_FILE_u)) return
 
     if ( ANY((elementCountPTile1 - elementCountPTile2) .NE. 0) ) then
-      shr_nuopc_methods_Distgrid_Match = .false.
+      med_methods_Distgrid_Match = .false.
       if (dbug_flag > 1) then
         call ESMF_LogWrite(trim(subname)//": Grid elementCountPTile MISMATCH ", &
           ESMF_LOGMSG_INFO)
@@ -3133,7 +3133,7 @@ contains
     endif
 
     if ( ANY((minIndexPTile1 - minIndexPTile2) .NE. 0) ) then
-      shr_nuopc_methods_Distgrid_Match = .false.
+      med_methods_Distgrid_Match = .false.
       if (dbug_flag > 1) then
         call ESMF_LogWrite(trim(subname)//": Grid minIndexPTile MISMATCH ", &
           ESMF_LOGMSG_INFO)
@@ -3141,7 +3141,7 @@ contains
     endif
 
     if ( ANY((maxIndexPTile1 - maxIndexPTile2) .NE. 0) ) then
-      shr_nuopc_methods_Distgrid_Match = .false.
+      med_methods_Distgrid_Match = .false.
       if (dbug_flag > 1) then
         call ESMF_LogWrite(trim(subname)//": Grid maxIndexPTile MISMATCH ", &
           ESMF_LOGMSG_INFO)
@@ -3161,11 +3161,11 @@ contains
       call ESMF_LogWrite(subname//": done", ESMF_LOGMSG_INFO)
     endif
 
-  end function shr_nuopc_methods_Distgrid_Match
+  end function med_methods_Distgrid_Match
 
 !================================================================================
 
-  subroutine shr_nuopc_methods_State_GetScalar(state, scalar_id, scalar_value, flds_scalar_name, flds_scalar_num, rc)
+  subroutine med_methods_State_GetScalar(state, scalar_id, scalar_value, flds_scalar_name, flds_scalar_num, rc)
 
     ! ----------------------------------------------
     ! Get scalar data from State for a particular name and broadcast it to all other pets
@@ -3190,7 +3190,7 @@ contains
     type(ESMF_Field)  :: field
     real(R8), pointer :: farrayptr(:,:)
     real(r8)          :: tmp(1)
-    character(len=*), parameter :: subname='(shr_nuopc_methods_State_GetScalar)'
+    character(len=*), parameter :: subname='(med_methods_State_GetScalar)'
     ! ----------------------------------------------
 
     rc = ESMF_SUCCESS
@@ -3226,11 +3226,11 @@ contains
       call ESMF_LogWrite(trim(subname)//": no ESMF_Field found named: "//trim(flds_scalar_name), ESMF_LOGMSG_INFO)
     end if 
 
-  end subroutine shr_nuopc_methods_State_GetScalar
+  end subroutine med_methods_State_GetScalar
 
 !================================================================================
 
-  subroutine shr_nuopc_methods_State_SetScalar(scalar_value, scalar_id, State, flds_scalar_name, flds_scalar_num,  rc)
+  subroutine med_methods_State_SetScalar(scalar_value, scalar_id, State, flds_scalar_name, flds_scalar_num,  rc)
 
     ! ----------------------------------------------
     ! Set scalar data from State for a particular name
@@ -3252,7 +3252,7 @@ contains
     type(ESMF_Field)  :: field
     type(ESMF_VM)     :: vm
     real(R8), pointer :: farrayptr(:,:)
-    character(len=*), parameter :: subname='(shr_nuopc_methods_State_SetScalar)'
+    character(len=*), parameter :: subname='(med_methods_State_SetScalar)'
     ! ----------------------------------------------
 
     rc = ESMF_SUCCESS
@@ -3277,11 +3277,11 @@ contains
       farrayptr(scalar_id,1) = scalar_value
     endif
 
-  end subroutine shr_nuopc_methods_State_SetScalar
+  end subroutine med_methods_State_SetScalar
 
   !-----------------------------------------------------------------------------
 
-  subroutine shr_nuopc_methods_State_UpdateTimestamp(state, time, rc)
+  subroutine med_methods_State_UpdateTimestamp(state, time, rc)
 
     use NUOPC , only : NUOPC_GetStateMemberLists
     use ESMF  , only : ESMF_State, ESMF_Time, ESMF_Field, ESMF_SUCCESS
@@ -3294,7 +3294,7 @@ contains
     ! local variables
     integer                  :: i
     type(ESMF_Field),pointer :: fieldList(:)
-    character(len=*), parameter :: subname='(shr_nuopc_methods_State_UpdateTimestamp)'
+    character(len=*), parameter :: subname='(med_methods_State_UpdateTimestamp)'
     ! ----------------------------------------------
 
     rc = ESMF_SUCCESS
@@ -3303,15 +3303,15 @@ contains
     if (chkerr(rc,__LINE__,u_FILE_u)) return
 
     do i=1, size(fieldList)
-      call shr_nuopc_methods_Field_UpdateTimestamp(fieldList(i), time, rc=rc)
+      call med_methods_Field_UpdateTimestamp(fieldList(i), time, rc=rc)
       if (chkerr(rc,__LINE__,u_FILE_u)) return
     enddo
 
-  end subroutine shr_nuopc_methods_State_UpdateTimestamp
+  end subroutine med_methods_State_UpdateTimestamp
 
   !-----------------------------------------------------------------------------
 
-  subroutine shr_nuopc_methods_Field_UpdateTimestamp(field, time, rc)
+  subroutine med_methods_Field_UpdateTimestamp(field, time, rc)
 
     use ESMF, only : ESMF_Field, ESMF_Time, ESMF_TimeGet, ESMF_AttributeSet, ESMF_ATTNEST_ON, ESMF_SUCCESS
 
@@ -3322,7 +3322,7 @@ contains
 
     ! local variables
     integer :: yy, mm, dd, h, m, s, ms, us, ns
-    character(len=*), parameter :: subname='(shr_nuopc_methods_Field_UpdateTimestamp)'
+    character(len=*), parameter :: subname='(med_methods_Field_UpdateTimestamp)'
     ! ----------------------------------------------
 
     rc = ESMF_SUCCESS
@@ -3336,11 +3336,11 @@ contains
       attnestflag=ESMF_ATTNEST_ON, rc=rc)
     if (chkerr(rc,__LINE__,u_FILE_u)) return
 
-  end subroutine shr_nuopc_methods_Field_UpdateTimestamp
+  end subroutine med_methods_Field_UpdateTimestamp
 
   !-----------------------------------------------------------------------------
 
-  subroutine shr_nuopc_methods_State_FldDebug(state, flds_scalar_name, prefix, ymd, tod, logunit, rc)
+  subroutine med_methods_State_FldDebug(state, flds_scalar_name, prefix, ymd, tod, logunit, rc)
 
     use ESMF, only : ESMF_State, ESMF_StateGet, ESMF_Field, ESMF_FieldGet
 
@@ -3434,11 +3434,11 @@ contains
     deallocate(lfields)
     deallocate(dimCounts)
 
-  end subroutine shr_nuopc_methods_State_FldDebug
+  end subroutine med_methods_State_FldDebug
 
   !-----------------------------------------------------------------------------
 
-  subroutine shr_nuopc_methods_FB_getNumFlds(FB, string, nflds, rc)
+  subroutine med_methods_FB_getNumFlds(FB, string, nflds, rc)
 
     ! ---------------------------------------------- 
     ! Determine if fieldbundle is created and if so, the number of non-scalar
@@ -3470,11 +3470,11 @@ contains
        end if
     end if
 
-  end subroutine shr_nuopc_methods_FB_getNumFlds
+  end subroutine med_methods_FB_getNumFlds
 
   !-----------------------------------------------------------------------------
 
-  subroutine shr_nuopc_methods_States_GetSharedFlds(State1, State2, flds_scalar_name, fldnames_shared, rc)
+  subroutine med_methods_States_GetSharedFlds(State1, State2, flds_scalar_name, fldnames_shared, rc)
 
     ! ---------------------------------------------- 
     ! Get shared Fld names between State1 and State2 and
@@ -3495,7 +3495,7 @@ contains
     integer                                 :: n1, n2, nshr
     character(len=ESMF_MAXSTR), allocatable :: fldnames1(:)
     character(len=ESMF_MAXSTR), allocatable :: fldnames2(:)
-    character(len=*), parameter :: subname='(shr_nuopc_methods_States_GetSharedFlds)'
+    character(len=*), parameter :: subname='(med_methods_States_GetSharedFlds)'
     ! ----------------------------------------------
 
     rc = ESMF_SUCCESS
@@ -3539,7 +3539,7 @@ contains
        end do
     end do
 
-  end subroutine shr_nuopc_methods_States_GetSharedFlds
+  end subroutine med_methods_States_GetSharedFlds
 
-end module shr_nuopc_methods_mod
+end module med_methods_mod
 

--- a/mediator/med_phases_aofluxes_mod.F90
+++ b/mediator/med_phases_aofluxes_mod.F90
@@ -1,14 +1,17 @@
 module med_phases_aofluxes_mod
 
   use med_constants_mod     , only : R8, CL, CX
+  use med_internalstate_mod , only : InternalState
   use med_internalstate_mod , only : mastertask, logunit
   use med_constants_mod     , only : dbug_flag    => med_constants_dbug_flag
-  use shr_nuopc_utils_mod   , only : memcheck     => shr_nuopc_memcheck
-  use shr_nuopc_utils_mod   , only : chkerr       => shr_nuopc_utils_chkerr
-  use shr_nuopc_methods_mod , only : FB_fldchk    => shr_nuopc_methods_FB_FldChk
-  use shr_nuopc_methods_mod , only : FB_GetFldPtr => shr_nuopc_methods_FB_GetFldPtr
-  use shr_nuopc_methods_mod , only : FB_diagnose  => shr_nuopc_methods_FB_diagnose
-  use shr_nuopc_methods_mod , only : FB_init      => shr_nuopc_methods_FB_init
+  use med_utils_mod         , only : memcheck     => med_memcheck
+  use med_utils_mod         , only : chkerr       => med_utils_chkerr
+  use med_methods_mod       , only : FB_fldchk    => med_methods_FB_FldChk
+  use med_methods_mod       , only : FB_GetFldPtr => med_methods_FB_GetFldPtr
+  use med_methods_mod       , only : FB_diagnose  => med_methods_FB_diagnose
+  use med_methods_mod       , only : FB_init      => med_methods_FB_init
+  use med_map_mod           , only : med_map_FB_Regrid_Norm
+  use perf_mod              , only : t_startf, t_stopf
 
   implicit none
   private
@@ -85,15 +88,12 @@ contains
 
   subroutine med_phases_aofluxes_run(gcomp, rc)
 
-    use ESMF                  , only : ESMF_GridComp, ESMF_Clock, ESMF_GridCompGet
-    use ESMF                  , only : ESMF_LogWrite, ESMF_LOGMSG_INFO, ESMF_SUCCESS
-    use ESMF                  , only : ESMF_FieldBundleIsCreated
-    use NUOPC                 , only : NUOPC_IsConnected, NUOPC_CompAttributeGet
-    use med_internalstate_mod , only : InternalState
-    use med_map_mod           , only : med_map_FB_Regrid_Norm
-    use esmFlds               , only : shr_nuopc_fldList_GetNumFlds, shr_nuopc_fldList_GetFldNames
-    use esmFlds               , only : fldListFr, fldListMed_aoflux, compatm, compocn, compname
-    use perf_mod              , only : t_startf, t_stopf
+    use ESMF     , only : ESMF_GridComp, ESMF_Clock, ESMF_GridCompGet
+    use ESMF     , only : ESMF_LogWrite, ESMF_LOGMSG_INFO, ESMF_SUCCESS
+    use ESMF     , only : ESMF_FieldBundleIsCreated
+    use NUOPC    , only : NUOPC_IsConnected, NUOPC_CompAttributeGet
+    use esmFlds  , only : med_fldList_GetNumFlds, med_fldList_GetFldNames
+    use esmFlds  , only : fldListFr, fldListMed_aoflux, compatm, compocn, compname
 
     !-----------------------------------------------------------------------
     ! Compute atm/ocn fluxes
@@ -189,7 +189,6 @@ contains
     use ESMF     , only : ESMF_GridComp, ESMF_GridCompGet, ESMF_VM
     use ESMF     , only : ESMF_Field, ESMF_FieldGet, ESMF_FieldBundle, ESMF_VMGet
     use NUOPC    , only : NUOPC_CompAttributeGet
-    use perf_mod , only : t_startf, t_stopf
 
     !-----------------------------------------------------------------------
     ! Initialize pointers to the module variables
@@ -397,7 +396,6 @@ contains
     use ESMF          , only : ESMF_LogWrite, ESMF_LogMsg_Info
     use NUOPC         , only : NUOPC_CompAttributeGet
     use shr_flux_mod  , only : shr_flux_atmocn, shr_flux_adjust_constants
-    use perf_mod      , only : t_startf, t_stopf
 
     !-----------------------------------------------------------------------
     ! Determine atm/ocn fluxes eother on atm or on ocean grid

--- a/mediator/med_phases_history_mod.F90
+++ b/mediator/med_phases_history_mod.F90
@@ -4,8 +4,23 @@ module med_phases_history_mod
   ! Mediator Phases
   !-----------------------------------------------------------------------------
 
-  use ESMF              , only : ESMF_Alarm
-  use med_constants_mod , only : R8, CL, CS, I8
+  use ESMF                  , only : ESMF_Alarm
+  use med_constants_mod     , only : R8, CL, CS, I8
+  use med_constants_mod     , only : dbug_flag       => med_constants_dbug_flag
+  use med_constants_mod     , only : SecPerDay       => med_constants_SecPerDay
+  use med_utils_mod         , only : chkerr          => med_utils_ChkErr
+  use med_time_mod          , only : alarmInit       => med_time_alarmInit
+  use med_methods_mod       , only : FB_reset        => med_methods_FB_reset
+  use med_methods_mod       , only : FB_diagnose     => med_methods_FB_diagnose
+  use med_methods_mod       , only : FB_GetFldPtr    => med_methods_FB_GetFldPtr
+  use med_methods_mod       , only : FB_accum        => med_methods_FB_accum
+  use med_methods_mod       , only : State_GetScalar => med_methods_State_GetScalar
+  use med_map_mod           , only : med_map_FB_Regrid_Norm
+  use med_internalstate_mod , only : InternalState, mastertask
+  use med_io_mod            , only : med_io_write, med_io_wopen, med_io_enddef
+  use med_io_mod            , only : med_io_close, med_io_date2yyyymmdd, med_io_sec2hms
+  use med_io_mod            , only : med_io_ymd2date
+  use perf_mod              , only : t_startf, t_stopf
 
   implicit none
   private
@@ -26,19 +41,16 @@ contains
 
     ! Initialize mediator history file alarm
 
-    use ESMF                  , only : ESMF_GridComp, ESMF_GridCompGet
-    use ESMF                  , only : ESMF_Clock, ESMF_ClockGet
-    use ESMF                  , only : ESMF_Calendar
-    use ESMF                  , only : ESMF_Time, ESMF_TimeGet
-    use ESMF                  , only : ESMF_TimeInterval, ESMF_TimeIntervalGet
-    use ESMF                  , only : ESMF_LogWrite, ESMF_LOGMSG_INFO, ESMF_LOGMSG_ERROR
-    use ESMF                  , only : ESMF_SUCCESS, ESMF_FAILURE
-    use ESMF                  , only : operator(==), operator(-)
-    use ESMF                  , only : ESMF_AlarmIsCreated
-    use NUOPC                 , only : NUOPC_CompAttributeGet
-    use shr_nuopc_utils_mod   , only : chkerr          => shr_nuopc_utils_ChkErr
-    use shr_nuopc_time_mod    , only : alarmInit       => shr_nuopc_time_alarmInit
-    use med_constants_mod     , only : dbug_flag       => med_constants_dbug_flag
+    use ESMF  , only : ESMF_GridComp, ESMF_GridCompGet
+    use ESMF  , only : ESMF_Clock, ESMF_ClockGet
+    use ESMF  , only : ESMF_Calendar
+    use ESMF  , only : ESMF_Time, ESMF_TimeGet
+    use ESMF  , only : ESMF_TimeInterval, ESMF_TimeIntervalGet
+    use ESMF  , only : ESMF_LogWrite, ESMF_LOGMSG_INFO, ESMF_LOGMSG_ERROR
+    use ESMF  , only : ESMF_SUCCESS, ESMF_FAILURE
+    use ESMF  , only : operator(==), operator(-)
+    use ESMF  , only : ESMF_AlarmIsCreated
+    use NUOPC , only : NUOPC_CompAttributeGet
 
     ! input/output variables
     type(ESMF_GridComp)  :: gcomp
@@ -134,21 +146,6 @@ contains
     use NUOPC                 , only : NUOPC_CompAttributeGet
     use esmFlds               , only : compatm, complnd, compocn, compice, comprof, compglc, ncomps, compname
     use esmFlds               , only : fldListFr, fldListTo
-    use shr_nuopc_utils_mod   , only : chkerr          => shr_nuopc_utils_ChkErr
-    use shr_nuopc_methods_mod , only : FB_reset        => shr_nuopc_methods_FB_reset
-    use shr_nuopc_methods_mod , only : FB_diagnose     => shr_nuopc_methods_FB_diagnose
-    use shr_nuopc_methods_mod , only : FB_GetFldPtr    => shr_nuopc_methods_FB_GetFldPtr
-    use shr_nuopc_methods_mod , only : FB_accum        => shr_nuopc_methods_FB_accum
-    use shr_nuopc_methods_mod , only : State_GetScalar => shr_nuopc_methods_State_GetScalar
-    use shr_nuopc_time_mod    , only : alarmInit       => shr_nuopc_time_alarmInit
-    use med_constants_mod     , only : dbug_flag       => med_constants_dbug_flag
-    use med_constants_mod     , only : SecPerDay       => med_constants_SecPerDay
-    use med_map_mod           , only : med_map_FB_Regrid_Norm
-    use med_internalstate_mod , only : InternalState, mastertask
-    use med_io_mod            , only : med_io_write, med_io_wopen, med_io_enddef
-    use med_io_mod            , only : med_io_close, med_io_date2yyyymmdd, med_io_sec2hms
-    use med_io_mod            , only : med_io_ymd2date
-    use perf_mod              , only : t_startf, t_stopf
 
     ! input/output variables
     type(ESMF_GridComp)  :: gcomp

--- a/mediator/med_phases_ocnalb_mod.F90
+++ b/mediator/med_phases_ocnalb_mod.F90
@@ -1,7 +1,7 @@
 module med_phases_ocnalb_mod
 
   use med_constants_mod  , only : R8
-  use shr_nuopc_utils_mod, only : chkerr => shr_nuopc_utils_chkerr
+  use med_utils_mod, only : chkerr => med_utils_chkerr
 
   implicit none
   private
@@ -55,13 +55,14 @@ contains
     use ESMF                  , only : ESMF_GridCompGet, ESMF_VMGet, ESMF_FieldGet, ESMF_GEOMTYPE_MESH
     use ESMF                  , only : ESMF_MeshGet
     use ESMF                  , only : operator(==)
-    use shr_nuopc_methods_mod , only : shr_nuopc_methods_FB_GetFldPtr
-    use shr_nuopc_methods_mod , only : shr_nuopc_methods_FB_getFieldN
+    use med_methods_mod       , only : med_methods_FB_GetFldPtr
+    use med_methods_mod       , only : med_methods_FB_getFieldN
     use med_internalstate_mod , only : InternalState
     use med_constants_mod     , only : CL, R8
     use med_constants_mod     , only : dbug_flag =>med_constants_dbug_flag
     use esmFlds               , only : compatm, compocn
     use perf_mod              , only : t_startf, t_stopf
+
     ! Arguments
     type(ESMF_GridComp)               :: gcomp
     type(ocnalb_type) , intent(inout) :: ocnalb
@@ -84,6 +85,7 @@ contains
     integer                  :: dbrc
     character(*), parameter  :: subname = '(med_phases_ocnalb_init) '
     !-----------------------------------------------------------------------
+
     call t_startf('MED:'//subname)
     if (dbug_flag > 5) then
       call ESMF_LogWrite(trim(subname)//": called", ESMF_LOGMSG_INFO, rc=dbrc)
@@ -109,13 +111,13 @@ contains
     ! These must must be on the ocean grid since the ocean albedo computation is on the ocean grid
     ! The following sets pointers to the module arrays
 
-    call shr_nuopc_methods_FB_GetFldPtr(is_local%wrap%FBMed_ocnalb_o, fldname='So_avsdr', fldptr1=ocnalb%avsdr, rc=rc)
+    call med_methods_FB_GetFldPtr(is_local%wrap%FBMed_ocnalb_o, fldname='So_avsdr', fldptr1=ocnalb%avsdr, rc=rc)
     if (chkerr(rc,__LINE__,u_FILE_u)) return
-    call shr_nuopc_methods_FB_GetFldPtr(is_local%wrap%FBMed_ocnalb_o, fldname='So_avsdf', fldptr1=ocnalb%avsdf, rc=rc)
+    call med_methods_FB_GetFldPtr(is_local%wrap%FBMed_ocnalb_o, fldname='So_avsdf', fldptr1=ocnalb%avsdf, rc=rc)
     if (chkerr(rc,__LINE__,u_FILE_u)) return
-    call shr_nuopc_methods_FB_GetFldPtr(is_local%wrap%FBMed_ocnalb_o, fldname='So_anidr', fldptr1=ocnalb%anidr, rc=rc)
+    call med_methods_FB_GetFldPtr(is_local%wrap%FBMed_ocnalb_o, fldname='So_anidr', fldptr1=ocnalb%anidr, rc=rc)
     if (chkerr(rc,__LINE__,u_FILE_u)) return
-    call shr_nuopc_methods_FB_GetFldPtr(is_local%wrap%FBMed_ocnalb_o, fldname='So_anidf', fldptr1=ocnalb%anidf, rc=rc)
+    call med_methods_FB_GetFldPtr(is_local%wrap%FBMed_ocnalb_o, fldname='So_anidf', fldptr1=ocnalb%anidf, rc=rc)
     if (chkerr(rc,__LINE__,u_FILE_u)) return
 
     !----------------------------------
@@ -124,7 +126,7 @@ contains
 
     ! The following assumes that all fields in FBMed_ocnalb_o have the same grid - so
     ! only need to query field 1
-    call shr_nuopc_methods_FB_getFieldN(is_local%wrap%FBMed_ocnalb_o, fieldnum=1, field=lfield, rc=rc)
+    call med_methods_FB_getFieldN(is_local%wrap%FBMed_ocnalb_o, fieldnum=1, field=lfield, rc=rc)
     if (chkerr(rc,__LINE__,u_FILE_u)) return
 
     ! Determine if first field is on a grid or a mesh - default will be mesh
@@ -185,10 +187,10 @@ contains
     use NUOPC                 , only : NUOPC_CompAttributeGet
     use shr_orb_mod           , only : shr_orb_cosz, shr_orb_decl
     use esmFlds               , only : mapconsf, mapnames
-    use shr_nuopc_methods_mod , only : shr_nuopc_methods_FB_GetFldPtr
-    use shr_nuopc_methods_mod , only : shr_nuopc_methods_FB_diagnose
-    use shr_nuopc_methods_mod , only : shr_nuopc_methods_State_GetScalar
-    use shr_nuopc_methods_mod , only : shr_nuopc_methods_FB_FieldRegrid
+    use med_methods_mod       , only : med_methods_FB_GetFldPtr
+    use med_methods_mod       , only : med_methods_FB_diagnose
+    use med_methods_mod       , only : med_methods_State_GetScalar
+    use med_methods_mod       , only : med_methods_FB_FieldRegrid
     use med_constants_mod     , only : CS, CL, R8
     use med_constants_mod     , only : dbug_flag =>med_constants_dbug_flag
     use med_constants_mod     , only : shr_const_pi
@@ -299,7 +301,7 @@ contains
           call ESMF_TimeGet( currTime, dayOfYear_r8=nextsw_cday, rc=rc )
           if (chkerr(rc,__LINE__,u_FILE_u)) return
        else
-          call shr_nuopc_methods_State_GetScalar(&
+          call med_methods_State_GetScalar(&
                state=is_local%wrap%NstateImp(compatm), &
                flds_scalar_name=is_local%wrap%flds_scalar_name, &
                flds_scalar_num=is_local%wrap%flds_scalar_num, &
@@ -312,8 +314,8 @@ contains
 
     else
 
-       ! Note that shr_nuopc_methods_State_GetScalar includes a broadcast to all other pets
-       call shr_nuopc_methods_State_GetScalar(&
+       ! Note that med_methods_State_GetScalar includes a broadcast to all other pets
+       call med_methods_State_GetScalar(&
             state=is_local%wrap%NstateImp(compatm), &
             flds_scalar_name=is_local%wrap%flds_scalar_name, &
             flds_scalar_num=is_local%wrap%flds_scalar_num, &
@@ -386,20 +388,20 @@ contains
 
     ! Update current ifrad/ofrad values if albedo was updated in field bundle
     if (update_alb) then
-       call shr_nuopc_methods_FB_getFldPtr(is_local%wrap%FBfrac(compocn), fldname='ifrac', fldptr1=ifrac, rc=rc)
+       call med_methods_FB_getFldPtr(is_local%wrap%FBfrac(compocn), fldname='ifrac', fldptr1=ifrac, rc=rc)
        if (chkerr(rc,__LINE__,u_FILE_u)) return
-       call shr_nuopc_methods_FB_getFldPtr(is_local%wrap%FBfrac(compocn), fldname='ifrad', fldptr1=ifrad, rc=rc)
+       call med_methods_FB_getFldPtr(is_local%wrap%FBfrac(compocn), fldname='ifrad', fldptr1=ifrad, rc=rc)
        if (chkerr(rc,__LINE__,u_FILE_u)) return
-       call shr_nuopc_methods_FB_getFldPtr(is_local%wrap%FBfrac(compocn), fldname='ofrac', fldptr1=ofrac, rc=rc)
+       call med_methods_FB_getFldPtr(is_local%wrap%FBfrac(compocn), fldname='ofrac', fldptr1=ofrac, rc=rc)
        if (chkerr(rc,__LINE__,u_FILE_u)) return
-       call shr_nuopc_methods_FB_getFldPtr(is_local%wrap%FBfrac(compocn), fldname='ofrad', fldptr1=ofrad, rc=rc)
+       call med_methods_FB_getFldPtr(is_local%wrap%FBfrac(compocn), fldname='ofrad', fldptr1=ofrad, rc=rc)
        if (chkerr(rc,__LINE__,u_FILE_u)) return
        ifrad(:) = ifrac(:)
        ofrad(:) = ofrac(:)
     endif
 
     if (dbug_flag > 1) then
-       call shr_nuopc_methods_FB_diagnose(is_local%wrap%FBMed_ocnalb_o, &
+       call med_methods_FB_diagnose(is_local%wrap%FBMed_ocnalb_o, &
             string=trim(subname)//' FBMed_ocnalb_o', rc=rc)
        if (chkerr(rc,__LINE__,u_FILE_u)) return
     end if

--- a/mediator/med_phases_prep_atm_mod.F90
+++ b/mediator/med_phases_prep_atm_mod.F90
@@ -16,219 +16,219 @@ module med_phases_prep_atm_mod
 contains
 !-----------------------------------------------------------------------------
 
-    subroutine med_phases_prep_atm(gcomp, rc)
+  subroutine med_phases_prep_atm(gcomp, rc)
 
-      use ESMF                  , only : ESMF_LogWrite, ESMF_LOGMSG_INFO, ESMF_SUCCESS
-      use ESMF                  , only : ESMF_FieldBundleGet, ESMF_GridCompGet, ESMF_ClockGet, ESMF_TimeGet
-      use ESMF                  , only : ESMF_GridComp, ESMF_Clock, ESMF_Time, ESMF_ClockPrint
-      use esmFlds               , only : compatm, compocn, compice, ncomps, compname
-      use esmFlds               , only : fldListFr, fldListTo
-      use esmFlds               , only : fldListMed_aoflux
-      use esmFlds               , only : coupling_mode
-      use med_constants_mod     , only : R8
-      use med_constants_mod     , only : dbug_flag       => med_constants_dbug_flag
-      use shr_nuopc_utils_mod   , only : memcheck        => shr_nuopc_memcheck
-      use shr_nuopc_utils_mod   , only : chkerr          => shr_nuopc_utils_ChkErr
-      use shr_nuopc_methods_mod , only : FB_fldchk       => shr_nuopc_methods_FB_FldChk
-      use shr_nuopc_methods_mod , only : FB_GetFldPtr    => shr_nuopc_methods_FB_GetFldPtr
-      use shr_nuopc_methods_mod , only : FB_diagnose     => shr_nuopc_methods_FB_diagnose
-      use shr_nuopc_methods_mod , only : FB_init         => shr_nuopc_methods_FB_init
-      use shr_nuopc_methods_mod , only : FB_rest         => shr_nuopc_methods_FB_reset
-      use shr_nuopc_methods_mod , only : FB_getNumFlds   => shr_nuopc_methods_FB_getNumFlds
-      use shr_nuopc_methods_mod , only : State_GetScalar => shr_nuopc_methods_State_GetScalar
-      use shr_nuopc_methods_mod , only : State_SetScalar => shr_nuopc_methods_State_SetScalar
-      use med_merge_mod         , only : med_merge_auto
-      use med_map_mod           , only : med_map_FB_Regrid_Norm
-      use med_internalstate_mod , only : InternalState, mastertask
-      use med_phases_ocnalb_mod , only : med_phases_ocnalb_mapo2a
-      use perf_mod              , only : t_startf, t_stopf
+    use ESMF                  , only : ESMF_LogWrite, ESMF_LOGMSG_INFO, ESMF_SUCCESS
+    use ESMF                  , only : ESMF_FieldBundleGet, ESMF_GridCompGet, ESMF_ClockGet, ESMF_TimeGet
+    use ESMF                  , only : ESMF_GridComp, ESMF_Clock, ESMF_Time, ESMF_ClockPrint
+    use esmFlds               , only : compatm, compocn, compice, ncomps, compname
+    use esmFlds               , only : fldListFr, fldListTo
+    use esmFlds               , only : fldListMed_aoflux
+    use esmFlds               , only : coupling_mode
+    use med_constants_mod     , only : R8
+    use med_constants_mod     , only : dbug_flag       => med_constants_dbug_flag
+    use med_utils_mod         , only : memcheck        => med_memcheck
+    use med_utils_mod         , only : chkerr          => med_utils_ChkErr
+    use med_methods_mod       , only : FB_fldchk       => med_methods_FB_FldChk
+    use med_methods_mod       , only : FB_GetFldPtr    => med_methods_FB_GetFldPtr
+    use med_methods_mod       , only : FB_diagnose     => med_methods_FB_diagnose
+    use med_methods_mod       , only : FB_init         => med_methods_FB_init
+    use med_methods_mod       , only : FB_rest         => med_methods_FB_reset
+    use med_methods_mod       , only : FB_getNumFlds   => med_methods_FB_getNumFlds
+    use med_methods_mod       , only : State_GetScalar => med_methods_State_GetScalar
+    use med_methods_mod       , only : State_SetScalar => med_methods_State_SetScalar
+    use med_merge_mod         , only : med_merge_auto
+    use med_map_mod           , only : med_map_FB_Regrid_Norm
+    use med_internalstate_mod , only : InternalState, mastertask
+    use med_phases_ocnalb_mod , only : med_phases_ocnalb_mapo2a
+    use perf_mod              , only : t_startf, t_stopf
 
-      ! input/output variables
-      type(ESMF_GridComp)  :: gcomp
-      integer, intent(out) :: rc
+    ! input/output variables
+    type(ESMF_GridComp)  :: gcomp
+    integer, intent(out) :: rc
 
-      ! local variables
-      type(ESMF_Clock)           :: clock
-      type(ESMF_Time)            :: time
-      character(len=64)          :: timestr
-      type(InternalState)        :: is_local
-      real(R8), pointer          :: dataPtr1(:),dataPtr2(:)
-      integer                    :: i, j, n, n1, ncnt
-      integer                    :: dbrc
-      character(len=*),parameter :: subname='(med_phases_prep_atm)'
-      !-------------------------------------------------------------------------------
+    ! local variables
+    type(ESMF_Clock)           :: clock
+    type(ESMF_Time)            :: time
+    character(len=64)          :: timestr
+    type(InternalState)        :: is_local
+    real(R8), pointer          :: dataPtr1(:),dataPtr2(:)
+    integer                    :: i, j, n, n1, ncnt
+    integer                    :: dbrc
+    character(len=*),parameter :: subname='(med_phases_prep_atm)'
+    !-------------------------------------------------------------------------------
 
-      call t_startf('MED:'//subname)
-      rc = ESMF_SUCCESS
+    call t_startf('MED:'//subname)
+    rc = ESMF_SUCCESS
 
-      if (dbug_flag > 5) then
-         call ESMF_LogWrite(subname//' called', ESMF_LOGMSG_INFO, rc=dbrc)
-      end if
-      call memcheck(subname, 3, mastertask)
+    if (dbug_flag > 5) then
+       call ESMF_LogWrite(subname//' called', ESMF_LOGMSG_INFO, rc=dbrc)
+    end if
+    call memcheck(subname, 3, mastertask)
 
-      !---------------------------------------
-      ! --- Get the internal state
-      !---------------------------------------
+    !---------------------------------------
+    ! --- Get the internal state
+    !---------------------------------------
 
-      nullify(is_local%wrap)
-      call ESMF_GridCompGetInternalState(gcomp, is_local, rc)
-      if (ChkErr(rc,__LINE__,u_FILE_u)) return
+    nullify(is_local%wrap)
+    call ESMF_GridCompGetInternalState(gcomp, is_local, rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
 
-      !---------------------------------------
-      !--- Count the number of fields outside of scalar data, if zero, then return
-      !---------------------------------------
+    !---------------------------------------
+    !--- Count the number of fields outside of scalar data, if zero, then return
+    !---------------------------------------
 
-      ! Note - the scalar field has been removed from all mediator field bundles - so this is why we check if the
-      ! fieldCount is 0 and not 1 here
+    ! Note - the scalar field has been removed from all mediator field bundles - so this is why we check if the
+    ! fieldCount is 0 and not 1 here
 
-      call ESMF_FieldBundleGet(is_local%wrap%FBExp(compatm), fieldCount=ncnt, rc=rc)
-      if (ChkErr(rc,__LINE__,u_FILE_u)) return
+    call ESMF_FieldBundleGet(is_local%wrap%FBExp(compatm), fieldCount=ncnt, rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
 
-      if (ncnt == 0) then
-         call ESMF_LogWrite(trim(subname)//": only scalar data is present in FBexp(compatm), returning", &
-              ESMF_LOGMSG_INFO, rc=dbrc)
-      else
+    if (ncnt == 0) then
+       call ESMF_LogWrite(trim(subname)//": only scalar data is present in FBexp(compatm), returning", &
+            ESMF_LOGMSG_INFO, rc=dbrc)
+    else
 
-         !---------------------------------------
-         !--- Get the current time from the clock
-         !---------------------------------------
-         call ESMF_GridCompGet(gcomp, clock=clock)
-         if (ChkErr(rc,__LINE__,u_FILE_u)) return
-         call ESMF_ClockGet(clock,currtime=time,rc=rc)
-         if (ChkErr(rc,__LINE__,u_FILE_u)) return
-         call ESMF_TimeGet(time,timestring=timestr)
-         if (ChkErr(rc,__LINE__,u_FILE_u)) return
-         call ESMF_LogWrite(trim(subname)//": time = "//trim(timestr), ESMF_LOGMSG_INFO, rc=dbrc)
-         if (dbug_flag > 1) then
-            if (mastertask) then
-               call ESMF_ClockPrint(clock, options="currTime", &
-                    preString="-------->"//trim(subname)//" mediating for: ", rc=rc)
-               if (ChkErr(rc,__LINE__,u_FILE_u)) return
-            end if
-         end if
+       !---------------------------------------
+       !--- Get the current time from the clock
+       !---------------------------------------
+       call ESMF_GridCompGet(gcomp, clock=clock)
+       if (ChkErr(rc,__LINE__,u_FILE_u)) return
+       call ESMF_ClockGet(clock,currtime=time,rc=rc)
+       if (ChkErr(rc,__LINE__,u_FILE_u)) return
+       call ESMF_TimeGet(time,timestring=timestr)
+       if (ChkErr(rc,__LINE__,u_FILE_u)) return
+       call ESMF_LogWrite(trim(subname)//": time = "//trim(timestr), ESMF_LOGMSG_INFO, rc=dbrc)
+       if (dbug_flag > 1) then
+          if (mastertask) then
+             call ESMF_ClockPrint(clock, options="currTime", &
+                  preString="-------->"//trim(subname)//" mediating for: ", rc=rc)
+             if (ChkErr(rc,__LINE__,u_FILE_u)) return
+          end if
+       end if
 
-         !---------------------------------------
-         !--- map import field bundles from n1 grid to atm grid - FBimp(:,compatm)
-         !---------------------------------------
-         do n1 = 1,ncomps
-            if (is_local%wrap%med_coupling_active(n1,compatm)) then
-               call med_map_FB_Regrid_Norm( &
-                    fldsSrc=fldListFr(n1)%flds, &
-                    srccomp=n1, destcomp=compatm, &
-                    FBSrc=is_local%wrap%FBImp(n1,n1), &
-                    FBDst=is_local%wrap%FBImp(n1,compatm), &
-                    FBFracSrc=is_local%wrap%FBFrac(n1), &
-                    FBNormOne=is_local%wrap%FBNormOne(n1,compatm,:), &
-                    RouteHandles=is_local%wrap%RH(n1,compatm,:), &
-                    string=trim(compname(n1))//'2'//trim(compname(compatm)), rc=rc)
-               if (ChkErr(rc,__LINE__,u_FILE_u)) return
-            endif
-         enddo
+       !---------------------------------------
+       !--- map import field bundles from n1 grid to atm grid - FBimp(:,compatm)
+       !---------------------------------------
+       do n1 = 1,ncomps
+          if (is_local%wrap%med_coupling_active(n1,compatm)) then
+             call med_map_FB_Regrid_Norm( &
+                  fldsSrc=fldListFr(n1)%flds, &
+                  srccomp=n1, destcomp=compatm, &
+                  FBSrc=is_local%wrap%FBImp(n1,n1), &
+                  FBDst=is_local%wrap%FBImp(n1,compatm), &
+                  FBFracSrc=is_local%wrap%FBFrac(n1), &
+                  FBNormOne=is_local%wrap%FBNormOne(n1,compatm,:), &
+                  RouteHandles=is_local%wrap%RH(n1,compatm,:), &
+                  string=trim(compname(n1))//'2'//trim(compname(compatm)), rc=rc)
+             if (ChkErr(rc,__LINE__,u_FILE_u)) return
+          endif
+       enddo
 
-         !---------------------------------------
-         !--- map ocean albedos from ocn to atm grid if appropriate
-         !---------------------------------------
-         if (trim(coupling_mode) == 'cesm') then
-            call med_phases_ocnalb_mapo2a(gcomp, rc)
-         end if
+       !---------------------------------------
+       !--- map ocean albedos from ocn to atm grid if appropriate
+       !---------------------------------------
+       if (trim(coupling_mode) == 'cesm') then
+          call med_phases_ocnalb_mapo2a(gcomp, rc)
+       end if
 
-         !---------------------------------------
-         !--- map atm/ocn fluxes from ocn to atm grid if appropriate
-         !---------------------------------------
-         ! Assumption here is that fluxes are computed on the ocean grid
+       !---------------------------------------
+       !--- map atm/ocn fluxes from ocn to atm grid if appropriate
+       !---------------------------------------
+       ! Assumption here is that fluxes are computed on the ocean grid
 
-         if (trim(coupling_mode) == 'cesm' .or. trim(coupling_mode) == 'nems_orig') then
-            call med_map_FB_Regrid_Norm(&
-                 fldsSrc=fldListMed_aoflux%flds, &
-                 srccomp=compocn, destcomp=compatm, &
-                 FBSrc=is_local%wrap%FBMed_aoflux_o, &
-                 FBDst=is_local%wrap%FBMed_aoflux_a, &
-                 FBFracSrc=is_local%wrap%FBFrac(compocn), &
-                 FBNormOne=is_local%wrap%FBNormOne(compocn,compatm,:), &
-                 RouteHandles=is_local%wrap%RH(compocn,compatm,:), &
-                 string='FBMed_aoflux_o_To_FBMEd_aoflux_a', rc=rc)
-            if (ChkErr(rc,__LINE__,u_FILE_u)) return
-         endif
+       if (trim(coupling_mode) == 'cesm' .or. trim(coupling_mode) == 'nems_orig') then
+          call med_map_FB_Regrid_Norm(&
+               fldsSrc=fldListMed_aoflux%flds, &
+               srccomp=compocn, destcomp=compatm, &
+               FBSrc=is_local%wrap%FBMed_aoflux_o, &
+               FBDst=is_local%wrap%FBMed_aoflux_a, &
+               FBFracSrc=is_local%wrap%FBFrac(compocn), &
+               FBNormOne=is_local%wrap%FBNormOne(compocn,compatm,:), &
+               RouteHandles=is_local%wrap%RH(compocn,compatm,:), &
+               string='FBMed_aoflux_o_To_FBMEd_aoflux_a', rc=rc)
+          if (ChkErr(rc,__LINE__,u_FILE_u)) return
+       endif
 
-         !---------------------------------------
-         !--- merge all fields to atm
-         !---------------------------------------
-         if (trim(coupling_mode) == 'cesm') then
-            call med_merge_auto(trim(compname(compatm)), &
-                 is_local%wrap%FBExp(compatm), is_local%wrap%FBFrac(compatm), &
-                 is_local%wrap%FBImp(:,compatm), fldListTo(compatm), &
-                 FBMed1=is_local%wrap%FBMed_ocnalb_a, &
-                 FBMed2=is_local%wrap%FBMed_aoflux_a, rc=rc)
-            if (ChkErr(rc,__LINE__,u_FILE_u)) return
-         else if (trim(coupling_mode) == 'nems_orig') then
-            call med_merge_auto(trim(compname(compatm)), &
-                 is_local%wrap%FBExp(compatm), is_local%wrap%FBFrac(compatm), &
-                 is_local%wrap%FBImp(:,compatm), fldListTo(compatm), &
-                 FBMed1=is_local%wrap%FBMed_aoflux_a, rc=rc)
-            if (ChkErr(rc,__LINE__,u_FILE_u)) return
-         else if (trim(coupling_mode) == 'nems_frac') then
-            call med_merge_auto(trim(compname(compatm)), &
-                 is_local%wrap%FBExp(compatm), is_local%wrap%FBFrac(compatm), &
-                 is_local%wrap%FBImp(:,compatm), fldListTo(compatm), rc=rc)
-            if (ChkErr(rc,__LINE__,u_FILE_u)) return
-         end if
+       !---------------------------------------
+       !--- merge all fields to atm
+       !---------------------------------------
+       if (trim(coupling_mode) == 'cesm') then
+          call med_merge_auto(trim(compname(compatm)), &
+               is_local%wrap%FBExp(compatm), is_local%wrap%FBFrac(compatm), &
+               is_local%wrap%FBImp(:,compatm), fldListTo(compatm), &
+               FBMed1=is_local%wrap%FBMed_ocnalb_a, &
+               FBMed2=is_local%wrap%FBMed_aoflux_a, rc=rc)
+          if (ChkErr(rc,__LINE__,u_FILE_u)) return
+       else if (trim(coupling_mode) == 'nems_orig') then
+          call med_merge_auto(trim(compname(compatm)), &
+               is_local%wrap%FBExp(compatm), is_local%wrap%FBFrac(compatm), &
+               is_local%wrap%FBImp(:,compatm), fldListTo(compatm), &
+               FBMed1=is_local%wrap%FBMed_aoflux_a, rc=rc)
+          if (ChkErr(rc,__LINE__,u_FILE_u)) return
+       else if (trim(coupling_mode) == 'nems_frac') then
+          call med_merge_auto(trim(compname(compatm)), &
+               is_local%wrap%FBExp(compatm), is_local%wrap%FBFrac(compatm), &
+               is_local%wrap%FBImp(:,compatm), fldListTo(compatm), rc=rc)
+          if (ChkErr(rc,__LINE__,u_FILE_u)) return
+       end if
 
-         if (dbug_flag > 1) then
-            call FB_diagnose(is_local%wrap%FBExp(compatm), &
-                 string=trim(subname)//' FBexp(compatm) ', rc=rc)
-            if (ChkErr(rc,__LINE__,u_FILE_u)) return
-         end if
+       if (dbug_flag > 1) then
+          call FB_diagnose(is_local%wrap%FBExp(compatm), &
+               string=trim(subname)//' FBexp(compatm) ', rc=rc)
+          if (ChkErr(rc,__LINE__,u_FILE_u)) return
+       end if
 
-         !---------------------------------------
-         !--- custom calculations
-         !---------------------------------------
+       !---------------------------------------
+       !--- custom calculations
+       !---------------------------------------
 
-         ! set fractions to send back to atm
-         if (FB_FldChk(is_local%wrap%FBExp(compatm), 'So_ofrac', rc=rc)) then
-            call FB_GetFldPtr(is_local%wrap%FBExp(compatm), 'So_ofrac', dataptr1, rc=rc)
-            if (ChkErr(rc,__LINE__,u_FILE_u)) return
-            call FB_GetFldPtr(is_local%wrap%FBFrac(compatm), 'ofrac', dataptr2, rc=rc)
-            if (ChkErr(rc,__LINE__,u_FILE_u)) return
-            do n = 1,size(dataptr1)
-               dataptr1(n) = dataptr2(n)
-            end do
-         end if
-         if (FB_FldChk(is_local%wrap%FBExp(compatm), 'Si_ifrac', rc=rc)) then
-            call FB_GetFldPtr(is_local%wrap%FBExp(compatm), 'Si_ifrac', dataptr1, rc=rc)
-            if (ChkErr(rc,__LINE__,u_FILE_u)) return
-            call FB_GetFldPtr(is_local%wrap%FBFrac(compatm), 'ifrac', dataptr2, rc=rc)
-            if (ChkErr(rc,__LINE__,u_FILE_u)) return
-            do n = 1,size(dataptr1)
-               dataptr1(n) = dataptr2(n)
-            end do
-         end if
-         if (FB_FldChk(is_local%wrap%FBExp(compatm), 'Sl_lfrac', rc=rc)) then
-            call FB_GetFldPtr(is_local%wrap%FBExp(compatm), 'Sl_lfrac', dataptr1, rc=rc)
-            if (ChkErr(rc,__LINE__,u_FILE_u)) return
-            call FB_GetFldPtr(is_local%wrap%FBFrac(compatm), 'lfrac', dataptr2, rc=rc)
-            if (ChkErr(rc,__LINE__,u_FILE_u)) return
-            do n = 1,size(dataptr1)
-               dataptr1(n) = dataptr2(n)
-            end do
-         end if
+       ! set fractions to send back to atm
+       if (FB_FldChk(is_local%wrap%FBExp(compatm), 'So_ofrac', rc=rc)) then
+          call FB_GetFldPtr(is_local%wrap%FBExp(compatm), 'So_ofrac', dataptr1, rc=rc)
+          if (ChkErr(rc,__LINE__,u_FILE_u)) return
+          call FB_GetFldPtr(is_local%wrap%FBFrac(compatm), 'ofrac', dataptr2, rc=rc)
+          if (ChkErr(rc,__LINE__,u_FILE_u)) return
+          do n = 1,size(dataptr1)
+             dataptr1(n) = dataptr2(n)
+          end do
+       end if
+       if (FB_FldChk(is_local%wrap%FBExp(compatm), 'Si_ifrac', rc=rc)) then
+          call FB_GetFldPtr(is_local%wrap%FBExp(compatm), 'Si_ifrac', dataptr1, rc=rc)
+          if (ChkErr(rc,__LINE__,u_FILE_u)) return
+          call FB_GetFldPtr(is_local%wrap%FBFrac(compatm), 'ifrac', dataptr2, rc=rc)
+          if (ChkErr(rc,__LINE__,u_FILE_u)) return
+          do n = 1,size(dataptr1)
+             dataptr1(n) = dataptr2(n)
+          end do
+       end if
+       if (FB_FldChk(is_local%wrap%FBExp(compatm), 'Sl_lfrac', rc=rc)) then
+          call FB_GetFldPtr(is_local%wrap%FBExp(compatm), 'Sl_lfrac', dataptr1, rc=rc)
+          if (ChkErr(rc,__LINE__,u_FILE_u)) return
+          call FB_GetFldPtr(is_local%wrap%FBFrac(compatm), 'lfrac', dataptr2, rc=rc)
+          if (ChkErr(rc,__LINE__,u_FILE_u)) return
+          do n = 1,size(dataptr1)
+             dataptr1(n) = dataptr2(n)
+          end do
+       end if
 
-         !---------------------------------------
-         !--- update local scalar data
-         !---------------------------------------
+       !---------------------------------------
+       !--- update local scalar data
+       !---------------------------------------
 
-         !is_local%wrap%scalar_data(1) =
+       !is_local%wrap%scalar_data(1) =
 
-         !---------------------------------------
-         !--- clean up
-         !---------------------------------------
+       !---------------------------------------
+       !--- clean up
+       !---------------------------------------
 
-      endif
+    endif
 
-      if (dbug_flag > 5) then
-         call ESMF_LogWrite(trim(subname)//": done", ESMF_LOGMSG_INFO, rc=dbrc)
-      end if
-      call t_stopf('MED:'//subname)
+    if (dbug_flag > 5) then
+       call ESMF_LogWrite(trim(subname)//": done", ESMF_LOGMSG_INFO, rc=dbrc)
+    end if
+    call t_stopf('MED:'//subname)
 
-    end subroutine med_phases_prep_atm
+  end subroutine med_phases_prep_atm
 
 end module med_phases_prep_atm_mod

--- a/mediator/med_phases_prep_glc_mod.F90
+++ b/mediator/med_phases_prep_glc_mod.F90
@@ -18,7 +18,7 @@ module med_phases_prep_glc_mod
   use ESMF                  , only : ESMF_Mesh, ESMF_MeshGet, ESMF_MESHLOC_ELEMENT
   use ESMF                  , only : ESMF_TYPEKIND_R8
   use esmFlds               , only : compglc, complnd, mapbilnr, mapconsf, compname
-  use esmFlds               , only : shr_nuopc_fldlist_type
+  use esmFlds               , only : med_fldlist_type
   use shr_sys_mod           , only : shr_sys_abort
   use med_internalstate_mod , only : InternalState, mastertask, logunit
   use med_constants_mod     , only : R8, CS
@@ -26,11 +26,11 @@ module med_phases_prep_glc_mod
   use med_internalstate_mod , only : InternalState, mastertask, logunit
   use med_map_mod           , only : med_map_FB_Regrid_Norm
   use med_map_mod           , only : med_map_Fractions_Init
-  use shr_nuopc_methods_mod , only : FB_Init      => shr_nuopc_methods_FB_init
-  use shr_nuopc_methods_mod , only : FB_getFldPtr => shr_nuopc_methods_FB_getFldPtr
-  use shr_nuopc_methods_mod , only : FB_diagnose  => shr_nuopc_methods_FB_diagnose
-  use shr_nuopc_methods_mod , only : FB_reset     => shr_nuopc_methods_FB_reset
-  use shr_nuopc_utils_mod   , only : chkerr       => shr_nuopc_utils_ChkErr
+  use med_methods_mod       , only : FB_Init      => med_methods_FB_init
+  use med_methods_mod       , only : FB_getFldPtr => med_methods_FB_getFldPtr
+  use med_methods_mod       , only : FB_diagnose  => med_methods_FB_diagnose
+  use med_methods_mod       , only : FB_reset     => med_methods_FB_reset
+  use med_utils_mod         , only : chkerr       => med_utils_ChkErr
   use glc_elevclass_mod     , only : glc_get_num_elevation_classes
   use glc_elevclass_mod     , only : glc_get_elevation_classes
   use glc_elevclass_mod     , only : glc_get_fractional_icecov
@@ -52,12 +52,12 @@ module med_phases_prep_glc_mod
   ! Need to keep track of the lnd->med fields destined for glc in the FBlndAccum field bundle.
 
   ! Needed for standard lnd->glc mapping
-  type(ESMF_FieldBundle)       :: FBlndAccum_lnd
-  type(ESMF_FieldBundle)       :: FBlndAccum_glc
-  integer                      :: FBlndAccumCnt
-  type(shr_nuopc_fldlist_type) :: fldlist_lnd2glc
-  character(len=14)            :: fldnames_fr_lnd(3) = (/'Flgl_qice_elev','Sl_tsrf_elev  ','Sl_topo_elev  '/)
-  character(len=14)            :: fldnames_to_glc(2) = (/'Flgl_qice     ','Sl_tsrf       '/)
+  type(ESMF_FieldBundle) :: FBlndAccum_lnd
+  type(ESMF_FieldBundle) :: FBlndAccum_glc
+  integer                :: FBlndAccumCnt
+  type(med_fldlist_type) :: fldlist_lnd2glc
+  character(len=14)      :: fldnames_fr_lnd(3) = (/'Flgl_qice_elev','Sl_tsrf_elev  ','Sl_topo_elev  '/)
+  character(len=14)      :: fldnames_to_glc(2) = (/'Flgl_qice     ','Sl_tsrf       '/)
 
   ! Whether to renormalize the SMB for conservation.
   ! Should be set to true for 2-way coupled runs with evolving ice sheets.
@@ -65,18 +65,18 @@ module med_phases_prep_glc_mod
   logical :: smb_renormalize
 
   ! Needed if renormalize SMB
-  type(ESMF_FieldBundle)       :: FBglc_icemask
-  type(ESMF_FieldBundle)       :: FBlnd_icemask
-  type(shr_nuopc_fldlist_type) :: fldlist_glc2lnd_icemask
-  type(ESMF_FieldBundle)       :: FBglc_frac
-  type(ESMF_FieldBundle)       :: FBlnd_frac
-  type(shr_nuopc_fldlist_type) :: fldlist_glc2lnd_frac
-  real(r8) , pointer           :: aream_l(:)         ! cell areas on land grid, for mapping
-  real(r8) , pointer           :: aream_g(:)         ! cell areas on glc grid, for mapping
-  character(len=*), parameter  :: qice_fieldname   = 'Flgl_qice' ! Name of flux field giving surface mass balance
-  character(len=*), parameter  :: Sg_frac_field    = 'Sg_ice_covered'
-  character(len=*), parameter  :: Sg_topo_field    = 'Sg_topo'
-  character(len=*), parameter  :: Sg_icemask_field = 'Sg_icemask'
+  type(ESMF_FieldBundle)      :: FBglc_icemask
+  type(ESMF_FieldBundle)      :: FBlnd_icemask
+  type(med_fldlist_type)      :: fldlist_glc2lnd_icemask
+  type(ESMF_FieldBundle)      :: FBglc_frac
+  type(ESMF_FieldBundle)      :: FBlnd_frac
+  type(med_fldlist_type)      :: fldlist_glc2lnd_frac
+  real(r8) , pointer          :: aream_l(:)         ! cell areas on land grid, for mapping
+  real(r8) , pointer          :: aream_g(:)         ! cell areas on glc grid, for mapping
+  character(len=*), parameter :: qice_fieldname   = 'Flgl_qice' ! Name of flux field giving surface mass balance
+  character(len=*), parameter :: Sg_frac_field    = 'Sg_ice_covered'
+  character(len=*), parameter :: Sg_topo_field    = 'Sg_topo'
+  character(len=*), parameter :: Sg_icemask_field = 'Sg_icemask'
 
   ! Size of undistributed dimension from land
   integer :: ungriddedCount ! this equals the number of elevation classes + 1 (for bare land)

--- a/mediator/med_phases_prep_ice_mod.F90
+++ b/mediator/med_phases_prep_ice_mod.F90
@@ -27,14 +27,14 @@ contains
     use esmFlds               , only : compatm, compice, comprof, compglc, ncomps, compname
     use esmFlds               , only : fldListFr, fldListTo
     use esmFlds               , only : mapbilnr
-    use shr_nuopc_utils_mod   , only : chkerr            => shr_nuopc_utils_ChkErr
-    use shr_nuopc_methods_mod , only : fldchk            => shr_nuopc_methods_FB_FldChk
-    use shr_nuopc_methods_mod , only : FB_GetFldPtr      => shr_nuopc_methods_FB_GetFldPtr
-    use shr_nuopc_methods_mod , only : FB_diagnose       => shr_nuopc_methods_FB_diagnose
-    use shr_nuopc_methods_mod , only : FB_FieldRegrid    => shr_nuopc_methods_FB_FieldRegrid
-    use shr_nuopc_methods_mod , only : FB_getNumFlds     => shr_nuopc_methods_FB_getNumFlds
-    use shr_nuopc_methods_mod , only : State_GetScalar   => shr_nuopc_methods_State_GetScalar
-    use shr_nuopc_methods_mod , only : State_SetScalar   => shr_nuopc_methods_State_SetScalar
+    use med_utils_mod         , only : chkerr            => med_utils_ChkErr
+    use med_methods_mod       , only : fldchk            => med_methods_FB_FldChk
+    use med_methods_mod       , only : FB_GetFldPtr      => med_methods_FB_GetFldPtr
+    use med_methods_mod       , only : FB_diagnose       => med_methods_FB_diagnose
+    use med_methods_mod       , only : FB_FieldRegrid    => med_methods_FB_FieldRegrid
+    use med_methods_mod       , only : FB_getNumFlds     => med_methods_FB_getNumFlds
+    use med_methods_mod       , only : State_GetScalar   => med_methods_State_GetScalar
+    use med_methods_mod       , only : State_SetScalar   => med_methods_State_SetScalar
     use med_constants_mod     , only : CS, R8, dbug_flag => med_constants_dbug_flag
     use med_merge_mod         , only : med_merge_auto
     use med_map_mod           , only : med_map_FB_Regrid_Norm

--- a/mediator/med_phases_prep_lnd_mod.F90
+++ b/mediator/med_phases_prep_lnd_mod.F90
@@ -16,16 +16,16 @@ module med_phases_prep_lnd_mod
   use ESMF                  , only : ESMF_TYPEKIND_R8
   use esmFlds               , only : complnd, compatm, compglc, ncomps, compname, mapconsf
   use esmFlds               , only : fldListFr, fldListTo
-  use esmFlds               , only : shr_nuopc_fldlist_type
-  use shr_nuopc_methods_mod , only : FB_getFieldN    => shr_nuopc_methods_FB_getFieldN
-  use shr_nuopc_methods_mod , only : FB_getFldPtr    => shr_nuopc_methods_FB_getFldPtr
-  use shr_nuopc_methods_mod , only : FB_getNumFlds   => shr_nuopc_methods_FB_getNumFlds
-  use shr_nuopc_methods_mod , only : FB_init         => shr_nuopc_methods_FB_init
-  use shr_nuopc_methods_mod , only : FB_diagnose     => shr_nuopc_methods_FB_diagnose
-  use shr_nuopc_methods_mod , only : FB_FldChk       => shr_nuopc_methods_FB_FldChk
-  use shr_nuopc_methods_mod , only : State_GetScalar => shr_nuopc_methods_State_GetScalar
-  use shr_nuopc_methods_mod , only : State_SetScalar => shr_nuopc_methods_State_SetScalar
-  use shr_nuopc_utils_mod   , only : chkerr          => shr_nuopc_utils_ChkErr
+  use esmFlds               , only : med_fldlist_type
+  use med_methods_mod       , only : FB_getFieldN    => med_methods_FB_getFieldN
+  use med_methods_mod       , only : FB_getFldPtr    => med_methods_FB_getFldPtr
+  use med_methods_mod       , only : FB_getNumFlds   => med_methods_FB_getNumFlds
+  use med_methods_mod       , only : FB_init         => med_methods_FB_init
+  use med_methods_mod       , only : FB_diagnose     => med_methods_FB_diagnose
+  use med_methods_mod       , only : FB_FldChk       => med_methods_FB_FldChk
+  use med_methods_mod       , only : State_GetScalar => med_methods_State_GetScalar
+  use med_methods_mod       , only : State_SetScalar => med_methods_State_SetScalar
+  use med_utils_mod         , only : chkerr          => med_utils_ChkErr
   use med_constants_mod     , only : R8, CS
   use med_constants_mod     , only : dbug_flag=>med_constants_dbug_flag
   use med_internalstate_mod , only : InternalState, logunit
@@ -59,9 +59,9 @@ module med_phases_prep_lnd_mod
   type(ESMF_FieldBundle) :: FBglc_ec
   type(ESMF_FieldBundle) :: FBlnd_ec
 
-  type(shr_nuopc_fldlist_type) :: fldlist_glc2lnd_frac_x_icemask
-  type(shr_nuopc_fldlist_type) :: fldlist_glc2lnd_norm_icemask
-  type(shr_nuopc_fldlist_type) :: fldlist_glc2lnd_norm_none
+  type(med_fldlist_type) :: fldlist_glc2lnd_frac_x_icemask
+  type(med_fldlist_type) :: fldlist_glc2lnd_norm_icemask
+  type(med_fldlist_type) :: fldlist_glc2lnd_norm_none
 
   ! the number of elevation classes (excluding bare land) = ungriddedCount - 1
   integer :: ungriddedCount ! this equals the number of elevation classes + 1 (for bare land)

--- a/mediator/med_phases_prep_ocn_mod.F90
+++ b/mediator/med_phases_prep_ocn_mod.F90
@@ -4,18 +4,22 @@ module med_phases_prep_ocn_mod
   ! Mediator phases for preparing ocn export from mediator
   !-----------------------------------------------------------------------------
 
-  use med_internalstate_mod , only : mastertask
+  use med_constants_mod     , only : czero=>med_constants_czero
   use med_constants_mod     , only : dbug_flag     => med_constants_dbug_flag
-  use shr_nuopc_utils_mod   , only : memcheck      => shr_nuopc_memcheck
-  use shr_nuopc_utils_mod   , only : chkerr        => shr_nuopc_utils_ChkErr
-  use shr_nuopc_methods_mod , only : FB_diagnose   => shr_nuopc_methods_FB_diagnose
-  use shr_nuopc_methods_mod , only : FB_getNumFlds => shr_nuopc_methods_FB_getNumFlds
-  use shr_nuopc_methods_mod , only : FB_fldchk     => shr_nuopc_methods_FB_FldChk
-  use shr_nuopc_methods_mod , only : FB_GetFldPtr  => shr_nuopc_methods_FB_GetFldPtr
-  use shr_nuopc_methods_mod , only : FB_accum      => shr_nuopc_methods_FB_accum
-  use shr_nuopc_methods_mod , only : FB_average    => shr_nuopc_methods_FB_average
-  use shr_nuopc_methods_mod , only : FB_copy       => shr_nuopc_methods_FB_copy
-  use shr_nuopc_methods_mod , only : FB_reset      => shr_nuopc_methods_FB_reset
+  use med_constants_mod     , only : R8, CS
+  use med_internalstate_mod , only : InternalState, mastertask, logunit
+  use med_merge_mod         , only : med_merge_auto, med_merge_field
+  use med_map_mod           , only : med_map_FB_Regrid_Norm
+  use med_utils_mod         , only : memcheck      => med_memcheck
+  use med_utils_mod         , only : chkerr        => med_utils_ChkErr
+  use med_methods_mod       , only : FB_diagnose   => med_methods_FB_diagnose
+  use med_methods_mod       , only : FB_getNumFlds => med_methods_FB_getNumFlds
+  use med_methods_mod       , only : FB_fldchk     => med_methods_FB_FldChk
+  use med_methods_mod       , only : FB_GetFldPtr  => med_methods_FB_GetFldPtr
+  use med_methods_mod       , only : FB_accum      => med_methods_FB_accum
+  use med_methods_mod       , only : FB_average    => med_methods_FB_average
+  use med_methods_mod       , only : FB_copy       => med_methods_FB_copy
+  use med_methods_mod       , only : FB_reset      => med_methods_FB_reset
 
   implicit none
   private
@@ -42,8 +46,6 @@ contains
     use ESMF                  , only : ESMF_LogWrite, ESMF_LOGMSG_INFO,ESMF_SUCCESS
     use ESMF                  , only : ESMF_GridCompGet, ESMF_ClockGet, ESMF_TimeGet, ESMF_ClockPrint
     use ESMF                  , only : ESMF_FieldBundleGet
-    use med_internalstate_mod , only : InternalState
-    use med_map_mod           , only : med_map_FB_Regrid_Norm
     use esmFlds               , only : fldListFr
     use esmFlds               , only : compocn, ncomps, compname
     use perf_mod              , only : t_startf, t_stopf
@@ -116,9 +118,6 @@ contains
     use ESMF                  , only : ESMF_GridComp, ESMF_FieldBundleGet
     use ESMF                  , only : ESMF_LogWrite, ESMF_LOGMSG_INFO, ESMF_SUCCESS
     use ESMF                  , only : ESMF_FAILURE,  ESMF_LOGMSG_ERROR
-    use med_constants_mod     , only : R8, CS
-    use med_internalstate_mod , only : InternalState, mastertask, logunit
-    use med_merge_mod         , only : med_merge_auto, med_merge_field
     use esmFlds               , only : fldListTo
     use esmFlds               , only : compocn, compname, compatm, compice
     use esmFlds               , only : coupling_mode
@@ -594,7 +593,6 @@ contains
     use ESMF                  , only : ESMF_LogWrite, ESMF_LOGMSG_INFO, ESMF_SUCCESS
     use ESMF                  , only : ESMF_GridCompGet, ESMF_ClockGet, ESMF_TimeGet, ESMF_ClockPrint
     use ESMF                  , only : ESMF_FieldBundleGet
-    use med_internalstate_mod , only : InternalState, mastertask
     use esmFlds               , only : compocn
     use perf_mod              , only : t_startf, t_stopf
 
@@ -670,8 +668,6 @@ contains
     use ESMF                  , only : ESMF_GridComp, ESMF_Clock, ESMF_Time
     use ESMF                  , only : ESMF_LogWrite, ESMF_LOGMSG_INFO, ESMF_SUCCESS
     use ESMF                  , only : ESMF_FieldBundleGet
-    use med_constants_mod     , only : czero=>med_constants_czero
-    use med_internalstate_mod , only : InternalState
     use esmFlds               , only : compocn
     use perf_mod              , only : t_startf, t_stopf
 

--- a/mediator/med_phases_prep_rof_mod.F90
+++ b/mediator/med_phases_prep_rof_mod.F90
@@ -10,24 +10,24 @@ module med_phases_prep_rof_mod
   !   this will be done in med_phases_prep_rof_avg
   !-----------------------------------------------------------------------------
 
-  use ESMF                  , only : ESMF_FieldBundle
-  use esmFlds               , only : ncomps, complnd, comprof, compname, mapconsf
-  use esmFlds               , only : shr_nuopc_fldlist_type
-  use med_constants_mod     , only : R8, CS
-  use med_constants_mod     , only : dbug_flag       => med_constants_dbug_flag
-  use shr_nuopc_utils_mod   , only : chkerr          => shr_nuopc_utils_ChkErr
-  use shr_nuopc_methods_mod , only : FB_init         => shr_nuopc_methods_FB_init
-  use shr_nuopc_methods_mod , only : FB_diagnose     => shr_nuopc_methods_FB_diagnose
-  use shr_nuopc_methods_mod , only : FB_getNumFlds   => shr_nuopc_methods_FB_getNumFlds
-  use shr_nuopc_methods_mod , only : FB_accum        => shr_nuopc_methods_FB_accum
-  use shr_nuopc_methods_mod , only : FB_getFldPtr    => shr_nuopc_methods_FB_getFldPtr
-  use shr_nuopc_methods_mod , only : FB_average      => shr_nuopc_methods_FB_average
-  use shr_nuopc_methods_mod , only : FB_reset        => shr_nuopc_methods_FB_reset
-  use shr_nuopc_methods_mod , only : FB_clean        => shr_nuopc_methods_FB_clean
-  use shr_nuopc_methods_mod , only : FB_FieldRegrid  => shr_nuopc_methods_FB_FieldRegrid
-  use shr_nuopc_methods_mod , only : State_GetScalar => shr_nuopc_methods_State_GetScalar
-  use shr_nuopc_methods_mod , only : State_SetScalar => shr_nuopc_methods_State_SetScalar
-  use perf_mod              , only : t_startf, t_stopf
+  use ESMF              , only : ESMF_FieldBundle
+  use esmFlds           , only : ncomps, complnd, comprof, compname, mapconsf
+  use esmFlds           , only : med_fldlist_type
+  use med_constants_mod , only : R8, CS
+  use med_constants_mod , only : dbug_flag       => med_constants_dbug_flag
+  use med_utils_mod     , only : chkerr          => med_utils_ChkErr
+  use med_methods_mod   , only : FB_init         => med_methods_FB_init
+  use med_methods_mod   , only : FB_diagnose     => med_methods_FB_diagnose
+  use med_methods_mod   , only : FB_getNumFlds   => med_methods_FB_getNumFlds
+  use med_methods_mod   , only : FB_accum        => med_methods_FB_accum
+  use med_methods_mod   , only : FB_getFldPtr    => med_methods_FB_getFldPtr
+  use med_methods_mod   , only : FB_average      => med_methods_FB_average
+  use med_methods_mod   , only : FB_reset        => med_methods_FB_reset
+  use med_methods_mod   , only : FB_clean        => med_methods_FB_clean
+  use med_methods_mod   , only : FB_FieldRegrid  => med_methods_FB_FieldRegrid
+  use med_methods_mod   , only : State_GetScalar => med_methods_State_GetScalar
+  use med_methods_mod   , only : State_SetScalar => med_methods_State_SetScalar
+  use perf_mod          , only : t_startf, t_stopf
 
   implicit none
   private
@@ -41,7 +41,7 @@ module med_phases_prep_rof_mod
   type(ESMF_FieldBundle)      :: FBrofVolr          ! needed for lnd2rof irrigation
   type(ESMF_FieldBundle)      :: FBlndIrrig         ! needed for lnd2rof irrigation
   type(ESMF_FieldBundle)      :: FBrofIrrig         ! needed for lnd2rof irrigation
-  type(shr_nuopc_fldlist_type):: fldlist_lnd2rof    ! needed for lnd2rof irrigation
+  type(med_fldlist_type)      :: fldlist_lnd2rof    ! needed for lnd2rof irrigation
 
   character(len=*), parameter :: volr_field             = 'Flrr_volrmch'
   character(len=*), parameter :: irrig_flux_field       = 'Flrl_irrig'

--- a/mediator/med_phases_prep_wav_mod.F90
+++ b/mediator/med_phases_prep_wav_mod.F90
@@ -26,9 +26,9 @@ contains
     use esmFlds               , only : fldListFr, fldListTo
     use med_constants_mod     , only : CS
     use med_constants_mod     , only : dbug_flag     => med_constants_dbug_flag
-    use shr_nuopc_utils_mod   , only : chkerr        => shr_nuopc_utils_ChkErr
-    use shr_nuopc_methods_mod , only : FB_diagnose   => shr_nuopc_methods_FB_diagnose
-    use shr_nuopc_methods_mod , only : FB_getNumFlds => shr_nuopc_methods_FB_getNumFlds
+    use med_utils_mod         , only : chkerr        => med_utils_ChkErr
+    use med_methods_mod       , only : FB_diagnose   => med_methods_FB_diagnose
+    use med_methods_mod       , only : FB_getNumFlds => med_methods_FB_getNumFlds
     use med_merge_mod         , only : med_merge_auto
     use med_map_mod           , only : med_map_FB_Regrid_Norm
     use med_internalstate_mod , only : InternalState, mastertask

--- a/mediator/med_phases_profile_mod.F90
+++ b/mediator/med_phases_profile_mod.F90
@@ -1,8 +1,17 @@
 module med_phases_profile_mod
+
   !-----------------------------------------------------------------------------
   ! Output med profile to log file
   !-----------------------------------------------------------------------------
-  use med_constants_mod, only : R8
+
+  use med_constants_mod     , only : R8
+  use med_constants_mod     , only : dbug_flag=>med_constants_dbug_flag, CS, CL
+  use med_utils_mod         , only : med_utils_chkerr, med_memcheck
+  use med_internalstate_mod , only : mastertask, logunit
+  use med_utils_mod         , only : med_utils_chkerr
+  use perf_mod              , only : t_startf, t_stopf
+  use shr_mem_mod           , only : shr_mem_getusage
+
   implicit none
   private
 
@@ -14,26 +23,22 @@ module med_phases_profile_mod
   real(R8) :: accumulated_time=0_R8, timestep_length
   real(r8) :: previous_time=0_R8
   integer  :: iterations=0
+
 !=================================================================================
 contains
 !=================================================================================
 
   subroutine med_phases_profile(gcomp, rc)
-    use ESMF, only : ESMF_VMGetCurrent, ESMF_CLOCK, ESMF_GridComp, ESMF_LogMsg_Info
-    use ESMF, only : ESMF_LogWrite, ESMF_GridCompGet, ESMF_SUCCESS, ESMF_VM
-    use ESMF, only : ESMF_VMGet, ESMF_ClockGetAlarm, ESMF_AlarmRingerOff
-    use ESMF, only : ESMF_Alarm, ESMF_AlarmisRinging, ESMF_VMWtime
-    use ESMF, only : ESMF_TimeSyncToRealTime, ESMF_Time, ESMF_TimeSet
-    use ESMF, only : ESMF_TimeInterval, ESMF_AlarmGet, ESMF_TimeIntervalGet
-    use ESMF, only : ESMF_ClockGetNextTime, ESMF_TimeGet, ESMF_ClockGet
-    use ESMF, only : operator(-)
-    use NUOPC, only : NUOPC_CompAttributeGet
-    use shr_nuopc_utils_mod, only : shr_nuopc_utils_chkerr, shr_nuopc_memcheck
-    use med_constants_mod, only : dbug_flag=>med_constants_dbug_flag, CS, CL
-    use med_internalstate_mod, only : mastertask, logunit
 
-    use perf_mod, only : t_startf, t_stopf
-    use shr_mem_mod, only : shr_mem_getusage
+    use ESMF                  , only : ESMF_VMGetCurrent, ESMF_CLOCK, ESMF_GridComp, ESMF_LogMsg_Info
+    use ESMF                  , only : ESMF_LogWrite, ESMF_GridCompGet, ESMF_SUCCESS, ESMF_VM
+    use ESMF                  , only : ESMF_VMGet, ESMF_ClockGetAlarm, ESMF_AlarmRingerOff
+    use ESMF                  , only : ESMF_Alarm, ESMF_AlarmisRinging, ESMF_VMWtime
+    use ESMF                  , only : ESMF_TimeSyncToRealTime, ESMF_Time, ESMF_TimeSet
+    use ESMF                  , only : ESMF_TimeInterval, ESMF_AlarmGet, ESMF_TimeIntervalGet
+    use ESMF                  , only : ESMF_ClockGetNextTime, ESMF_TimeGet, ESMF_ClockGet
+    use ESMF                  , only : operator(-)
+    use NUOPC                 , only : NUOPC_CompAttributeGet
 
     ! write profile output
 
@@ -65,17 +70,17 @@ contains
     rc = ESMF_SUCCESS
 
     call ESMF_VMGetCurrent(vm, rc=rc)
-    if (shr_nuopc_utils_chkerr(rc,__LINE__,u_FILE_u)) return
+    if (med_utils_chkerr(rc,__LINE__,u_FILE_u)) return
 
     call ESMF_VMGet(vm, localPet=iam, rc=rc)
-    if (shr_nuopc_utils_chkerr(rc,__LINE__,u_FILE_u)) return
+    if (med_utils_chkerr(rc,__LINE__,u_FILE_u)) return
 
     call NUOPC_CompAttributeGet(gcomp, name='inst_suffix', isPresent=isPresent, rc=rc)
-    if (shr_nuopc_utils_chkerr(rc,__LINE__,u_FILE_u)) return
+    if (med_utils_chkerr(rc,__LINE__,u_FILE_u)) return
 
     if(isPresent) then
        call NUOPC_CompAttributeGet(gcomp, name='inst_suffix', value=cpl_inst_tag, rc=rc)
-       if (shr_nuopc_utils_chkerr(rc,__LINE__,u_FILE_u)) return
+       if (med_utils_chkerr(rc,__LINE__,u_FILE_u)) return
     else
        cpl_inst_tag = ""
     endif
@@ -84,20 +89,20 @@ contains
     ! --- profiler Alarm
     !---------------------------------------
     call ESMF_GridCompGet(gcomp, clock=clock, rc=rc)
-    if (shr_nuopc_utils_chkerr(rc,__LINE__,u_FILE_u)) return
+    if (med_utils_chkerr(rc,__LINE__,u_FILE_u)) return
     if (iterations == 0) then
        ! intialize and return
        call ESMF_VMWtime(previous_time, rc=rc)
-       if (shr_nuopc_utils_chkerr(rc,__LINE__,u_FILE_u)) return
+       if (med_utils_chkerr(rc,__LINE__,u_FILE_u)) return
        ! Here we are just getting a single timestep interval
        call ESMF_ClockGet( clock, timestep=timestep, rc=rc)
-       if (shr_nuopc_utils_chkerr(rc,__LINE__,u_FILE_u)) return
+       if (med_utils_chkerr(rc,__LINE__,u_FILE_u)) return
 
        call ESMF_ClockGet(clock, currTime=prevtime, rc=rc)
-       if (shr_nuopc_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
+       if (med_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
 
        call ESMF_TimeIntervalGet(timestep, d_r8=timestep_length, rc=rc)
-       if (shr_nuopc_utils_chkerr(rc,__LINE__,u_FILE_u)) return
+       if (med_utils_chkerr(rc,__LINE__,u_FILE_u)) return
        iterations = 1
     else
        !---------------------------------------
@@ -105,21 +110,21 @@ contains
        !---------------------------------------
 
        call ESMF_ClockGetAlarm(clock, alarmname='med_profile_alarm', alarm=alarm, rc=rc)
-       if (shr_nuopc_utils_chkerr(rc,__LINE__,u_FILE_u)) return
+       if (med_utils_chkerr(rc,__LINE__,u_FILE_u)) return
 
        if (ESMF_AlarmIsRinging(alarm, rc=rc)) then
-          if (shr_nuopc_utils_chkerr(rc,__LINE__,u_FILE_u)) return
+          if (med_utils_chkerr(rc,__LINE__,u_FILE_u)) return
           alarmIsOn = .true.
           call ESMF_AlarmRingerOff( alarm, rc=rc )
-          if (shr_nuopc_utils_chkerr(rc,__LINE__,u_FILE_u)) return
+          if (med_utils_chkerr(rc,__LINE__,u_FILE_u)) return
        else
           call ESMF_ClockGetAlarm(clock, alarmname='alarm_stop', alarm=salarm, rc=rc)
-          if (shr_nuopc_utils_chkerr(rc,__LINE__,u_FILE_u)) return
+          if (med_utils_chkerr(rc,__LINE__,u_FILE_u)) return
           if (ESMF_AlarmIsRinging(salarm, rc=rc)) then
-             if (shr_nuopc_utils_chkerr(rc,__LINE__,u_FILE_u)) return
+             if (med_utils_chkerr(rc,__LINE__,u_FILE_u)) return
              stopalarmIsOn = .true.
              call ESMF_AlarmRingerOff( salarm, rc=rc )
-             if (shr_nuopc_utils_chkerr(rc,__LINE__,u_FILE_u)) return
+             if (med_utils_chkerr(rc,__LINE__,u_FILE_u)) return
           else
              AlarmIsOn = .false.
              stopalarmison = .false.
@@ -128,39 +133,39 @@ contains
        if ((stopalarmison .or. alarmIsOn .or. iterations==1) .and. mastertask) then
           ! We need to get the next time for display
           call ESMF_ClockGetNextTime(clock, nextTime=nexttime, rc=rc)
-          if (shr_nuopc_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
+          if (med_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
 
           call ESMF_VMWtime(current_time, rc=rc)
-          if (shr_nuopc_utils_chkerr(rc,__LINE__,u_FILE_u)) return
+          if (med_utils_chkerr(rc,__LINE__,u_FILE_u)) return
 
           wallclockelapsed = current_time - previous_time
           accumulated_time = accumulated_time + wallclockelapsed
 
           if (alarmison) then
              call ESMF_AlarmGet( alarm, ringInterval=ringInterval, rc=rc)
-             if (shr_nuopc_utils_chkerr(rc,__LINE__,u_FILE_u)) return
+             if (med_utils_chkerr(rc,__LINE__,u_FILE_u)) return
              call ESMF_TimeIntervalGet(ringInterval, d_r8=ringdays, rc=rc)
-             if (shr_nuopc_utils_chkerr(rc,__LINE__,u_FILE_u)) return
+             if (med_utils_chkerr(rc,__LINE__,u_FILE_u)) return
              avgdt = accumulated_time/(ringdays*real(iterations-1))
           else if (stopalarmison) then
              ! Here we need the interval since the last call to this function
              call ESMF_TimeIntervalGet(nexttime-prevtime, d_r8=ringdays, rc=rc)
-             if (shr_nuopc_utils_chkerr(rc,__LINE__,u_FILE_u)) return
+             if (med_utils_chkerr(rc,__LINE__,u_FILE_u)) return
           else
              avgdt = wallclockelapsed/timestep_length
              ringdays = timestep_length
           endif
           prevtime = nexttime
           call ESMF_TimeGet(nexttime, timestring=nexttimestr, rc=rc)
-          if (shr_nuopc_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
+          if (med_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
           ! get current wall clock time
           call ESMF_TimeSet(wallclocktime, rc=rc)
-          if (shr_nuopc_utils_chkerr(rc,__LINE__,u_FILE_u)) return
+          if (med_utils_chkerr(rc,__LINE__,u_FILE_u)) return
           call ESMF_TimeSyncToRealTime(wallclocktime, rc=rc)
-          if (shr_nuopc_utils_chkerr(rc,__LINE__,u_FILE_u)) return
+          if (med_utils_chkerr(rc,__LINE__,u_FILE_u)) return
 
           call ESMF_TimeGet(wallclocktime,timeString=walltimestr, rc=rc)
-          if (shr_nuopc_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
+          if (med_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
 
 
           ! 1 model day/ x seconds = 1/365 yrs/ (wallclockelapsed s/86400spd
@@ -188,10 +193,10 @@ contains
 
   end subroutine med_phases_profile
 
+!=================================================================================
+
   subroutine med_phases_profile_finalize()
     use ESMF, only : ESMF_VMWtime
-    use med_internalstate_mod, only : logunit
-    use shr_nuopc_utils_mod, only : shr_nuopc_utils_chkerr
 
     real(r8) :: SYPD
     character(*), parameter :: FormatR = '(": =============== ", A31,F12.3,1x,  " ===============")'
@@ -199,7 +204,7 @@ contains
     integer :: rc
 
     call ESMF_VMWtime(current_time, rc=rc)
-    if (shr_nuopc_utils_chkerr(rc,__LINE__,u_FILE_u)) return
+    if (med_utils_chkerr(rc,__LINE__,u_FILE_u)) return
 
     wallclockelapsed = current_time - previous_time
     accumulated_time = accumulated_time + wallclockelapsed
@@ -208,6 +213,5 @@ contains
     write(logunit,FormatR) '# simulated years / cmp-day = ', SYPD
 
   end subroutine med_phases_profile_finalize
-
 
 end module med_phases_profile_mod

--- a/mediator/med_phases_restart_mod.F90
+++ b/mediator/med_phases_restart_mod.F90
@@ -6,7 +6,8 @@ module med_phases_restart_mod
 
   use med_constants_mod   , only : R8
   use med_constants_mod   , only : dbug_flag => med_constants_dbug_flag
-  use shr_nuopc_utils_mod , only : chkerr    => shr_nuopc_utils_ChkErr
+  use med_constants_mod   , only : SecPerDay => med_constants_SecPerDay
+  use med_utils_mod       , only : chkerr    => med_utils_ChkErr
 
   implicit none
   private
@@ -35,7 +36,6 @@ contains
     use ESMF                  , only : ESMF_Calendar
     use NUOPC                 , only : NUOPC_CompAttributeGet
     use esmFlds               , only : ncomps, compname, compocn
-    use med_constants_mod     , only : SecPerDay => med_constants_SecPerDay
     use med_internalstate_mod , only : mastertask, logunit, InternalState
     use med_io_mod            , only : med_io_write, med_io_wopen, med_io_enddef
     use med_io_mod            , only : med_io_close, med_io_date2yyyymmdd

--- a/mediator/med_time_mod.F90
+++ b/mediator/med_time_mod.F90
@@ -1,4 +1,4 @@
-module shr_nuopc_time_mod
+module med_time_mod
 
   use ESMF                , only : ESMF_GridComp, ESMF_GridCompGet, ESMF_GridCompSet
   use ESMF                , only : ESMF_Clock, ESMF_ClockCreate, ESMF_ClockGet, ESMF_ClockSet
@@ -16,17 +16,17 @@ module shr_nuopc_time_mod
   use ESMF                , only : operator(<=), operator(>), operator(==)
   use NUOPC               , only : NUOPC_CompAttributeGet
   use med_constants_mod   , only : dbug_flag => med_constants_dbug_flag
-  use shr_nuopc_utils_mod , only : chkerr => shr_nuopc_utils_ChkErr
+  use med_utils_mod       , only : chkerr => med_utils_ChkErr
 
   implicit none
   private    ! default private
 
-  public  :: shr_nuopc_time_clockInit  ! initialize driver clock (assumes default calendar)
-  public  :: shr_nuopc_time_alarmInit  ! initialize an alarm
-  public  :: shr_nuopc_time_set_component_stop_alarm
+  public  :: med_time_clockInit  ! initialize driver clock (assumes default calendar)
+  public  :: med_time_alarmInit  ! initialize an alarm
+  public  :: med_time_set_component_stop_alarm
 
-  private :: shr_nuopc_time_timeInit
-  private :: shr_nuopc_time_date2ymd
+  private :: med_time_timeInit
+  private :: med_time_date2ymd
 
   ! Clock and alarm options
   character(len=*), private, parameter :: &
@@ -61,7 +61,7 @@ module shr_nuopc_time_mod
 contains
 !===============================================================================
 
-  subroutine shr_nuopc_time_clockInit(ensemble_driver, esmdriver, logunit, rc)
+  subroutine med_time_clockInit(ensemble_driver, esmdriver, logunit, rc)
 
     use med_constants_mod     , only : CL, CS
     use shr_cal_mod           , only : shr_cal_noleap, shr_cal_gregorian, shr_cal_calendarname
@@ -117,7 +117,7 @@ contains
     character(CS)           :: inst_suffix
     integer                 :: tmp(6)              ! Array for Broadcast
     logical                 :: isPresent
-    character(len=*), parameter :: subname = '(shr_nuopc_time_clockInit): '
+    character(len=*), parameter :: subname = '(med_time_clockInit): '
     !-------------------------------------------------------------------------------
 
     rc = ESMF_SUCCESS
@@ -210,7 +210,7 @@ contains
           endif
        endif
        if (mastertask) then
-          call shr_nuopc_time_read_restart(restart_file, &
+          call med_time_read_restart(restart_file, &
                start_ymd, start_tod, ref_ymd, ref_tod, curr_ymd, curr_tod, rc)
           if (ChkErr(rc,__LINE__,u_FILE_u)) return
        endif
@@ -241,7 +241,7 @@ contains
 
     ! Determine start time (THE FOLLOWING ASSUMES THAT THE DEFAULT CALENDAR IS SET in the driver)
 
-    call shr_nuopc_time_date2ymd(start_ymd, yr, mon, day)
+    call med_time_date2ymd(start_ymd, yr, mon, day)
     call ESMF_TimeSet( StartTime, yy=yr, mm=mon, dd=day, s=start_tod, rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
     if(mastertask .or. dbug_flag > 2) then
@@ -254,7 +254,7 @@ contains
     endif
 
     ! Determine reference time
-    call shr_nuopc_time_date2ymd(ref_ymd, yr, mon, day)
+    call med_time_date2ymd(ref_ymd, yr, mon, day)
     call ESMF_TimeSet( RefTime, yy=yr, mm=mon, dd=day, s=ref_tod, rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
 
@@ -267,7 +267,7 @@ contains
        write(logunit,*)   trim(subname)//': driver ref_tod: '// trim(tmpstr)
     endif
     ! Determine current time
-    call shr_nuopc_time_date2ymd(curr_ymd, yr, mon, day)
+    call med_time_date2ymd(curr_ymd, yr, mon, day)
     call ESMF_TimeSet( CurrTime, yy=yr, mm=mon, dd=day, s=curr_tod, rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
     if(mastertask .or. dbug_flag > 2) then
@@ -386,7 +386,7 @@ contains
        call ESMF_LogWrite(trim(subname)//': driver stop_tod: '// trim(tmpstr), ESMF_LOGMSG_INFO)
        write(logunit,*)   trim(subname)//': driver stop_tod: '// trim(tmpstr)
     endif
-    call shr_nuopc_time_alarmInit(clock, &
+    call med_time_alarmInit(clock, &
          alarm   = alarm_stop,           &
          option  = stop_option,          &
          opt_n   = stop_n,               &
@@ -396,7 +396,7 @@ contains
          alarmname = 'alarm_stop', rc=rc)
        if (ChkErr(rc,__LINE__,u_FILE_u)) return
 
-    call shr_nuopc_time_alarmInit(clock, &
+    call med_time_alarmInit(clock, &
          alarm     = alarm_datestop,     &
          option    = optDate,            &
          opt_ymd   = stop_ymd,           &
@@ -429,9 +429,9 @@ contains
 
 
 
- end subroutine shr_nuopc_time_clockInit
+ end subroutine med_time_clockInit
 
- subroutine shr_nuopc_time_set_component_stop_alarm(gcomp, rc)
+ subroutine med_time_set_component_stop_alarm(gcomp, rc)
    use ESMF, only : ESMF_GridComp, ESMF_Alarm, ESMF_Clock, ESMF_ClockGet
    use ESMF, only : ESMF_AlarmSet
    use NUOPC, only : NUOPC_CompAttributeGet
@@ -465,7 +465,7 @@ contains
    call NUOPC_CompAttributeGet(gcomp, name="stop_ymd", value=cvalue, rc=rc)
    if (ChkErr(rc,__LINE__,u_FILE_u)) return
    read(cvalue,*) stop_ymd
-   call shr_nuopc_time_alarmInit(mclock, stop_alarm, stop_option, &
+   call med_time_alarmInit(mclock, stop_alarm, stop_option, &
         opt_n   = stop_n,           &
         opt_ymd = stop_ymd,         &
         RefTime = mcurrTime,           &
@@ -474,11 +474,11 @@ contains
 
    call ESMF_AlarmSet(stop_alarm, clock=mclock, rc=rc)
    if (ChkErr(rc,__LINE__,u_FILE_u)) return
- end subroutine shr_nuopc_time_set_component_stop_alarm
+ end subroutine med_time_set_component_stop_alarm
 
 !===============================================================================
 
-  subroutine shr_nuopc_time_alarmInit( clock, alarm, option, &
+  subroutine med_time_alarmInit( clock, alarm, option, &
        opt_n, opt_ymd, opt_tod, RefTime, alarmname, rc)
 
     ! !DESCRIPTION: Setup an alarm in a clock
@@ -514,7 +514,7 @@ contains
     type(ESMF_Time)         :: NextAlarm        ! Next restart alarm time
     type(ESMF_TimeInterval) :: AlarmInterval    ! Alarm interval
     integer                 :: sec
-    character(len=*), parameter :: subname = '(shr_nuopc_time_alarmInit): '
+    character(len=*), parameter :: subname = '(med_time_alarmInit): '
     !-------------------------------------------------------------------------------
 
     rc = ESMF_SUCCESS
@@ -572,7 +572,7 @@ contains
        end if
        call ESMF_TimeIntervalSet(AlarmInterval, yy=9999, rc=rc)
        if (ChkErr(rc,__LINE__,u_FILE_u)) return
-       call shr_nuopc_time_timeInit(NextAlarm, lymd, cal, tod=ltod, desc="optDate")
+       call med_time_timeInit(NextAlarm, lymd, cal, tod=ltod, desc="optDate")
        if (ChkErr(rc,__LINE__,u_FILE_u)) return
        update_nextalarm  = .false.
 
@@ -860,11 +860,11 @@ contains
          ringInterval=AlarmInterval, rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
 
-  end subroutine shr_nuopc_time_alarmInit
+  end subroutine med_time_alarmInit
 
   !===============================================================================
 
-  subroutine shr_nuopc_time_timeInit( Time, ymd, cal, tod, desc, logunit )
+  subroutine med_time_timeInit( Time, ymd, cal, tod, desc, logunit )
 
     !  Create the ESMF_Time object corresponding to the given input time, given in
     !  YMD (Year Month Day) and TOD (Time-of-day) format.
@@ -883,7 +883,7 @@ contains
     integer                     :: ltod         ! local tod
     character(len=256)          :: ldesc        ! local desc
     integer                     :: rc           ! return code
-    character(len=*), parameter :: subname = '(shr_nuopc_time_m_ETimeInit) '
+    character(len=*), parameter :: subname = '(med_time_m_ETimeInit) '
     !-------------------------------------------------------------------------------
 
     ltod = 0
@@ -901,16 +901,16 @@ contains
        return
     end if
 
-    call shr_nuopc_time_date2ymd (ymd,yr,mon,day)
+    call med_time_date2ymd (ymd,yr,mon,day)
 
     call ESMF_TimeSet( Time, yy=yr, mm=mon, dd=day, s=ltod, calendar=cal, rc=rc )
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
 
-  end subroutine shr_nuopc_time_timeInit
+  end subroutine med_time_timeInit
 
   !===============================================================================
 
-  subroutine shr_nuopc_time_date2ymd (date, year, month, day)
+  subroutine med_time_date2ymd (date, year, month, day)
 
     ! input/output variables
     integer, intent(in)  :: date             ! coded-date (yyyymmdd)
@@ -918,7 +918,7 @@ contains
 
     ! local variables
     integer :: tdate   ! temporary date
-    character(*),parameter :: subName = "(shr_nuopc_time_date2ymd)"
+    character(*),parameter :: subName = "(med_time_date2ymd)"
     !-------------------------------------------------------------------------------
 
     tdate = abs(date)
@@ -929,11 +929,11 @@ contains
     month = int( mod(tdate,10000)/  100)
     day = mod(tdate,  100)
 
-  end subroutine shr_nuopc_time_date2ymd
+  end subroutine med_time_date2ymd
 
   !===============================================================================
 
-  subroutine shr_nuopc_time_read_restart(restart_file, &
+  subroutine med_time_read_restart(restart_file, &
        start_ymd, start_tod, ref_ymd, ref_tod, curr_ymd, curr_tod, rc)
 
     use netcdf                , only : nf90_open, nf90_nowrite, nf90_noerr
@@ -954,7 +954,7 @@ contains
     ! local variables
     integer                 :: status, ncid, varid ! netcdf stuff
     character(CL)           :: tmpstr              ! temporary
-    character(len=*), parameter :: subname = "(shr_nuopc_time_read_restart)"
+    character(len=*), parameter :: subname = "(med_time_read_restart)"
     !----------------------------------------------------------------
 
     ! use netcdf here since it's serial
@@ -1057,6 +1057,6 @@ contains
     write(tmpstr,*) trim(subname)//" read curr_tod  = ",curr_tod
     call ESMF_LogWrite(trim(tmpstr), ESMF_LOGMSG_INFO)
 
-  end subroutine shr_nuopc_time_read_restart
+  end subroutine med_time_read_restart
 
-end module shr_nuopc_time_mod
+end module med_time_mod

--- a/mediator/med_utils_mod.F90
+++ b/mediator/med_utils_mod.F90
@@ -1,11 +1,13 @@
-module shr_nuopc_utils_mod
+module med_utils_mod
+
+  use med_constants_mod, only : CL
 
   implicit none
   private
 
-  public :: shr_nuopc_memcheck
-  public :: shr_nuopc_utils_ChkErr
-  public :: shr_nuopc_log_clock_advance
+  public :: med_memcheck
+  public :: med_utils_ChkErr
+  public :: med_log_clock_advance
 
   integer     , parameter :: memdebug_level=1
   character(*), parameter :: u_FILE_u = &
@@ -15,7 +17,7 @@ module shr_nuopc_utils_mod
 contains
 !===============================================================================
 
-  subroutine shr_nuopc_memcheck(string, level, mastertask)
+  subroutine med_memcheck(string, level, mastertask)
     character(len=*), intent(in) :: string
     integer, intent(in) :: level
     logical, intent(in) :: mastertask
@@ -24,11 +26,11 @@ contains
     if((mastertask .and. memdebug_level > level) .or. memdebug_level > level+1) then
        ierr = GPTLprint_memusage(string)
     endif
-  end subroutine shr_nuopc_memcheck
+  end subroutine med_memcheck
 
 !===============================================================================
 
-  logical function shr_nuopc_utils_ChkErr(rc, line, file, mpierr)
+  logical function med_utils_ChkErr(rc, line, file, mpierr)
 
     use mpi , only : MPI_ERROR_STRING, MPI_MAX_ERROR_STRING, MPI_SUCCESS
     use ESMF, only : ESMF_LogFoundError, ESMF_LOGERR_PASSTHRU, ESMF_LOGMSG_INFO
@@ -43,7 +45,7 @@ contains
     character(MPI_MAX_ERROR_STRING) :: lstring
     integer :: dbrc, lrc, len, ierr
 
-    shr_nuopc_utils_ChkErr = .false.
+    med_utils_ChkErr = .false.
     lrc = rc
     if (present(mpierr) .and. mpierr) then
        if (rc == MPI_SUCCESS) return
@@ -53,16 +55,15 @@ contains
     endif
 
     if (ESMF_LogFoundError(rcToCheck=lrc, msg=ESMF_LOGERR_PASSTHRU, line=line, file=file)) then
-      shr_nuopc_utils_ChkErr = .true.
+      med_utils_ChkErr = .true.
     endif
 
-  end function shr_nuopc_utils_ChkErr
+  end function med_utils_ChkErr
 
 !===============================================================================
 
-  subroutine shr_nuopc_log_clock_advance(clock, component, logunit)
+  subroutine med_log_clock_advance(clock, component, logunit)
     use ESMF, only : ESMF_Clock, ESMF_ClockPrint
-    use med_constants_mod, only : CL
 
     type(ESMF_Clock) :: clock
     character(len=*), intent(in) :: component
@@ -74,14 +75,14 @@ contains
     write(prestring, *) "------>Advancing ",trim(component)," from: "
     call ESMF_ClockPrint(clock, options="currTime", unit=cvalue, &
          preString=trim(prestring), rc=rc)
-    if (shr_nuopc_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
+    if (med_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
     write(logunit, *) trim(cvalue)
 
     call ESMF_ClockPrint(clock, options="stopTime", unit=cvalue, &
          preString="--------------------------------> to: ", rc=rc)
-    if (shr_nuopc_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
+    if (med_utils_ChkErr(rc,__LINE__,u_FILE_u)) return
     write(logunit, *) trim(cvalue)
 
-  end subroutine shr_nuopc_log_clock_advance
+  end subroutine med_log_clock_advance
 
-end module shr_nuopc_utils_mod
+end module med_utils_mod


### PR DESCRIPTION
Moved shr_nuopc_xxx.F90 files back to the mediator/ directory with renaming

Change Description: moved shr_nuopc_xxx.F90 files back to the mediator/ directory and renamed them med_xxx.F90 instead
Testing Completed: testlist_driver.xml - results were bfb with oct30
(did not run CIME_DRIVER=nuopc scripts_regression_tests.py since full test suite was run and bfb was validated)

CIME HASH: 2cd9068ba
