### PR TITLE
new testlist for CESM components

### DIFF
--- a/cime_config/runseq/runseq_CG.py
+++ b/cime_config/runseq/runseq_CG.py
@@ -80,7 +80,7 @@ def runseq(case, coupling_times):
     elif comp_wav == 'ww' or comp_wav == "dwav":
 
         if atm_cpl_dt < ocn_cpl_dt:
-            expect(False, "for C or G compset assume that atm_cpl_ct >= ocn_cpl_dt")
+            expect(False, "for C or G compset require that atm_cpl_ct >= ocn_cpl_dt")
 
         outfile.write ("runSeq::                                \n")
         outfile.write ("@" + str(atm_cpl_dt) + "                \n") 

--- a/cime_config/runseq/runseq_CG.py
+++ b/cime_config/runseq/runseq_CG.py
@@ -14,12 +14,9 @@ def runseq(case, coupling_times):
     rundir    = case.get_value("RUNDIR")
     caseroot  = case.get_value("CASEROOT")
     comp_wav  = case.get_value("COMP_WAV")
-
     atm_cpl_dt = coupling_times["atm_cpl_dt"]
     ocn_cpl_dt = coupling_times["ocn_cpl_dt"]
 
-    print ("atm_cpl_dt = ",atm_cpl_dt)
-    print ("atm_cpl_dt = ",ocn_cpl_dt)
     outfile   = open(os.path.join(caseroot, "CaseDocs", "nuopc.runseq"), "w")
 
     # The following is for RASM_OPTION1
@@ -81,15 +78,18 @@ def runseq(case, coupling_times):
             outfile.write ("::                                  \n")
 
     elif comp_wav == 'ww' or comp_wav == "dwav":
+
+        if atm_cpl_dt < ocn_cpl_dt:
+            expect(False, "for C or G compset assume that atm_cpl_ct >= ocn_cpl_dt")
+
         outfile.write ("runSeq::                                \n")
-        outfile.write ("@" + str(atm_cpl_dt) + "                \n") # Assume that atm_cpl_dt >= ocn_cpl_dt
+        outfile.write ("@" + str(atm_cpl_dt) + "                \n") 
         outfile.write ("  MED med_phases_prep_ocn_map           \n") # map to ocean (including wav)
         outfile.write ("  MED med_phases_aofluxes_run           \n") # run atm/ocn flux calculation
         outfile.write ("  MED med_phases_prep_ocn_merge         \n")
         outfile.write ("  MED med_phases_prep_ocn_accum_fast    \n")
         outfile.write ("  MED med_phases_prep_ocn_accum_avg     \n")
         outfile.write ("  MED med_phases_ocnalb_run             \n")
-        outfile.write ("  MED -> OCN :remapMethod=redist        \n")
         outfile.write ("  MED med_phases_prep_ice               \n")
         outfile.write ("  MED -> ICE :remapMethod=redist        \n")
         outfile.write ("  MED med_phases_prep_wav               \n")
@@ -103,10 +103,13 @@ def runseq(case, coupling_times):
         outfile.write ("  ROF -> MED :remapMethod=redist        \n")
         outfile.write ("  WAV -> MED :remapMethod=redist        \n")
         outfile.write ("  ATM -> MED :remapMethod=redist        \n")
-        outfile.write ("  @ocn_cpl_dt   #ocean coupling step    \n")
-        outfile.write ("    OCN                                 \n")
-        outfile.write ("  @                                     \n")
+        if atm_cpl_dt > ocn_cpl_dt:
+            outfile.write ("  @" + str(ocn_cpl_dt) + "          \n")
+        outfile.write ("  MED -> OCN :remapMethod=redist        \n")
+        outfile.write ("  OCN                                   \n")
         outfile.write ("  OCN -> MED :remapMethod=redist        \n")
+        if atm_cpl_dt > ocn_cpl_dt:
+            outfile.write ("  @                                 \n")
         outfile.write ("  MED med_phases_restart_write          \n")
         outfile.write ("  MED med_phases_history_write          \n")
         outfile.write ("  MED med_phases_profile                \n")

--- a/cime_config/testdefs/testlist_drv.xml
+++ b/cime_config/testdefs/testlist_drv.xml
@@ -1,6 +1,60 @@
 <?xml version="1.0"?>
 <testlist version="2.0">
 
+  <!-- ======================================= -->
+  <!-- A compsets -->
+  <!-- ======================================= -->
+
+  <test compset="A" grid="f19_g17_rx1" name="SMS_Vnuopc_Ld1_N3">
+    <machines>
+      <machine name="cheyenne" compiler="intel" category="nuopc"/>
+      <machine name="theia" compiler="intel" category="nuopc"/>
+      <machine name="izumi" compiler="intel" category="nuopc"/>
+    </machines>
+    <options>
+      <option name="wallclock"> 00:10:00 </option>
+    </options>
+  </test>
+  <test compset="A" grid="f19_g17_rx1" name="SMS_Vnuopc_Ln11_D">
+    <machines>
+      <machine name="cheyenne" compiler="intel" category="nuopc"/>
+      <machine name="theia" compiler="intel" category="nuopc"/>
+      <machine name="izumi" compiler="intel" category="nuopc"/>
+    </machines>
+    <options>
+      <option name="wallclock"> 00:10:00 </option>
+    </options>
+  </test>
+  <test compset="A" grid="f19_g17_rx1" name="SMS_Vmct_Ld1">
+    <machines>
+      <machine name="cheyenne" compiler="intel" category="nuopc"/>
+      <machine name="theia" compiler="intel" category="nuopc"/>
+      <machine name="izumi" compiler="intel" category="nuopc"/>
+    </machines>
+    <options>
+      <option name="wallclock"> 00:10:00 </option>
+    </options>
+  </test>
+  <test compset="A" grid="f19_g17_rx1" name="ERS_Vnuopc_Ln9_N3">
+    <machines>
+      <machine name="cheyenne" compiler="intel" category="nuopc"/>
+      <machine name="theia" compiler="intel" category="nuopc"/>
+      <machine name="izumi" compiler="intel" category="nuopc"/>
+    </machines>
+    <options>
+      <option name="wallclock"> 00:10:00 </option>
+    </options>
+  </test>
+  <test compset="A" grid="f19_g17_rx1" name="ERS_Vmct_Ln9">
+    <machines>
+      <machine name="cheyenne" compiler="intel" category="mctcheck"/>
+      <machine name="theia" compiler="intel" category="mctcheck"/>
+      <machine name="izumi" compiler="intel" category="mctcheck"/>
+    </machines>
+    <options>
+      <option name="wallclock"> 00:10:00 </option>
+    </options>
+  </test>
   <test compset="ADWAV" grid="ww3a" name="SMS_Vnuopc_Ld2">
     <machines>
       <machine name="cheyenne" compiler="intel" category="nuopc"/>
@@ -21,7 +75,6 @@
       <option name="wallclock"> 00:10:00 </option>
     </options>
   </test>
-
   <test compset="A1850DLND" grid="f09_f09_mg17" name="SMS_Vnuopc_Ld3">
     <machines>
       <machine name="cheyenne" compiler="intel" category="nuopc"/>
@@ -43,114 +96,9 @@
     </options>
   </test>
 
-  <test compset="BMOM" grid="f19_g16" name="SMS_Vnuopc_Ld5" testmods="allactive/nuopc_cap_io">
-    <machines>
-      <machine name="cheyenne" compiler="intel" category="nuopc"/>
-      <machine name="theia" compiler="intel" category="nuopc"/>
-      <machine name="izumi" compiler="intel" category="nuopc"/>
-    </machines>
-    <options>
-      <option name="wallclock"> 00:40:00 </option>
-    </options>
-  </test>
-  <test compset="BMOM" grid="f19_g16" name="SMS_Vmct_Ld5" testmods="allactive/nuopc_cap_io">
-    <machines>
-      <machine name="cheyenne" compiler="intel" category="mctcheck"/>
-      <machine name="theia" compiler="intel" category="mctcheck"/>
-      <machine name="izumi" compiler="intel" category="mctcheck"/>
-    </machines>
-    <options>
-      <option name="wallclock"> 00:40:00 </option>
-    </options>
-  </test>
-
-  <test compset="CMOM" grid="T62_g16" name="SMS_Vnuopc_Ld5">
-    <machines>
-      <machine name="cheyenne" compiler="intel" category="nuopc"/>
-      <machine name="theia" compiler="intel" category="nuopc"/>
-      <machine name="izumi" compiler="intel" category="nuopc"/>
-    </machines>
-    <options>
-      <option name="wallclock"> 00:40:00 </option>
-    </options>
-  </test>
-
-  <test compset="CMOM" grid="T62_g16" name="SMS_Vmct_Ld5">
-    <machines>
-      <machine name="cheyenne" compiler="intel" category="mctcheck"/>
-      <machine name="theia" compiler="intel" category="mctcheck"/>
-      <machine name="izumi" compiler="intel" category="mctcheck"/>
-    </machines>
-    <options>
-      <option name="wallclock"> 00:10:00 </option>
-    </options>
-  </test>
-
-  <test compset="GMOM" grid="T62_g16" name="SMS_Vnuopc_Ld5">
-    <machines>
-      <machine name="cheyenne" compiler="intel" category="nuopc"/>
-      <machine name="theia" compiler="intel" category="nuopc"/>
-      <machine name="izumi" compiler="intel" category="nuopc"/>
-    </machines>
-    <options>
-      <option name="wallclock"> 00:10:00 </option>
-    </options>
-  </test>
-
-  <test compset="GMOM" grid="T62_g16" name="SMS_Vmct_Ld5">
-    <machines>
-      <machine name="cheyenne" compiler="intel" category="mctcheck"/>
-      <machine name="theia" compiler="intel" category="mctcheck"/>
-      <machine name="izumi" compiler="intel" category="mctcheck"/>
-    </machines>
-    <options>
-      <option name="wallclock"> 00:10:00 </option>
-    </options>
-  </test>
-
-  <test compset="DTEST" grid="T62_g37" name="SMS_Vnuopc_Ld5" testmods="cice/nuopc_cap">
-    <machines>
-      <machine name="cheyenne" compiler="intel" category="nuopc"/>
-      <machine name="theia" compiler="intel" category="nuopc"/>
-      <machine name="izumi" compiler="intel" category="nuopc"/>
-    </machines>
-    <options>
-      <option name="wallclock"> 00:10:00 </option>
-    </options>
-  </test>
-
-  <test compset="DTEST" grid="T62_g37" name="SMS_Vmct_Ld5" testmods="cice/nuopc_cap">
-    <machines>
-      <machine name="cheyenne" compiler="intel" category="mctcheck"/>
-      <machine name="theia" compiler="intel" category="mctcheck"/>
-      <machine name="izumi" compiler="intel" category="mctcheck"/>
-    </machines>
-    <options>
-      <option name="wallclock"> 00:10:00 </option>
-    </options>
-  </test>
-
-  <test compset="F2000Nuopc" grid="f19_f19_mg17" name="SMS_Vnuopc_Ln5" testmods="cam/nuopc_cap">
-    <machines>
-      <machine name="cheyenne" compiler="intel" category="nuopc"/>
-      <machine name="theia" compiler="intel" category="nuopc"/>
-      <machine name="izumi" compiler="intel" category="nuopc"/>
-    </machines>
-    <options>
-      <option name="wallclock"> 00:10:00 </option>
-    </options>
-  </test>
-
-  <test compset="F2000Nuopc" grid="f19_f19_mg17" name="SMS_Vmct_Ln5" testmods="cam/nuopc_cap">
-    <machines>
-      <machine name="cheyenne" compiler="intel" category="mctcheck"/>
-      <machine name="theia" compiler="intel" category="mctcheck"/>
-      <machine name="izumi" compiler="intel" category="mctcheck"/>
-    </machines>
-    <options>
-      <option name="wallclock"> 00:10:00 </option>
-    </options>
-  </test>
+  <!-- ======================================= -->
+  <!-- X compsets -->
+  <!-- ======================================= -->
 
   <test compset="X" grid="f19_g17" name="SMS_Vnuopc">
     <machines>
@@ -162,7 +110,6 @@
       <option name="wallclock"> 00:20:00 </option>
     </options>
   </test>
-
   <test compset="X" grid="f19_g17" name="SMS_Vmct">
     <machines>
       <machine name="cheyenne" compiler="intel" category="nuopc"/>
@@ -173,214 +120,6 @@
       <option name="wallclock"> 00:20:00 </option>
     </options>
   </test>
-
-  <test compset="A" grid="f19_g17_rx1" name="SMS_Vnuopc_Ld1_N3">
-    <machines>
-      <machine name="cheyenne" compiler="intel" category="nuopc"/>
-      <machine name="theia" compiler="intel" category="nuopc"/>
-      <machine name="izumi" compiler="intel" category="nuopc"/>
-    </machines>
-    <options>
-      <option name="wallclock"> 00:10:00 </option>
-    </options>
-  </test>
-
-  <test compset="A" grid="f19_g17_rx1" name="SMS_Vnuopc_Ln11_D">
-    <machines>
-      <machine name="cheyenne" compiler="intel" category="nuopc"/>
-      <machine name="theia" compiler="intel" category="nuopc"/>
-      <machine name="izumi" compiler="intel" category="nuopc"/>
-    </machines>
-    <options>
-      <option name="wallclock"> 00:10:00 </option>
-    </options>
-  </test>
-
-  <test compset="A" grid="f19_g17_rx1" name="SMS_Vmct_Ld1">
-    <machines>
-      <machine name="cheyenne" compiler="intel" category="nuopc"/>
-      <machine name="theia" compiler="intel" category="nuopc"/>
-      <machine name="izumi" compiler="intel" category="nuopc"/>
-    </machines>
-    <options>
-      <option name="wallclock"> 00:10:00 </option>
-    </options>
-  </test>
-
-  <test compset="I2000Clm50SpNuopc" grid="f45_f45_mg37" name="SMS_Vnuopc_Ln5" testmods="clm/nuopc_cap">
-    <machines>
-      <machine name="cheyenne" compiler="intel" category="nuopc"/>
-      <machine name="theia" compiler="intel" category="nuopc"/>
-      <machine name="izumi" compiler="intel" category="nuopc"/>
-    </machines>
-    <options>
-      <option name="wallclock"> 00:10:00 </option>
-    </options>
-  </test>
-  <test compset="I2000Clm50SpNuopc" grid="f45_f45_mg37" name="SMS_Vmct_Ln5" testmods="clm/nuopc_cap">
-    <machines>
-      <machine name="cheyenne" compiler="intel" category="mctcheck"/>
-      <machine name="theia" compiler="intel" category="mctcheck"/>
-      <machine name="izumi" compiler="intel" category="mctcheck"/>
-    </machines>
-    <options>
-      <option name="wallclock"> 00:10:00 </option>
-    </options>
-  </test>
-
-  <test compset="I2000Clm50SpGs" grid="f19_f19_mg17" name="SMS_Vnuopc_Ln5" testmods="clm/nuopc_cap">
-    <machines>
-      <machine name="cheyenne" compiler="intel" category="nuopc"/>
-      <machine name="theia" compiler="intel" category="nuopc"/>
-      <machine name="izumi" compiler="intel" category="nuopc"/>
-    </machines>
-    <options>
-      <option name="wallclock"> 00:10:00 </option>
-    </options>
-  </test>
-  <test compset="I2000Clm50SpGs" grid="f19_f19_mg17" name="SMS_Vmct_Ln5" testmods="clm/nuopc_cap">
-    <machines>
-      <machine name="cheyenne" compiler="intel" category="mctcheck"/>
-      <machine name="theia" compiler="intel" category="mctcheck"/>
-      <machine name="izumi" compiler="intel" category="mctcheck"/>
-    </machines>
-    <options>
-      <option name="wallclock"> 00:10:00 </option>
-    </options>
-  </test>
-
-  <test compset="QPC4" grid="ne16_ne16_mg17" name="SMS_Vnuopc_Ln5" testmods="cam/nuopc_cap">
-    <machines>
-      <machine name="cheyenne" compiler="intel" category="nuopc"/>
-      <machine name="theia" compiler="intel" category="nuopc"/>
-      <machine name="izumi" compiler="intel" category="nuopc"/>
-    </machines>
-    <options>
-      <option name="wallclock"> 00:10:00 </option>
-    </options>
-  </test>
-
-  <test compset="QPC4" grid="ne16_ne16_mg17" name="SMS_Vmct_Ln5" testmods="cam/nuopc_cap">
-    <machines>
-      <machine name="cheyenne" compiler="intel" category="mctcheck"/>
-      <machine name="theia" compiler="intel" category="mctcheck"/>
-      <machine name="izumi" compiler="intel" category="mctcheck"/>
-    </machines>
-    <options>
-      <option name="wallclock"> 00:10:00 </option>
-    </options>
-  </test>
-
-  <test compset="BMOM" grid="f19_g16" name="ERR_Vnuopc_Ld5" testmods="allactive/nuopc_cap_io">
-    <machines>
-      <machine name="cheyenne" compiler="intel" category="nuopc"/>
-      <machine name="theia" compiler="intel" category="nuopc"/>
-      <machine name="izumi" compiler="intel" category="nuopc"/>
-    </machines>
-    <options>
-      <option name="wallclock"> 00:40:00 </option>
-    </options>
-  </test>
-
-  <test compset="BMOM" grid="f19_g16" name="ERR_Vmct_Ld5" testmods="allactive/nuopc_cap_io">
-    <machines>
-      <machine name="cheyenne" compiler="intel" category="mctcheck"/>
-      <machine name="theia" compiler="intel" category="mctcheck"/>
-      <machine name="izumi" compiler="intel" category="mctcheck"/>
-    </machines>
-    <options>
-      <option name="wallclock"> 00:40:00 </option>
-    </options>
-  </test>
-
-  <test compset="CMOM" grid="T62_g16" name="ERS_Vnuopc_Ld5">
-    <machines>
-      <machine name="cheyenne" compiler="intel" category="nuopc"/>
-      <machine name="theia" compiler="intel" category="nuopc"/>
-      <machine name="izumi" compiler="intel" category="nuopc"/>
-    </machines>
-    <options>
-      <option name="wallclock"> 00:40:00 </option>
-    </options>
-  </test>
-
-  <test compset="CMOM" grid="T62_g16" name="ERS_Vmct_Ld5">
-    <machines>
-      <machine name="cheyenne" compiler="intel" category="mctcheck"/>
-      <machine name="theia" compiler="intel" category="mctcheck"/>
-      <machine name="izumi" compiler="intel" category="mctcheck"/>
-    </machines>
-    <options>
-      <option name="wallclock"> 00:10:00 </option>
-    </options>
-  </test>
-
-  <test compset="GMOM" grid="T62_g16" name="ERS_Vnuopc_Ld5">
-    <machines>
-      <machine name="cheyenne" compiler="intel" category="nuopc"/>
-      <machine name="theia" compiler="intel" category="nuopc"/>
-      <machine name="izumi" compiler="intel" category="nuopc"/>
-    </machines>
-    <options>
-      <option name="wallclock"> 00:20:00 </option>
-    </options>
-  </test>
-
-  <test compset="GMOM" grid="T62_g16" name="ERS_Vmct_Ld5">
-    <machines>
-      <machine name="cheyenne" compiler="intel" category="mctcheck"/>
-      <machine name="theia" compiler="intel" category="mctcheck"/>
-      <machine name="izumi" compiler="intel" category="mctcheck"/>
-    </machines>
-    <options>
-      <option name="wallclock"> 00:10:00 </option>
-    </options>
-  </test>
-
-  <test compset="DTEST" grid="T62_g37" name="ERS_Vnuopc_Ld5" testmods="cice/nuopc_cap">
-    <machines>
-      <machine name="cheyenne" compiler="intel" category="nuopc"/>
-      <machine name="theia" compiler="intel" category="nuopc"/>
-      <machine name="izumi" compiler="intel" category="nuopc"/>
-    </machines>
-    <options>
-      <option name="wallclock"> 00:10:00 </option>
-    </options>
-  </test>
-
-  <test compset="DTEST" grid="T62_g37" name="ERS_Vmct_Ld5" testmods="cice/nuopc_cap">
-    <machines>
-      <machine name="cheyenne" compiler="intel" category="mctcheck"/>
-      <machine name="theia" compiler="intel" category="mctcheck"/>
-      <machine name="izumi" compiler="intel" category="mctcheck"/>
-    </machines>
-    <options>
-      <option name="wallclock"> 00:10:00 </option>
-    </options>
-  </test>
-
-  <test compset="F2000Nuopc" grid="f19_f19_mg17" name="ERS_Vnuopc_Ln5" testmods="cam/nuopc_cap">
-    <machines>
-      <machine name="cheyenne" compiler="intel" category="nuopc"/>
-      <machine name="theia" compiler="intel" category="nuopc"/>
-      <machine name="izumi" compiler="intel" category="nuopc"/>
-    </machines>
-    <options>
-      <option name="wallclock"> 00:10:00 </option>
-    </options>
-  </test>
-
-  <test compset="F2000Nuopc" grid="f19_f19_mg17" name="ERS_Vmct_Ln5" testmods="cam/nuopc_cap">
-    <machines>
-      <machine name="cheyenne" compiler="intel" category="mctcheck"/>
-      <machine name="theia" compiler="intel" category="mctcheck"/>
-      <machine name="izumi" compiler="intel" category="mctcheck"/>
-    </machines>
-    <options>
-      <option name="wallclock"> 00:10:00 </option>
-    </options>
-  </test>
-
   <test compset="X" grid="f19_g17" name="ERS_Vnuopc_Ln9">
     <machines>
       <machine name="cheyenne" compiler="intel" category="nuopc"/>
@@ -391,7 +130,6 @@
       <option name="wallclock"> 00:40:00 </option>
     </options>
   </test>
-
   <test compset="X" grid="f19_g17" name="ERS_Vmct_Ln9">
     <machines>
       <machine name="cheyenne" compiler="intel" category="mctcheck"/>
@@ -403,18 +141,96 @@
     </options>
   </test>
 
-  <test compset="A" grid="f19_g17_rx1" name="ERS_Vnuopc_Ln9_N3">
+  <!-- ======================================= -->
+  <!-- B compsets -->
+  <!-- ======================================= -->
+
+  <test compset="BMOM" grid="f09_t016" name="SMS_Vnuopc_Ld5" testmods="allactive/nuopc_cap_io">
     <machines>
       <machine name="cheyenne" compiler="intel" category="nuopc"/>
       <machine name="theia" compiler="intel" category="nuopc"/>
       <machine name="izumi" compiler="intel" category="nuopc"/>
     </machines>
     <options>
-      <option name="wallclock"> 00:10:00 </option>
+      <option name="wallclock"> 00:40:00 </option>
+    </options>
+  </test>
+  <test compset="BMOM" grid="f09_t016" name="SMS_Vmct_Ld5" testmods="allactive/nuopc_cap_io">
+    <machines>
+      <machine name="cheyenne" compiler="intel" category="mctcheck"/>
+      <machine name="theia" compiler="intel" category="mctcheck"/>
+      <machine name="izumi" compiler="intel" category="mctcheck"/>
+    </machines>
+    <options>
+      <option name="wallclock"> 00:40:00 </option>
+    </options>
+  </test>
+  <test compset="BMOM" grid="f09_t016" name="ERR_Vnuopc_Ld5" testmods="allactive/nuopc_cap_io">
+    <machines>
+      <machine name="cheyenne" compiler="intel" category="nuopc"/>
+      <machine name="theia" compiler="intel" category="nuopc"/>
+      <machine name="izumi" compiler="intel" category="nuopc"/>
+    </machines>
+    <options>
+      <option name="wallclock"> 00:40:00 </option>
+    </options>
+  </test>
+  <test compset="BMOM" grid="f09_t016" name="ERR_Vmct_Ld5" testmods="allactive/nuopc_cap_io">
+    <machines>
+      <machine name="cheyenne" compiler="intel" category="mctcheck"/>
+      <machine name="theia" compiler="intel" category="mctcheck"/>
+      <machine name="izumi" compiler="intel" category="mctcheck"/>
+    </machines>
+    <options>
+      <option name="wallclock"> 00:40:00 </option>
     </options>
   </test>
 
-  <test compset="A" grid="f19_g17_rx1" name="ERS_Vmct_Ln9">
+  <!-- ======================================= -->
+  <!-- C compsets -->
+  <!-- ======================================= -->
+
+  <test compset="C" grid="T62_g17" name="ERS_Vnuopc_Ld5">
+    <machines>
+      <machine name="cheyenne" compiler="intel" category="nuopc"/>
+      <machine name="theia" compiler="intel" category="nuopc"/>
+      <machine name="izumi" compiler="intel" category="nuopc"/>
+    </machines>
+    <options>
+      <option name="wallclock"> 00:40:00 </option>
+    </options>
+  </test>
+  <test compset="CMOM" grid="T62_t016" name="SMS_Vnuopc_Ld5">
+    <machines>
+      <machine name="cheyenne" compiler="intel" category="nuopc"/>
+      <machine name="theia" compiler="intel" category="nuopc"/>
+      <machine name="izumi" compiler="intel" category="nuopc"/>
+    </machines>
+    <options>
+      <option name="wallclock"> 00:40:00 </option>
+    </options>
+  </test>
+  <test compset="CMOM" grid="T62_t016" name="ERS_Vnuopc_Ld5">
+    <machines>
+      <machine name="cheyenne" compiler="intel" category="nuopc"/>
+      <machine name="theia" compiler="intel" category="nuopc"/>
+      <machine name="izumi" compiler="intel" category="nuopc"/>
+    </machines>
+    <options>
+      <option name="wallclock"> 00:40:00 </option>
+    </options>
+  </test>
+  <test compset="CMOM" grid="T62_t016" name="SMS_Vmct_Ld5">
+    <machines>
+      <machine name="cheyenne" compiler="intel" category="mctcheck"/>
+      <machine name="theia" compiler="intel" category="mctcheck"/>
+      <machine name="izumi" compiler="intel" category="mctcheck"/>
+    </machines>
+    <options>
+      <option name="wallclock"> 00:10:00 </option>
+    </options>
+  </test>
+  <test compset="CMOM" grid="T62_t016" name="ERS_Vmct_Ld5">
     <machines>
       <machine name="cheyenne" compiler="intel" category="mctcheck"/>
       <machine name="theia" compiler="intel" category="mctcheck"/>
@@ -425,7 +241,11 @@
     </options>
   </test>
 
-  <test compset="I2000Clm50SpNuopc" grid="f45_f45_mg37" name="ERS_Vnuopc_Ln5" testmods="clm/nuopc_cap">
+  <!-- ======================================= -->
+  <!-- G compsets -->
+  <!-- ======================================= -->
+
+  <test compset="G" grid="T62_g17" name="ERS_Vnuopc_Ld5">
     <machines>
       <machine name="cheyenne" compiler="intel" category="nuopc"/>
       <machine name="theia" compiler="intel" category="nuopc"/>
@@ -435,8 +255,38 @@
       <option name="wallclock"> 00:10:00 </option>
     </options>
   </test>
+  <test compset="GMOM" grid="T62_g016" name="SMS_Vnuopc_Ld5">
+    <machines>
+      <machine name="cheyenne" compiler="intel" category="nuopc"/>
+      <machine name="theia" compiler="intel" category="nuopc"/>
+      <machine name="izumi" compiler="intel" category="nuopc"/>
+    </machines>
+    <options>
+      <option name="wallclock"> 00:10:00 </option>
+    </options>
+  </test>
+  <test compset="GMOM" grid="T62_t016" name="SMS_Vmct_Ld5">
+    <machines>
+      <machine name="cheyenne" compiler="intel" category="mctcheck"/>
+      <machine name="theia" compiler="intel" category="mctcheck"/>
+      <machine name="izumi" compiler="intel" category="mctcheck"/>
+    </machines>
+    <options>
+      <option name="wallclock"> 00:10:00 </option>
+    </options>
+  </test>
+  <test compset="GMOM" grid="T62_t016" name="ERS_Vnuopc_Ld5">
+    <machines>
+      <machine name="cheyenne" compiler="intel" category="nuopc"/>
+      <machine name="theia" compiler="intel" category="nuopc"/>
+      <machine name="izumi" compiler="intel" category="nuopc"/>
+    </machines>
+    <options>
+      <option name="wallclock"> 00:20:00 </option>
+    </options>
+  </test>
 
-  <test compset="I2000Clm50SpNuopc" grid="f45_f45_mg37" name="ERS_Vmct_Ln5" testmods="clm/nuopc_cap">
+  <test compset="GMOM" grid="T62_t016" name="ERS_Vmct_Ld5">
     <machines>
       <machine name="cheyenne" compiler="intel" category="mctcheck"/>
       <machine name="theia" compiler="intel" category="mctcheck"/>
@@ -447,6 +297,120 @@
     </options>
   </test>
 
+  <!-- ======================================= -->
+  <!-- D compsets -->
+  <!-- ======================================= -->
+
+  <test compset="DTEST" grid="T62_g37" name="SMS_Vnuopc_Ld5" testmods="cice/nuopc_cap">
+    <machines>
+      <machine name="cheyenne" compiler="intel" category="nuopc"/>
+      <machine name="theia" compiler="intel" category="nuopc"/>
+      <machine name="izumi" compiler="intel" category="nuopc"/>
+    </machines>
+    <options>
+      <option name="wallclock"> 00:10:00 </option>
+    </options>
+  </test>
+  <test compset="DTEST" grid="T62_g37" name="SMS_Vmct_Ld5" testmods="cice/nuopc_cap">
+    <machines>
+      <machine name="cheyenne" compiler="intel" category="mctcheck"/>
+      <machine name="theia" compiler="intel" category="mctcheck"/>
+      <machine name="izumi" compiler="intel" category="mctcheck"/>
+    </machines>
+    <options>
+      <option name="wallclock"> 00:10:00 </option>
+    </options>
+  </test>
+  <test compset="DTEST" grid="T62_g37" name="ERS_Vnuopc_Ld5" testmods="cice/nuopc_cap">
+    <machines>
+      <machine name="cheyenne" compiler="intel" category="nuopc"/>
+      <machine name="theia" compiler="intel" category="nuopc"/>
+      <machine name="izumi" compiler="intel" category="nuopc"/>
+    </machines>
+    <options>
+      <option name="wallclock"> 00:10:00 </option>
+    </options>
+  </test>
+  <test compset="DTEST" grid="T62_g37" name="ERS_Vmct_Ld5" testmods="cice/nuopc_cap">
+    <machines>
+      <machine name="cheyenne" compiler="intel" category="mctcheck"/>
+      <machine name="theia" compiler="intel" category="mctcheck"/>
+      <machine name="izumi" compiler="intel" category="mctcheck"/>
+    </machines>
+    <options>
+      <option name="wallclock"> 00:10:00 </option>
+    </options>
+  </test>
+
+  <!-- ======================================= -->
+  <!-- F compsets -->
+  <!-- ======================================= -->
+
+  <test compset="F2000Nuopc" grid="f19_f19_mg17" name="SMS_Vnuopc_Ln5" testmods="cam/nuopc_cap">
+    <machines>
+      <machine name="cheyenne" compiler="intel" category="nuopc"/>
+      <machine name="theia" compiler="intel" category="nuopc"/>
+      <machine name="izumi" compiler="intel" category="nuopc"/>
+    </machines>
+    <options>
+      <option name="wallclock"> 00:10:00 </option>
+    </options>
+  </test>
+  <test compset="F2000Nuopc" grid="f19_f19_mg17" name="SMS_Vmct_Ln5" testmods="cam/nuopc_cap">
+    <machines>
+      <machine name="cheyenne" compiler="intel" category="mctcheck"/>
+      <machine name="theia" compiler="intel" category="mctcheck"/>
+      <machine name="izumi" compiler="intel" category="mctcheck"/>
+    </machines>
+    <options>
+      <option name="wallclock"> 00:10:00 </option>
+    </options>
+  </test>
+  <test compset="F2000Nuopc" grid="f19_f19_mg17" name="ERS_Vnuopc_Ln5" testmods="cam/nuopc_cap">
+    <machines>
+      <machine name="cheyenne" compiler="intel" category="nuopc"/>
+      <machine name="theia" compiler="intel" category="nuopc"/>
+      <machine name="izumi" compiler="intel" category="nuopc"/>
+    </machines>
+    <options>
+      <option name="wallclock"> 00:10:00 </option>
+    </options>
+  </test>
+  <test compset="F2000Nuopc" grid="f19_f19_mg17" name="ERS_Vmct_Ln5" testmods="cam/nuopc_cap">
+    <machines>
+      <machine name="cheyenne" compiler="intel" category="mctcheck"/>
+      <machine name="theia" compiler="intel" category="mctcheck"/>
+      <machine name="izumi" compiler="intel" category="mctcheck"/>
+    </machines>
+    <options>
+      <option name="wallclock"> 00:10:00 </option>
+    </options>
+  </test>
+
+  <!-- ======================================= -->
+  <!-- Q compsets -->
+  <!-- ======================================= -->
+
+  <test compset="QPC4" grid="ne16_ne16_mg17" name="SMS_Vnuopc_Ln5" testmods="cam/nuopc_cap">
+    <machines>
+      <machine name="cheyenne" compiler="intel" category="nuopc"/>
+      <machine name="theia" compiler="intel" category="nuopc"/>
+      <machine name="izumi" compiler="intel" category="nuopc"/>
+    </machines>
+    <options>
+      <option name="wallclock"> 00:10:00 </option>
+    </options>
+  </test>
+  <test compset="QPC4" grid="ne16_ne16_mg17" name="SMS_Vmct_Ln5" testmods="cam/nuopc_cap">
+    <machines>
+      <machine name="cheyenne" compiler="intel" category="mctcheck"/>
+      <machine name="theia" compiler="intel" category="mctcheck"/>
+      <machine name="izumi" compiler="intel" category="mctcheck"/>
+    </machines>
+    <options>
+      <option name="wallclock"> 00:10:00 </option>
+    </options>
+  </test>
   <test compset="QPC4" grid="ne16_ne16_mg17" name="ERS_Vnuopc_Ln5" testmods="cam/nuopc_cap">
     <machines>
       <machine name="cheyenne" compiler="intel" category="nuopc"/>
@@ -457,7 +421,6 @@
       <option name="wallclock"> 00:10:00 </option>
     </options>
   </test>
-
   <test compset="QPC4" grid="ne16_ne16_mg17" name="ERS_Vmct_Ln5" testmods="cam/nuopc_cap">
     <machines>
       <machine name="cheyenne" compiler="intel" category="mctcheck"/>
@@ -468,5 +431,61 @@
       <option name="wallclock"> 00:10:00 </option>
     </options>
   </test>
+
+  <!-- ======================================= -->
+  <!-- I compsets -->
+  <!-- ======================================= -->
+
+  <test compset="I2000Clm50SpRsGs" grid="f19_f19_mg17" name="ERS_Vnuopc_Ln11" testmods="clm/default">
+    <machines>
+      <machine name="cheyenne" compiler="intel" category="nuopc"/>
+      <machine name="theia" compiler="intel" category="nuopc"/>
+      <machine name="izumi" compiler="intel" category="nuopc"/>
+    </machines>
+    <options>
+      <option name="wallclock"> 00:10:00 </option>
+    </options>
+  </test>
+  <test compset="I2000Clm50SpGs" grid="f19_f19_mg17" name="ERS_Vnuopc_Ln11" testmods="clm/default">
+    <machines>
+      <machine name="cheyenne" compiler="intel" category="nuopc"/>
+      <machine name="theia" compiler="intel" category="nuopc"/>
+      <machine name="izumi" compiler="intel" category="nuopc"/>
+    </machines>
+    <options>
+      <option name="wallclock"> 00:10:00 </option>
+    </options>
+  </test>
+  <test compset="I2000Clm50SpRtmGs" grid="f45_f45_mg37" name="SMS_Vnuopc_Ln11" testmods="clm/default">
+    <machines>
+      <machine name="cheyenne" compiler="intel" category="nuopc"/>
+      <machine name="theia" compiler="intel" category="nuopc"/>
+      <machine name="izumi" compiler="intel" category="nuopc"/>
+    </machines>
+    <options>
+      <option name="wallclock"> 00:10:00 </option>
+    </options>
+  </test>
+
+  <test name="SMS_D_Ly1" grid="f09_g17_gl4" compset="T1850G">
+    <machines>
+      <machine name="cheyenne" compiler="gnu" category="nuopc">
+        <options>
+          <option name="wallclock">0:20</option>
+        </options>
+      </machine>
+    </machines>
+  </test>
+  <test name="ERS_Ly3" grid="f09_g17_gl4" compset="T1850G">
+    <machines>
+      <machine name="cheyenne" compiler="gnu" category="nuopc">
+        <options>
+          <option name="wallclock">0:20</option>
+        </options>
+      </machine>
+    </machines>
+  </test>
+
+
 
 </testlist>

--- a/cime_config/testdefs/testlist_drv.xml
+++ b/cime_config/testdefs/testlist_drv.xml
@@ -145,7 +145,7 @@
   <!-- B compsets -->
   <!-- ======================================= -->
 
-  <test compset="BMOM" grid="f09_t016" name="SMS_Vnuopc_Ld5" testmods="allactive/nuopc_cap_io">
+  <test compset="BMOM" grid="f19_g16" name="SMS_Vnuopc_Ld5" testmods="allactive/nuopc_cap_io">
     <machines>
       <machine name="cheyenne" compiler="intel" category="nuopc"/>
       <machine name="theia" compiler="intel" category="nuopc"/>
@@ -155,7 +155,7 @@
       <option name="wallclock"> 00:40:00 </option>
     </options>
   </test>
-  <test compset="BMOM" grid="f09_t016" name="SMS_Vmct_Ld5" testmods="allactive/nuopc_cap_io">
+  <test compset="BMOM" grid="f19_g16" name="SMS_Vmct_Ld5" testmods="allactive/nuopc_cap_io">
     <machines>
       <machine name="cheyenne" compiler="intel" category="mctcheck"/>
       <machine name="theia" compiler="intel" category="mctcheck"/>
@@ -165,7 +165,7 @@
       <option name="wallclock"> 00:40:00 </option>
     </options>
   </test>
-  <test compset="BMOM" grid="f09_t016" name="ERR_Vnuopc_Ld5" testmods="allactive/nuopc_cap_io">
+  <test compset="BMOM" grid="f19_g16" name="ERR_Vnuopc_Ld5" testmods="allactive/nuopc_cap_io">
     <machines>
       <machine name="cheyenne" compiler="intel" category="nuopc"/>
       <machine name="theia" compiler="intel" category="nuopc"/>
@@ -175,7 +175,7 @@
       <option name="wallclock"> 00:40:00 </option>
     </options>
   </test>
-  <test compset="BMOM" grid="f09_t016" name="ERR_Vmct_Ld5" testmods="allactive/nuopc_cap_io">
+  <test compset="BMOM" grid="f19_g16" name="ERR_Vmct_Ld5" testmods="allactive/nuopc_cap_io">
     <machines>
       <machine name="cheyenne" compiler="intel" category="mctcheck"/>
       <machine name="theia" compiler="intel" category="mctcheck"/>
@@ -200,7 +200,7 @@
       <option name="wallclock"> 00:40:00 </option>
     </options>
   </test>
-  <test compset="CMOM" grid="T62_t016" name="SMS_Vnuopc_Ld5">
+  <test compset="CMOM" grid="T62_t061" name="SMS_Vnuopc_Ld5">
     <machines>
       <machine name="cheyenne" compiler="intel" category="nuopc"/>
       <machine name="theia" compiler="intel" category="nuopc"/>
@@ -210,7 +210,7 @@
       <option name="wallclock"> 00:40:00 </option>
     </options>
   </test>
-  <test compset="CMOM" grid="T62_t016" name="ERS_Vnuopc_Ld5">
+  <test compset="CMOM" grid="T62_t061" name="ERS_Vnuopc_Ld5">
     <machines>
       <machine name="cheyenne" compiler="intel" category="nuopc"/>
       <machine name="theia" compiler="intel" category="nuopc"/>
@@ -220,7 +220,7 @@
       <option name="wallclock"> 00:40:00 </option>
     </options>
   </test>
-  <test compset="CMOM" grid="T62_t016" name="SMS_Vmct_Ld5">
+  <test compset="CMOM" grid="T62_t061" name="SMS_Vmct_Ld5">
     <machines>
       <machine name="cheyenne" compiler="intel" category="mctcheck"/>
       <machine name="theia" compiler="intel" category="mctcheck"/>
@@ -230,7 +230,7 @@
       <option name="wallclock"> 00:10:00 </option>
     </options>
   </test>
-  <test compset="CMOM" grid="T62_t016" name="ERS_Vmct_Ld5">
+  <test compset="CMOM" grid="T62_t061" name="ERS_Vmct_Ld5">
     <machines>
       <machine name="cheyenne" compiler="intel" category="mctcheck"/>
       <machine name="theia" compiler="intel" category="mctcheck"/>
@@ -255,7 +255,7 @@
       <option name="wallclock"> 00:10:00 </option>
     </options>
   </test>
-  <test compset="GMOM" grid="T62_g016" name="SMS_Vnuopc_Ld5">
+  <test compset="GMOM" grid="T62_t061" name="SMS_Vnuopc_Ld5">
     <machines>
       <machine name="cheyenne" compiler="intel" category="nuopc"/>
       <machine name="theia" compiler="intel" category="nuopc"/>
@@ -265,7 +265,7 @@
       <option name="wallclock"> 00:10:00 </option>
     </options>
   </test>
-  <test compset="GMOM" grid="T62_t016" name="SMS_Vmct_Ld5">
+  <test compset="GMOM" grid="T62_t061" name="SMS_Vmct_Ld5">
     <machines>
       <machine name="cheyenne" compiler="intel" category="mctcheck"/>
       <machine name="theia" compiler="intel" category="mctcheck"/>
@@ -275,7 +275,7 @@
       <option name="wallclock"> 00:10:00 </option>
     </options>
   </test>
-  <test compset="GMOM" grid="T62_t016" name="ERS_Vnuopc_Ld5">
+  <test compset="GMOM" grid="T62_t061" name="ERS_Vnuopc_Ld5">
     <machines>
       <machine name="cheyenne" compiler="intel" category="nuopc"/>
       <machine name="theia" compiler="intel" category="nuopc"/>
@@ -286,7 +286,7 @@
     </options>
   </test>
 
-  <test compset="GMOM" grid="T62_t016" name="ERS_Vmct_Ld5">
+  <test compset="GMOM" grid="T62_t061" name="ERS_Vmct_Ld5">
     <machines>
       <machine name="cheyenne" compiler="intel" category="mctcheck"/>
       <machine name="theia" compiler="intel" category="mctcheck"/>
@@ -467,18 +467,22 @@
     </options>
   </test>
 
-  <test name="SMS_D_Ly1" grid="f09_g17_gl4" compset="T1850G">
+  <!-- ======================================= -->
+  <!-- I compsets -->
+  <!-- ======================================= -->
+
+  <test name="SMS_D_Ly1_Vnuopc" grid="f09_g17_gl4" compset="T1850G">
     <machines>
-      <machine name="cheyenne" compiler="gnu" category="nuopc">
+      <machine name="cheyenne" compiler="intel" category="nuopc">
         <options>
           <option name="wallclock">0:20</option>
         </options>
       </machine>
     </machines>
   </test>
-  <test name="ERS_Ly3" grid="f09_g17_gl4" compset="T1850G">
+  <test name="ERS_Ly3_Vnuopc" grid="f09_g17_gl4" compset="T1850G">
     <machines>
-      <machine name="cheyenne" compiler="gnu" category="nuopc">
+      <machine name="cheyenne" compiler="intel" category="nuopc">
         <options>
           <option name="wallclock">0:20</option>
         </options>


### PR DESCRIPTION
Change Description: expanded new testlist for CESM components 

This PR brings expanded testing capability of the NUOPC caps in CESM components and
and updated app_cesm-cmeps to point to updated component hashses

Testing Completed: testlist_drv.xml
- compared to nov03 baselines and generated nov08 baselines 
- the following tests had baseline differences compared to nov03
```
ERR_Vnuopc_Ld5.f19_g16.BMOM.cheyenne_intel.allactive-nuopc_cap_io
ERS_Vnuopc_Ld5.T62_g17.C.cheyenne_intel
ERS_Vnuopc_Ld5.T62_g17.G.cheyenne_intel
ERS_Vnuopc_Ld5.T62_t061.CMOM.cheyenne_intel
ERS_Vnuopc_Ld5.T62_t061.GMOM.cheyenne_intel
ERS_Vnuopc_Ln11.f19_f19_mg17.I2000Clm50SpGs.cheyenne_intel.clm-default
ERS_Vnuopc_Ln11.f19_f19_mg17.I2000Clm50SpRsGs.cheyenne_intel.clm-default
ERS_Vnuopc_Ln5.f19_f19_mg17.F2000Nuopc.cheyenne_intel.cam-nuopc_cap
SMS_D_Ly1_Vnuopc.f09_g17_gl4.T1850G.cheyenne_intel
SMS_Vnuopc_Ld5.T62_t061.CMOM.cheyenne_intel
SMS_Vnuopc_Ld5.T62_t061.GMOM.cheyenne_intel
SMS_Vnuopc_Ld5.f19_g16.BMOM.cheyenne_intel.allactive-nuopc_cap_io
SMS_Vnuopc_Ln11.f45_f45_mg37.I2000Clm50SpRtmGs.cheyenne_intel.clm-default
SMS_Vnuopc_Ln5.f19_f19_mg17.F2000Nuopc.cheyenne_intel.cam-nuopc_cap
```
- the following tests did not have baselines (new baselines were created in nov08)
```
ERS_Vnuopc_Ld5.T62_g17.C.cheyenne_intel
ERS_Vnuopc_Ld5.T62_g17.G.cheyenne_intel
ERS_Vnuopc_Ld5.T62_t061.CMOM.cheyenne_intel
ERS_Vnuopc_Ld5.T62_t061.GMOM.cheyenne_intel
ERS_Vnuopc_Ln11.f19_f19_mg17.I2000Clm50SpGs.cheyenne_intel.clm-default
ERS_Vnuopc_Ln11.f19_f19_mg17.I2000Clm50SpRsGs.cheyenne_intel.clm-default
SMS_D_Ly1_Vnuopc.f09_g17_gl4.T1850G.cheyenne_intel
SMS_Vnuopc_Ld5.T62_t061.CMOM.cheyenne_intel
SMS_Vnuopc_Ld5.T62_t061.GMOM.cheyenne_intel
SMS_Vnuopc_Ln11.f45_f45_mg37.I2000Clm50SpRtmGs.cheyenne_intel.clm-default
```
- the following tests had failures that need to be fixed in upcoming commits:

```
FAIL ERS_Ly3_Vnuopc.f09_g17_gl4.T1850G.cheyenne_intel RUN time=46

     the problem is the following error statement
src/addon/NUOPC/src/NUOPC_Base.F90:869 Invalid argument  - setClock timeStep=31536000s is not a divisor of runDuration=31534308s
```
```
FAIL ERS_Vnuopc_Ld5.T62_g17.C.cheyenne_intel COMPARE_base_rest
FAIL ERS_Vnuopc_Ld5.T62_g17.G.cheyenne_intel COMPARE_base_rest

the problem is restarts failures for time_bound and time variables
ERS_Vnuopc_Ld5.T62_g17.C.cheyenne_intel.C.nov08.pop.h.once.nc.base.cprnc.out: RMS time_bound                       2.9376E+00            NORMALIZED  8.0141E-03
ERS_Vnuopc_Ld5.T62_g17.C.cheyenne_intel.C.nov08.pop.h.once.nc.base.cprnc.out: RMS time                             2.9583E+00            NORMALIZED  8.0705E-03
```

 ```
FAIL ERS_Vnuopc_Ln11.f19_f19_mg17.I2000Clm50SpGs.cheyenne_intel.clm-default COMPARE_base_rest

the problem is coupler restart differences in the following fields:
RMS lndExp_Flrr_volr                 1.4216E-05            NORMALIZED  6.4851E-01
RMS lndExp_Flrr_volrmch              1.9956E-06            NORMALIZED  2.0444E+00
RMS rofImp_Flrr_volr                 1.5142E-05            NORMALIZED  6.0736E-01
RMS rofImp_Flrr_volrmch              2.2766E-06            NORMALIZED  1.9957E+00
RMS rofImp_Forr_rofl                 8.4380E-06            NORMALIZED  2.6782E+00
RMS rofExp_Flrl_irrig                8.4414E-06            NORMALIZED  2.8065E+00
```
(Minimum testing: CIME_DRIVER=nuopc scripts_regression_tests.py) - did not run this test since almost no CMEPS files were changed

CIME HASH: 0323270cb1
**app_cesm-cmeps HASH: c96ea3f**


