### PR TITLE
move orbital calculations to the noupc caps

### DIFF
--- a/cime_config/buildnml
+++ b/cime_config/buildnml
@@ -56,6 +56,10 @@ def _create_drv_namelists(case, infile, confdir, nmlgen, files):
     config['COMP_ROF'] = case.get_value("COMP_ROF")
     config['COMP_WAV'] = case.get_value("COMP_WAV")
 
+    if ((case.get_value("COMP_ROF") == 'mosart' and case.get_value("MOSART_MODE") == 'NULL') or
+        (case.get_value("COMP_ROF") == 'rtm' and case.get_value("RTM_MODE") == 'NULL') or
+        (case.get_value("ROF_GRID") == 'null')):
+        config['ROF_MODE'] = 'null'
 
     if case.get_value('RUN_TYPE') == 'startup':
         config['run_type'] = 'startup'
@@ -229,6 +233,10 @@ def _create_drv_namelists(case, infile, confdir, nmlgen, files):
             if item != 'esp': #no esp xcpl component
                 if case.get_value(item.upper() + "_NX") == "0" and case.get_value(item.upper() + "_NY") == "0":
                     skip_comps.append(item.upper)
+    # special case - mosart or rtm in NULL mode
+    if (case.get_value("COMP_ROF") == 'mosart' or case.get_value("COMP_ROF") == 'rtm'):
+        if (case.get_value("MOSART_MODE") == 'NULL' or case.get_value("RTM_MODE") == 'NULL'):
+            skip_comps.append('ROF')
 
     logger.info("Writing nuopc_runseq will skip components {}".format(skip_comps))
 

--- a/cime_config/config_component.xml
+++ b/cime_config/config_component.xml
@@ -1914,7 +1914,7 @@
 
   <entry id="PIO_VERSION">
     <type>integer</type>
-    <default_value>1</default_value>
+    <default_value>2</default_value>
     <valid_values>1,2</valid_values>
     <group>build_macros</group>
     <file>env_build.xml</file>

--- a/cime_config/config_component.xml
+++ b/cime_config/config_component.xml
@@ -1914,7 +1914,7 @@
 
   <entry id="PIO_VERSION">
     <type>integer</type>
-    <default_value>2</default_value>
+    <default_value>1</default_value>
     <valid_values>1,2</valid_values>
     <group>build_macros</group>
     <file>env_build.xml</file>

--- a/cime_config/namelist_definition_drv.xml
+++ b/cime_config/namelist_definition_drv.xml
@@ -152,160 +152,6 @@
     </values>
   </entry>
 
-  <entry id="orb_mode">
-    <type>char</type>
-    <category>orbital</category>
-    <group>DRIVER_attributes</group>
-    <valid_values>fixed_year,variable_year,fixed_parameters</valid_values>
-    <desc>
-      orbital model setting.  this sets how the orbital mode will be
-      configured.
-      "fixed_year" uses the orb_iyear and other orb inputs are ignored.  In
-      this mode, the orbital parameters are constant and based on the year.
-      "variable_year" uses the orb_iyear and orb_iyear_align.  In this mode,
-      the orbital parameters vary as the model year advances and the model
-      year orb_iyear_align has the equivalent orbital year of orb_iyear.
-      "fixed_parameters" uses the orb_eccen, orb_mvelp, and orb_obliq to set
-      the orbital parameters which then remain constant through the model
-      integration. [fixed_year, variable_year, fixed_parameters]  (default: 'fixed_year'.)
-    </desc>
-    <values>
-      <value>fixed_year</value>
-      <value iyear='HIST'>variable_year</value>
-    </values>
-  </entry>
-
-  <entry id="orb_iyear_align">
-    <type>integer</type>
-    <category>orbital</category>
-    <group>DRIVER_attributes</group>
-    <desc>
-      model year associated with orb_iyear when orb_mode is variable_year. (default: 1990)
-    </desc>
-    <values>
-      <value>1990</value>
-      <value iyear="1850">1850</value>
-      <value iyear="2000">2000</value>
-      <value iyear='HIST'>1850</value>
-    </values>
-  </entry>
-
-  <entry id="orb_iyear">
-    <type>integer</type>
-    <category>orbital</category>
-    <group>DRIVER_attributes</group>
-    <desc>
-      year of orbit, used when orb_mode is fixed_year or variable_year. (default: 1990)
-    </desc>
-    <values>
-      <value>1990</value>
-      <value iyear="1850">1850</value>
-      <value iyear="2000">2000</value>
-      <value iyear='HIST'>1850</value>
-    </values>
-  </entry>
-
-  <entry id="orb_eccen">
-    <type>real</type>
-    <category>orbital</category>
-    <group>DRIVER_attributes</group>
-    <desc>
-      eccentricity of orbit, used when orb_mode is fixed_parameters.
-      default: SHR_ORB_UNDEF_REAL (1.e36) (Not currently used in build-namelist)
-    </desc>
-    <values>
-      <value>1.e36</value>
-    </values>
-  </entry>
-
-  <entry id="orb_mvelp">
-    <type>real</type>
-    <category>orbital</category>
-    <group>DRIVER_attributes</group>
-    <desc>
-      location of vernal equinox in longitude degrees, used when orb_mode is fixed_parameters.
-      default: SHR_ORB_UNDEF_REAL (1.e36)(Not currently used in build-namelist)
-    </desc>
-    <values>
-      <value>1.e36</value>
-    </values>
-  </entry>
-
-  <entry id="orb_obliq">
-    <type>real</type>
-    <category>orbital</category>
-    <group>DRIVER_attributes</group>
-    <desc>
-      obliquity of orbit in degrees, used when orb_mode is fixed_parameters.
-      default: SHR_ORB_UNDEF_REAL (1.e36) (Not currently used in build-namelist)
-    </desc>
-    <values>
-      <value>1.e36</value>
-    </values>
-  </entry>
-
-  <entry id="wv_sat_scheme">
-    <type>char</type>
-    <category>wv_sat</category>
-    <group>DRIVER_attributes</group>
-    <valid_values>GoffGratch,MurphyKoop,Bolton,Flatau</valid_values>
-    <desc>
-      Type of water vapor saturation vapor pressure scheme employed. 'GoffGratch' for
-      Goff and Gratch (1946); 'MurphyKoop' for Murphy and Koop (2005); 'Bolton' for
-      Bolton (1980); 'Flatau' for Flatau, Walko, and Cotton (1992).
-      Default: GoffGratch
-    </desc>
-    <values>
-      <value>GoffGratch</value>
-    </values>
-  </entry>
-
-  <entry id="wv_sat_transition_start">
-    <type>real</type>
-    <category>wv_sat</category>
-    <group>DRIVER_attributes</group>
-    <desc>
-      Width of the liquid-ice transition range in mixed-phase water saturation vapor
-      pressure calculations. The range always ends at 0 degrees Celsius, so this
-      variable only affects the start of the transition.
-      Default: 20K
-      WARNING: CAM is tuned to the default value of this variable. Because it affects
-      so many different parameterizations, changes to this variable may require a
-      significant retuning of CAM's cloud physics to give reasonable results.
-    </desc>
-    <values>
-      <value>20.0D0</value>
-    </values>
-  </entry>
-
-  <entry id="wv_sat_use_tables">
-    <type>logical</type>
-    <category>wv_sat</category>
-    <group>DRIVER_attributes</group>
-    <desc>
-      Whether or not to produce lookup tables at init time to use as a cache for
-      saturation vapor pressure.
-      Default: .false.
-    </desc>
-    <values>
-      <value>.false.</value>
-    </values>
-  </entry>
-
-  <entry id="wv_sat_table_spacing">
-    <type>real</type>
-    <category>wv_sat</category>
-    <group>DRIVER_attributes</group>
-    <desc>
-      Temperature resolution of saturation vapor pressure lookup tables in Kelvin.
-      (This is only used if wv_sat_use_tables is .true.)
-      Default: 1.0
-    </desc>
-    <values>
-      <value>1.0D0</value>
-    </values>
-  </entry>
-
   <entry id="wall_time_limit">
     <type>real</type>
     <category>control</category>
@@ -456,6 +302,172 @@
       <value>ATM OCN ICE LND ROF GLC WAV MED</value>
     </values>
   </entry>
+
+  <!-- =========================================== -->
+  <!-- DRIVER saturation vapor attributes          -->
+  <!-- =========================================== -->
+
+  <entry id="wv_sat_scheme">
+    <type>char</type>
+    <category>wv_sat</category>
+    <group>DRIVER_attributes</group>
+    <valid_values>GoffGratch,MurphyKoop,Bolton,Flatau</valid_values>
+    <desc>
+      Type of water vapor saturation vapor pressure scheme employed. 'GoffGratch' for
+      Goff and Gratch (1946); 'MurphyKoop' for Murphy and Koop (2005); 'Bolton' for
+      Bolton (1980); 'Flatau' for Flatau, Walko, and Cotton (1992).
+      Default: GoffGratch
+    </desc>
+    <values>
+      <value>GoffGratch</value>
+    </values>
+  </entry>
+
+  <entry id="wv_sat_transition_start">
+    <type>real</type>
+    <category>wv_sat</category>
+    <group>DRIVER_attributes</group>
+    <desc>
+      Width of the liquid-ice transition range in mixed-phase water saturation vapor
+      pressure calculations. The range always ends at 0 degrees Celsius, so this
+      variable only affects the start of the transition.
+      Default: 20K
+      WARNING: CAM is tuned to the default value of this variable. Because it affects
+      so many different parameterizations, changes to this variable may require a
+      significant retuning of CAM's cloud physics to give reasonable results.
+    </desc>
+    <values>
+      <value>20.0D0</value>
+    </values>
+  </entry>
+
+  <entry id="wv_sat_use_tables">
+    <type>logical</type>
+    <category>wv_sat</category>
+    <group>DRIVER_attributes</group>
+    <desc>
+      Whether or not to produce lookup tables at init time to use as a cache for
+      saturation vapor pressure.
+      Default: .false.
+    </desc>
+    <values>
+      <value>.false.</value>
+    </values>
+  </entry>
+
+  <entry id="wv_sat_table_spacing">
+    <type>real</type>
+    <category>wv_sat</category>
+    <group>DRIVER_attributes</group>
+    <desc>
+      Temperature resolution of saturation vapor pressure lookup tables in Kelvin.
+      (This is only used if wv_sat_use_tables is .true.)
+      Default: 1.0
+    </desc>
+    <values>
+      <value>1.0D0</value>
+    </values>
+  </entry>
+
+  <!-- =========================================== -->
+  <!-- All components orbital attributes           -->
+  <!-- =========================================== -->
+
+  <entry id="orb_mode">
+    <type>char</type>
+    <category>orbital</category>
+    <group>ALLCOMP_attributes</group>
+    <valid_values>fixed_year,variable_year,fixed_parameters</valid_values>
+    <desc>
+      orbital model setting.  this sets how the orbital mode will be
+      configured.
+      "fixed_year" uses the orb_iyear and other orb inputs are ignored.  In
+      this mode, the orbital parameters are constant and based on the year.
+      "variable_year" uses the orb_iyear and orb_iyear_align.  In this mode,
+      the orbital parameters vary as the model year advances and the model
+      year orb_iyear_align has the equivalent orbital year of orb_iyear.
+      "fixed_parameters" uses the orb_eccen, orb_mvelp, and orb_obliq to set
+      the orbital parameters which then remain constant through the model
+      integration. [fixed_year, variable_year, fixed_parameters]  (default: 'fixed_year'.)
+    </desc>
+    <values>
+      <value>fixed_year</value>
+      <value iyear='HIST'>variable_year</value>
+    </values>
+  </entry>
+
+  <entry id="orb_iyear_align">
+    <type>integer</type>
+    <category>orbital</category>
+    <group>ALLCOMP_attributes</group>
+    <desc>
+      model year associated with orb_iyear when orb_mode is variable_year. (default: 1990)
+    </desc>
+    <values>
+      <value>1990</value>
+      <value iyear="1850">1850</value>
+      <value iyear="2000">2000</value>
+      <value iyear='HIST'>1850</value>
+    </values>
+  </entry>
+
+  <entry id="orb_iyear">
+    <type>integer</type>
+    <category>orbital</category>
+    <group>ALLCOMP_attributes</group>
+    <desc>
+      year of orbit, used when orb_mode is fixed_year or variable_year. (default: 1990)
+    </desc>
+    <values>
+      <value>1990</value>
+      <value iyear="1850">1850</value>
+      <value iyear="2000">2000</value>
+      <value iyear='HIST'>1850</value>
+    </values>
+  </entry>
+
+  <entry id="orb_eccen">
+    <type>real</type>
+    <category>orbital</category>
+    <group>ALLCOMP_attributes</group>
+    <desc>
+      eccentricity of orbit, used when orb_mode is fixed_parameters.
+      default: SHR_ORB_UNDEF_REAL (1.e36) (Not currently used in build-namelist)
+    </desc>
+    <values>
+      <value>1.e36</value>
+    </values>
+  </entry>
+
+  <entry id="orb_mvelp">
+    <type>real</type>
+    <category>orbital</category>
+    <group>ALLCOMP_attributes</group>
+    <desc>
+      location of vernal equinox in longitude degrees, used when orb_mode is fixed_parameters.
+      default: SHR_ORB_UNDEF_REAL (1.e36)(Not currently used in build-namelist)
+    </desc>
+    <values>
+      <value>1.e36</value>
+    </values>
+  </entry>
+
+  <entry id="orb_obliq">
+    <type>real</type>
+    <category>orbital</category>
+    <group>ALLCOMP_attributes</group>
+    <desc>
+      obliquity of orbit in degrees, used when orb_mode is fixed_parameters.
+      default: SHR_ORB_UNDEF_REAL (1.e36) (Not currently used in build-namelist)
+    </desc>
+    <values>
+      <value>1.e36</value>
+    </values>
+  </entry>
+
+  <!-- =========================================== -->
+  <!-- All component general attributes            -->
+  <!-- =========================================== -->
 
   <entry id="MED_model">
     <type>char</type>
@@ -1588,18 +1600,6 @@
     </desc>
     <values>
       <value>3</value>
-    </values>
-  </entry>
-
-  <entry id="ScalarFieldIdxValidGlcInput">
-    <type>integer</type>
-    <category>expdef</category>
-    <group>ALLCOMP_attributes</group>
-    <desc>
-      index of valid glc input from mediator
-    </desc>
-    <values>
-      <value>4</value>
     </values>
   </entry>
 

--- a/cime_config/namelist_definition_drv.xml
+++ b/cime_config/namelist_definition_drv.xml
@@ -495,6 +495,7 @@
     <group>ALLCOMP_attributes</group>
     <values>
       <value>$COMP_ROF</value>
+      <value ROF_MODE='null'>srof</value>
     </values>
   </entry>
   <entry id="LND_model" modify_via_xml="COMP_LND">

--- a/cime_config/runseq/driver_config.py
+++ b/cime_config/runseq/driver_config.py
@@ -153,11 +153,13 @@ class DriverConfig(dict):
             if_prognostic = False
             med_to_rof = if_prognostic
         else:
-            # this is active runoff - if clm is active check the accelerated spinup mode flag
-            # otherwise if clm is not active then assume data lnd for now
-            if (case.get_value("COMP_LND") == 'clm'):
-                if (case.get_value("CLM_ACCELERATED_SPINUP") == 'on'):
-                    run_rof = False
+            # this is active runoff - determine if the mode or the grid is null - and in that case
+            # remove all interactions with rof from the run sequence
+            if ((case.get_value("COMP_ROF") == 'mosart' and case.get_value("MOSART_MODE") == 'NULL') or
+                (case.get_value("COMP_ROF") == 'rtm' and case.get_value("RTM_MODE") == 'NULL') or
+                (case.get_value("ROF_GRID") == 'null')):
+                run_rof = False
+                med_to_rof = False
 
         return (run_rof, med_to_rof, coupling_times["rof_cpl_dt"])
 

--- a/drivers/cime/esm.F90
+++ b/drivers/cime/esm.F90
@@ -240,7 +240,7 @@ contains
   subroutine SetRunSequence(driver, rc)
 
     use ESMF                  , only : ESMF_GridComp, ESMF_LogWrite, ESMF_SUCCESS, ESMF_LOGMSG_INFO
-    use ESMF                  , only : ESMF_Time, ESMF_TimeInterval, ESMF_Config
+    use ESMF                  , only : ESMF_Config
     use ESMF                  , only : ESMF_GridCompGet, ESMF_ConfigCreate
     use ESMF                  , only : ESMF_ConfigLoadFile
     use NUOPC                 , only : NUOPC_FreeFormat, NUOPC_FreeFormatDestroy
@@ -511,7 +511,6 @@ contains
     use ESMF             , only : ESMF_RC_NOT_VALID
     use ESMF             , only : ESMF_GridCompIsPetLocal, ESMF_VMBroadcast
     use NUOPC            , only : NUOPC_CompAttributeGet, NUOPC_CompAttributeSet, NUOPC_CompAttributeAdd
-    use shr_orb_mod      , only : shr_orb_params, SHR_ORB_UNDEF_INT, SHR_ORB_UNDEF_REAL
     use shr_assert_mod   , only : shr_assert_in_domain
     use shr_const_mod    , only : shr_const_tkfrz, shr_const_tktrip
     use shr_const_mod    , only : shr_const_mwwv, shr_const_mwdair
@@ -529,28 +528,12 @@ contains
     integer             , intent(out)   :: rc                 ! return code
 
     ! local variables
-    type(ESMF_Clock)             :: clock
-    type(ESMF_Time)              :: currTime
     character(len=CL)            :: errstring
     character(len=CL)            :: cvalue
     logical                      :: reprosum_use_ddpdd    ! setup reprosum, use ddpdd
     real(R8)                     :: reprosum_diffmax      ! setup reprosum, set rel_diff_max
     logical                      :: reprosum_recompute    ! setup reprosum, recompute if tolerance exceeded
-    integer                      :: year                  ! Current date (YYYY)
     character(LEN=CS)            :: tfreeze_option        ! Freezing point calculation
-    character(len=CL)            :: orb_mode              ! orbital mode
-    integer                      :: orb_iyear             ! orbital year
-    integer                      :: orb_iyear_align       ! associated with model year
-    integer                      :: orb_cyear             ! orbital year for current orbital computation
-    integer                      :: orb_nyear             ! orbital year associated with currrent model year
-    integer                      :: orbitmp(4)            ! array for integer parameter broadcast
-    real(R8)                     :: orbrtmp(6)            ! array for real parameter broadcast
-    real(R8)                     :: orb_eccen             ! orbital eccentricity
-    real(R8)                     :: orb_obliq             ! obliquity in degrees
-    real(R8)                     :: orb_mvelp             ! moving vernal equinox long
-    real(R8)                     :: orb_obliqr            ! Earths obliquity in rad
-    real(R8)                     :: orb_lambm0            ! Mean long of perihelion at vernal equinox (radians)
-    real(R8)                     :: orb_mvelpp            ! moving vernal equinox long
     real(R8)                     :: wall_time_limit       ! wall time limit in hours
     integer                      :: glc_nec               ! number of elevation classes in the land component for lnd->glc
     logical                      :: single_column         ! scm mode logical
@@ -571,9 +554,6 @@ contains
     integer          , parameter :: ens1=1                ! use first instance of ensemble only
     integer          , parameter :: fix1=1                ! temporary hard-coding to first ensemble, needs to be fixed
     real(R8)         , parameter :: epsilo = shr_const_mwwv/shr_const_mwdair
-    character(len=*) , parameter :: orb_fixed_year       = 'fixed_year'
-    character(len=*) , parameter :: orb_variable_year    = 'variable_year'
-    character(len=*) , parameter :: orb_fixed_parameters = 'fixed_parameters'
     character(len=*) , parameter :: subname = '(InitAttributes)'
     !----------------------------------------------------------
 
@@ -609,134 +589,12 @@ contains
 
     call shr_frz_freezetemp_init(tfreeze_option, mastertask)
 
-    !----------------------------------------------------------
-    ! Initialize orbital related values
-    !----------------------------------------------------------
-
-    call NUOPC_CompAttributeGet(driver, name="orb_mode", value=cvalue, rc=rc)
-    if (chkerr(rc,__LINE__,u_FILE_u)) return
-    read(cvalue,*) orb_mode
-
-    call NUOPC_CompAttributeGet(driver, name="orb_iyear", value=cvalue, rc=rc)
-    if (chkerr(rc,__LINE__,u_FILE_u)) return
-    read(cvalue,*) orb_iyear
-
-    call NUOPC_CompAttributeGet(driver, name="orb_iyear_align", value=cvalue, rc=rc)
-    if (chkerr(rc,__LINE__,u_FILE_u)) return
-    read(cvalue,*) orb_iyear_align
-
-    call NUOPC_CompAttributeGet(driver, name="orb_obliq", value=cvalue, rc=rc)
-    if (chkerr(rc,__LINE__,u_FILE_u)) return
-    read(cvalue,*) orb_obliq
-
-    call NUOPC_CompAttributeGet(driver, name="orb_eccen", value=cvalue, rc=rc)
-    if (chkerr(rc,__LINE__,u_FILE_u)) return
-    read(cvalue,*) orb_eccen
-
-    call NUOPC_CompAttributeGet(driver, name="orb_mvelp", value=cvalue, rc=rc)
-    if (chkerr(rc,__LINE__,u_FILE_u)) return
-    read(cvalue,*) orb_mvelp
-
-    if (trim(orb_mode) == trim(orb_fixed_year)) then
-       orb_obliq = SHR_ORB_UNDEF_REAL
-       orb_eccen = SHR_ORB_UNDEF_REAL
-       orb_mvelp = SHR_ORB_UNDEF_REAL
-       if (orb_iyear == SHR_ORB_UNDEF_INT) then
-          write(logunit,*) trim(subname),' ERROR: invalid settings orb_mode =',trim(orb_mode)
-          write(logunit,*) trim(subname),' ERROR: fixed_year settings = ',orb_iyear
-          write (msgstr, *) ' ERROR: invalid settings for orb_mode '//trim(orb_mode)
-          call ESMF_LogSetError(ESMF_RC_NOT_VALID, msg=msgstr, line=__LINE__, file=__FILE__, rcToReturn=rc)
-          return  ! bail out
-       endif
-    elseif (trim(orb_mode) == trim(orb_variable_year)) then
-       orb_obliq = SHR_ORB_UNDEF_REAL
-       orb_eccen = SHR_ORB_UNDEF_REAL
-       orb_mvelp = SHR_ORB_UNDEF_REAL
-       if (orb_iyear == SHR_ORB_UNDEF_INT .or. orb_iyear_align == SHR_ORB_UNDEF_INT) then
-          write(logunit,*) trim(subname),' ERROR: invalid settings orb_mode =',trim(orb_mode)
-          write(logunit,*) trim(subname),' ERROR: variable_year settings = ',orb_iyear, orb_iyear_align
-          write (msgstr, *) subname//' ERROR: invalid settings for orb_mode '//trim(orb_mode)
-          call ESMF_LogSetError(ESMF_RC_NOT_VALID, msg=msgstr, line=__LINE__, file=__FILE__, rcToReturn=rc)
-          return  ! bail out
-       endif
-    elseif (trim(orb_mode) == trim(orb_fixed_parameters)) then
-       !-- force orb_iyear to undef to make sure shr_orb_params works properly
-       orb_iyear = SHR_ORB_UNDEF_INT
-       orb_iyear_align = SHR_ORB_UNDEF_INT
-       if (orb_eccen == SHR_ORB_UNDEF_REAL .or. &
-           orb_obliq == SHR_ORB_UNDEF_REAL .or. &
-           orb_mvelp == SHR_ORB_UNDEF_REAL) then
-          write(logunit,*) trim(subname),' ERROR: invalid settings orb_mode =',trim(orb_mode)
-          write(logunit,*) trim(subname),' ERROR: orb_eccen = ',orb_eccen
-          write(logunit,*) trim(subname),' ERROR: orb_obliq = ',orb_obliq
-          write(logunit,*) trim(subname),' ERROR: orb_mvelp = ',orb_mvelp
-          write (msgstr, *) subname//' ERROR: invalid settings for orb_mode '//trim(orb_mode)
-          call ESMF_LogSetError(ESMF_RC_NOT_VALID, msg=msgstr, line=__LINE__, file=__FILE__, rcToReturn=rc)
-          return  ! bail out
-       endif
-    else
-       write (msgstr, *) subname//' ERROR: invalid orb_mode '//trim(orb_mode)
-       call ESMF_LogSetError(ESMF_RC_NOT_VALID, msg=msgstr, line=__LINE__, file=__FILE__, rcToReturn=rc)
-       return  ! bail out
-    endif
 
     call NUOPC_CompAttributeGet(driver, name='cpl_rootpe', value=cvalue, rc=rc)
     read(cvalue, *) rootpe_med
     if (chkerr(rc,__LINE__,u_FILE_u)) return
     call ESMF_GridCompGet(driver, localPet=localPet, rc=rc)
     if (chkerr(rc,__LINE__,u_FILE_u)) return
-
-    ! Determine orbital params
-    if (trim(orb_mode) == trim(orb_variable_year)) then
-       call ESMF_GridCompGet(driver, clock=clock, rc=rc)
-       if (chkerr(rc,__LINE__,u_FILE_u)) return
-
-       call ESMF_ClockGet(clock, CurrTime=CurrTime, rc=rc)
-       if (chkerr(rc,__LINE__,u_FILE_u)) return
-
-       call ESMF_TimeGet(CurrTime, yy=year, rc=rc)
-       if (chkerr(rc,__LINE__,u_FILE_u)) return
-
-       orb_cyear = orb_iyear + (year - orb_iyear_align)
-       call shr_orb_params(orb_cyear, orb_eccen, orb_obliq, orb_mvelp, &
-                           orb_obliqr, orb_lambm0, orb_mvelpp, mastertask)
-    else
-       call shr_orb_params(orb_iyear, orb_eccen, orb_obliq, orb_mvelp, &
-                           orb_obliqr, orb_lambm0, orb_mvelpp, mastertask)
-    end if
-
-    if (orb_eccen  == SHR_ORB_UNDEF_REAL .or. &
-         orb_obliqr == SHR_ORB_UNDEF_REAL .or. &
-         orb_mvelpp == SHR_ORB_UNDEF_REAL .or. &
-         orb_lambm0 == SHR_ORB_UNDEF_REAL) then
-       write (msgstr, *) subname//' ERROR: orb params incorrect'
-       call ESMF_LogSetError(ESMF_RC_NOT_VALID, msg=msgstr, line=__LINE__, file=__FILE__, rcToReturn=rc)
-       return  ! bail out
-    endif
-
-    ! Add updated orbital params to driver attributes
-
-    call NUOPC_CompAttributeAdd(driver, attrList=(/'orb_obliqr', 'orb_lambm0', 'orb_mvelpp'/), rc=rc)
-    if (chkerr(rc,__LINE__,u_FILE_u)) return
-
-    write(cvalue,*) orb_eccen
-    call NUOPC_CompAttributeSet(driver, name="orb_eccen", value=cvalue, rc=rc)
-    if (chkerr(rc,__LINE__,u_FILE_u)) return
-
-    write(cvalue,*) orb_obliqr
-    call NUOPC_CompAttributeSet(driver, name="orb_obliqr", value=cvalue, rc=rc)
-    if (chkerr(rc,__LINE__,u_FILE_u)) return
-
-    write(cvalue,*) orb_lambm0
-    call NUOPC_CompAttributeSet(driver, name="orb_lambm0", value=cvalue, rc=rc)
-    if (chkerr(rc,__LINE__,u_FILE_u)) return
-
-    write(cvalue,*) orb_mvelpp
-    call NUOPC_CompAttributeSet(driver, name="orb_mvelpp", value=cvalue, rc=rc)
-    if (chkerr(rc,__LINE__,u_FILE_u)) return
-
-    ! TODO: need to update orbital parameters during run time - actually - each component needs to update its orbital
-    ! parameters to be consistent
 
     !----------------------------------------------------------
     ! Initialize glc_elevclass_mod module variables
@@ -946,8 +804,8 @@ contains
     !------
     ! Add all the other attributes in AttrList (which have already been added to driver attributes)
     !------
-    allocate(attrList(5))
-    attrList =  (/"read_restart", "orb_eccen   ", "orb_obliqr  ", "orb_lambm0  ", "orb_mvelpp  "/)
+    allocate(attrList(1))
+    attrList =  (/"read_restart"/)
 
     call NUOPC_CompAttributeAdd(gcomp, attrList=attrList, rc=rc)
     if (chkerr(rc,__LINE__,u_FILE_u)) return
@@ -955,14 +813,11 @@ contains
        if (trim(attrList(n)) == "read_restart") then
           call NUOPC_CompAttributeGet(driver, name="mediator_read_restart", value=cvalue, rc=rc)
           if (chkerr(rc,__LINE__,u_FILE_u)) return
-          
           read(cvalue,*) lvalue
-
           if (.not. lvalue) then         
             call NUOPC_CompAttributeGet(driver, name=trim(attrList(n)), value=cvalue, rc=rc)
             if (chkerr(rc,__LINE__,u_FILE_u)) return
           end if
-
           call NUOPC_CompAttributeSet(gcomp, name=trim(attrList(n)), value=trim(cvalue), rc=rc)
           if (chkerr(rc,__LINE__,u_FILE_u)) return
        else 

--- a/drivers/cime/esm.F90
+++ b/drivers/cime/esm.F90
@@ -924,9 +924,7 @@ contains
     integer                        :: n
     integer                        :: stat
     integer                        :: inst_index
-    logical                        :: is_present
     character(len=CL)              :: cvalue
-    character(len=32), allocatable :: compLabels(:)
     character(len=32), allocatable :: attrList(:)
     integer                        :: componentCount
     character(len=*), parameter    :: subname = "(esm.F90:AddAttributes)"

--- a/mediator/med.F90
+++ b/mediator/med.F90
@@ -375,7 +375,6 @@ contains
     use ESMF  , only : ESMF_GridComp, ESMF_State, ESMF_Clock, ESMF_VM, ESMF_SUCCESS
     use ESMF  , only : ESMF_GridCompGet, ESMF_VMGet, ESMF_AttributeGet
     use ESMF  , only : ESMF_LogWrite, ESMF_LOGMSG_INFO, ESMF_METHOD_INITIALIZE
-    use ESMF  , only : ESMF_GridCompGet
     use NUOPC , only : NUOPC_CompFilterPhaseMap
     use med_internalstate_mod, only : mastertask
 

--- a/mediator/med_phases_ocnalb_mod.F90
+++ b/mediator/med_phases_ocnalb_mod.F90
@@ -14,6 +14,7 @@ module med_phases_ocnalb_mod
   use perf_mod              , only : t_startf, t_stopf
 #ifdef CESMCOUPLED 
   use shr_orb_mod           , only : shr_orb_cosz, shr_orb_decl
+  use shr_orb_mod           , only : shr_orb_params, SHR_ORB_UNDEF_INT, SHR_ORB_UNDEF_REAL
 #endif
 
   implicit none
@@ -31,6 +32,8 @@ module med_phases_ocnalb_mod
   !--------------------------------------------------------------------------
 
   private med_phases_ocnalb_init
+  private med_phases_ocnalb_orbital_init
+  private med_phases_ocnalb_orbital_update
 
   !--------------------------------------------------------------------------
   ! Private data
@@ -50,6 +53,17 @@ module med_phases_ocnalb_mod
   ! Conversion from degrees to radians
   character(*),parameter :: u_FILE_u = &
        __FILE__
+
+  character(len=CL)      :: orb_mode        ! attribute - orbital mode
+  integer                :: orb_iyear       ! attribute - orbital year
+  integer                :: orb_iyear_align ! attribute - associated with model year
+  real(R8)               :: orb_obliq       ! attribute - obliquity in degrees
+  real(R8)               :: orb_mvelp       ! attribute - moving vernal equinox longitude
+  real(R8)               :: orb_eccen       ! attribute and update-  orbital eccentricity
+
+  character(len=*) , parameter :: orb_fixed_year       = 'fixed_year'
+  character(len=*) , parameter :: orb_variable_year    = 'variable_year'
+  character(len=*) , parameter :: orb_fixed_parameters = 'fixed_parameters'
 
 !===============================================================================
 contains
@@ -89,6 +103,7 @@ contains
     real(R8), pointer        :: ownedElemCoords(:)
     character(len=CL)        :: tempc1,tempc2
     integer                  :: dbrc
+    logical                  :: mastertask
     character(*), parameter  :: subname = '(med_phases_ocnalb_init) '
     !-----------------------------------------------------------------------
 
@@ -169,6 +184,10 @@ contains
       return
     end if
 
+    ! Initialize orbital values
+    call  med_phases_ocnalb_orbital_init(gcomp, logunit, iam==0, rc)
+    if (chkerr(rc,__LINE__,u_FILE_u)) return
+
     if (dbug_flag > 5) then
       call ESMF_LogWrite(trim(subname)//": done", ESMF_LOGMSG_INFO, rc=dbrc)
     endif
@@ -184,13 +203,14 @@ contains
     ! Compute ocean albedos (on the ocean grid)
     !-----------------------------------------------------------------------
 
-    use ESMF                  , only : ESMF_GridComp, ESMF_Clock, ESMF_Time, ESMF_TimeInterval
-    use ESMF                  , only : ESMF_GridCompGet, ESMF_ClockGet, ESMF_TimeGet
-    use ESMF                  , only : ESMF_LogWrite, ESMF_LogFoundError
-    use ESMF                  , only : ESMf_SUCCESS, ESMF_FAILURE, ESMF_LOGMSG_INFO 
-    use ESMF                  , only : ESMF_RouteHandleIsCreated, ESMF_FieldBundleIsCreated
-    use ESMF                  , only : operator(+)
-    use NUOPC                 , only : NUOPC_CompAttributeGet
+    use ESMF  , only : ESMF_GridComp, ESMF_GridCompGet, ESMF_TimeInterval
+    use ESMF  , only : ESMF_Clock, ESMF_ClockGet, ESMF_Time, ESMF_TimeGet
+    use ESMF  , only : ESMF_VM, ESMF_VMGet
+    use ESMF  , only : ESMF_LogWrite, ESMF_LogFoundError
+    use ESMF  , only : ESMf_SUCCESS, ESMF_FAILURE, ESMF_LOGMSG_INFO 
+    use ESMF  , only : ESMF_RouteHandleIsCreated, ESMF_FieldBundleIsCreated
+    use ESMF  , only : operator(+)
+    use NUOPC , only : NUOPC_CompAttributeGet
 
     ! input/output variables
     type(ESMF_GridComp)  :: gcomp
@@ -198,6 +218,8 @@ contains
 
     ! local variables
     type(ocnalb_type), save :: ocnalb
+    type(ESMF_VM)           :: vm
+    integer                 :: iam
     logical                 :: update_alb
     type(InternalState)     :: is_local
     type(ESMF_Clock)        :: clock
@@ -240,6 +262,12 @@ contains
     RETURN  ! the following code is not executed unless the model is CESM
 
 #else
+
+    ! Determine master task
+    call ESMF_GridCompGet(gcomp, vm=vm, rc=rc)
+    if (chkerr(rc,__LINE__,u_FILE_u)) return
+    call ESMF_VMGet(vm, localPet=iam, rc=rc)
+    if (chkerr(rc,__LINE__,u_FILE_u)) return
 
     ! Get the internal state from Component.
     nullify(is_local%wrap)
@@ -329,21 +357,11 @@ contains
     if (chkerr(rc,__LINE__,u_FILE_u)) return
     read(cvalue,*) flux_albav
 
-    call NUOPC_CompAttributeGet(gcomp, name='orb_eccen', value=cvalue, rc=rc)
-    if (chkerr(rc,__LINE__,u_FILE_u)) return
-    read(cvalue,*) eccen
-    call NUOPC_CompAttributeGet(gcomp, name='orb_obliqr', value=cvalue, rc=rc)
-    if (chkerr(rc,__LINE__,u_FILE_u)) return
-    read(cvalue,*) obliqr
-    call NUOPC_CompAttributeGet(gcomp, name='orb_lambm0', value=cvalue, rc=rc)
-    if (chkerr(rc,__LINE__,u_FILE_u)) return
-    read(cvalue,*) lambm0
-    call NUOPC_CompAttributeGet(gcomp, name='orb_mvelpp', value=cvalue, rc=rc)
-    if (chkerr(rc,__LINE__,u_FILE_u)) return
-    read(cvalue,*) mvelpp
+    ! Get orbital values
+    call med_phases_ocnalb_orbital_update(clock, logunit, iam==0, eccen, obliqr, lambm0, mvelpp, rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
 
     ! Calculate ocean albedos on the ocean grid
-
     update_alb = .false.
     lsize = size(ocnalb%anidr)
 
@@ -458,5 +476,159 @@ contains
     call t_stopf('MED:'//subname)
 
   end subroutine med_phases_ocnalb_mapo2a
+
+!===============================================================================
+
+  subroutine med_phases_ocnalb_orbital_init(gcomp, logunit, mastertask, rc)
+
+    !----------------------------------------------------------
+    ! Obtain orbital related values
+    !----------------------------------------------------------
+
+    use ESMF  , only : ESMF_GridComp, ESMF_GridCompGet 
+    use ESMF  , only : ESMF_LogWrite, ESMF_LogFoundError, ESMF_LogSetError
+    use ESMF  , only : ESMf_SUCCESS, ESMF_FAILURE, ESMF_LOGMSG_INFO, ESMF_RC_NOT_VALID 
+    use NUOPC , only : NUOPC_CompAttributeGet
+
+    ! input/output variables
+    type(ESMF_GridComp) , intent(inout) :: gcomp
+    integer             , intent(in)    :: logunit         ! output logunit
+    logical             , intent(in)    :: mastertask 
+    integer             , intent(out)   :: rc              ! output error
+
+    ! local variables
+    character(len=CL) :: msgstr          ! temporary
+    character(len=CL) :: cvalue          ! temporary
+    character(len=*) , parameter :: subname = "(med_phases_ocnalb_orbital_init)"
+    !-------------------------------------------
+
+    rc = ESMF_SUCCESS
+
+    ! Determine orbital attributes from input
+    call NUOPC_CompAttributeGet(gcomp, name="orb_mode", value=cvalue, rc=rc)
+    if (chkerr(rc,__LINE__,u_FILE_u)) return
+    read(cvalue,*) orb_mode
+
+    call NUOPC_CompAttributeGet(gcomp, name="orb_iyear", value=cvalue, rc=rc)
+    if (chkerr(rc,__LINE__,u_FILE_u)) return
+    read(cvalue,*) orb_iyear
+
+    call NUOPC_CompAttributeGet(gcomp, name="orb_iyear_align", value=cvalue, rc=rc)
+    if (chkerr(rc,__LINE__,u_FILE_u)) return
+    read(cvalue,*) orb_iyear_align
+
+    call NUOPC_CompAttributeGet(gcomp, name="orb_obliq", value=cvalue, rc=rc)
+    if (chkerr(rc,__LINE__,u_FILE_u)) return
+    read(cvalue,*) orb_obliq
+
+    call NUOPC_CompAttributeGet(gcomp, name="orb_eccen", value=cvalue, rc=rc)
+    if (chkerr(rc,__LINE__,u_FILE_u)) return
+    read(cvalue,*) orb_eccen
+
+    call NUOPC_CompAttributeGet(gcomp, name="orb_mvelp", value=cvalue, rc=rc)
+    if (chkerr(rc,__LINE__,u_FILE_u)) return
+    read(cvalue,*) orb_mvelp
+
+    ! Error checks
+    if (trim(orb_mode) == trim(orb_fixed_year)) then
+       orb_obliq = SHR_ORB_UNDEF_REAL
+       orb_eccen = SHR_ORB_UNDEF_REAL
+       orb_mvelp = SHR_ORB_UNDEF_REAL
+       if (orb_iyear == SHR_ORB_UNDEF_INT) then
+          write(logunit,*) trim(subname),' ERROR: invalid settings orb_mode =',trim(orb_mode)
+          write(logunit,*) trim(subname),' ERROR: fixed_year settings = ',orb_iyear
+          write (msgstr, *) ' ERROR: invalid settings for orb_mode '//trim(orb_mode)
+          call ESMF_LogSetError(ESMF_RC_NOT_VALID, msg=msgstr, line=__LINE__, file=__FILE__, rcToReturn=rc)
+          return  ! bail out
+       endif
+    elseif (trim(orb_mode) == trim(orb_variable_year)) then
+       orb_obliq = SHR_ORB_UNDEF_REAL
+       orb_eccen = SHR_ORB_UNDEF_REAL
+       orb_mvelp = SHR_ORB_UNDEF_REAL
+       if (orb_iyear == SHR_ORB_UNDEF_INT .or. orb_iyear_align == SHR_ORB_UNDEF_INT) then
+          write(logunit,*) trim(subname),' ERROR: invalid settings orb_mode =',trim(orb_mode)
+          write(logunit,*) trim(subname),' ERROR: variable_year settings = ',orb_iyear, orb_iyear_align
+          write (msgstr, *) subname//' ERROR: invalid settings for orb_mode '//trim(orb_mode)
+          call ESMF_LogSetError(ESMF_RC_NOT_VALID, msg=msgstr, line=__LINE__, file=__FILE__, rcToReturn=rc)
+          return  ! bail out
+       endif
+    elseif (trim(orb_mode) == trim(orb_fixed_parameters)) then
+       !-- force orb_iyear to undef to make sure shr_orb_params works properly
+       orb_iyear = SHR_ORB_UNDEF_INT
+       orb_iyear_align = SHR_ORB_UNDEF_INT
+       if (orb_eccen == SHR_ORB_UNDEF_REAL .or. &
+           orb_obliq == SHR_ORB_UNDEF_REAL .or. &
+           orb_mvelp == SHR_ORB_UNDEF_REAL) then
+          write(logunit,*) trim(subname),' ERROR: invalid settings orb_mode =',trim(orb_mode)
+          write(logunit,*) trim(subname),' ERROR: orb_eccen = ',orb_eccen
+          write(logunit,*) trim(subname),' ERROR: orb_obliq = ',orb_obliq
+          write(logunit,*) trim(subname),' ERROR: orb_mvelp = ',orb_mvelp
+          write (msgstr, *) subname//' ERROR: invalid settings for orb_mode '//trim(orb_mode)
+          call ESMF_LogSetError(ESMF_RC_NOT_VALID, msg=msgstr, line=__LINE__, file=__FILE__, rcToReturn=rc)
+          return  ! bail out
+       endif
+    else
+       write (msgstr, *) subname//' ERROR: invalid orb_mode '//trim(orb_mode)
+       call ESMF_LogSetError(ESMF_RC_NOT_VALID, msg=msgstr, line=__LINE__, file=__FILE__, rcToReturn=rc)
+       rc = ESMF_FAILURE
+       return  ! bail out
+    endif
+
+  end subroutine med_phases_ocnalb_orbital_init
+
+  !===============================================================================
+
+  subroutine med_phases_ocnalb_orbital_update(clock, logunit,  mastertask, eccen, obliqr, lambm0, mvelpp, rc)
+
+    !----------------------------------------------------------
+    ! Update orbital settings 
+    !----------------------------------------------------------
+
+    use ESMF, only : ESMF_Clock, ESMF_ClockGet, ESMF_Time, ESMF_TimeGet
+    use ESMF, only : ESMF_LogSetError, ESMF_RC_NOT_VALID, ESMF_SUCCESS
+
+    ! input/output variables
+    type(ESMF_Clock) , intent(in)    :: clock
+    integer          , intent(in)    :: logunit 
+    logical          , intent(in)    :: mastertask
+    real(R8)         , intent(inout) :: eccen  ! orbital eccentricity
+    real(R8)         , intent(inout) :: obliqr ! Earths obliquity in rad
+    real(R8)         , intent(inout) :: lambm0 ! Mean long of perihelion at vernal equinox (radians)
+    real(R8)         , intent(inout) :: mvelpp ! moving vernal equinox long of perihelion plus pi (rad)
+    integer          , intent(out)   :: rc     ! output error
+
+    ! local variables
+    type(ESMF_Time)   :: CurrTime ! current time
+    integer           :: year     ! model year at current time 
+    integer           :: orb_year ! orbital year for current orbital computation
+    character(len=CL) :: msgstr   ! temporary
+    character(len=*) , parameter :: subname = "(lnd_orbital_update)"
+    !-------------------------------------------
+
+    rc = ESMF_SUCCESS
+
+    if (trim(orb_mode) == trim(orb_variable_year)) then
+       call ESMF_ClockGet(clock, CurrTime=CurrTime, rc=rc)
+       if (chkerr(rc,__LINE__,u_FILE_u)) return
+       call ESMF_TimeGet(CurrTime, yy=year, rc=rc)
+       if (chkerr(rc,__LINE__,u_FILE_u)) return
+       orb_year = orb_iyear + (year - orb_iyear_align)
+    else
+       orb_year = orb_iyear 
+    end if
+
+    eccen = orb_eccen
+    call shr_orb_params(orb_year, eccen, orb_obliq, orb_mvelp, obliqr, lambm0, mvelpp, mastertask)
+
+    if ( eccen  == SHR_ORB_UNDEF_REAL .or. obliqr == SHR_ORB_UNDEF_REAL .or. &
+         mvelpp == SHR_ORB_UNDEF_REAL .or. lambm0 == SHR_ORB_UNDEF_REAL) then
+       write (msgstr, *) subname//' ERROR: orb params incorrect'
+       call ESMF_LogSetError(ESMF_RC_NOT_VALID, msg=msgstr, line=__LINE__, file=__FILE__, rcToReturn=rc)
+       return  ! bail out
+    endif
+
+  end subroutine med_phases_ocnalb_orbital_update
+
+!===============================================================================
 
 end module med_phases_ocnalb_mod

--- a/mediator/med_phases_ocnalb_mod.F90
+++ b/mediator/med_phases_ocnalb_mod.F90
@@ -491,7 +491,7 @@ contains
     use NUOPC , only : NUOPC_CompAttributeGet
 
     ! input/output variables
-    type(ESMF_GridComp) , intent(inout) :: gcomp
+    type(ESMF_GridComp)                 :: gcomp
     integer             , intent(in)    :: logunit         ! output logunit
     logical             , intent(in)    :: mastertask 
     integer             , intent(out)   :: rc              ! output error
@@ -602,6 +602,8 @@ contains
     integer           :: year     ! model year at current time 
     integer           :: orb_year ! orbital year for current orbital computation
     character(len=CL) :: msgstr   ! temporary
+    logical           :: lprint
+    logical           :: first_time = .true.
     character(len=*) , parameter :: subname = "(lnd_orbital_update)"
     !-------------------------------------------
 
@@ -613,12 +615,19 @@ contains
        call ESMF_TimeGet(CurrTime, yy=year, rc=rc)
        if (chkerr(rc,__LINE__,u_FILE_u)) return
        orb_year = orb_iyear + (year - orb_iyear_align)
+       lprint = mastertask
     else
        orb_year = orb_iyear 
+       if (first_time) then
+          lprint = mastertask
+          first_time = .false.
+       else
+          lprint = .false.
+       end if
     end if
 
     eccen = orb_eccen
-    call shr_orb_params(orb_year, eccen, orb_obliq, orb_mvelp, obliqr, lambm0, mvelpp, mastertask)
+    call shr_orb_params(orb_year, eccen, orb_obliq, orb_mvelp, obliqr, lambm0, mvelpp, lprint)
 
     if ( eccen  == SHR_ORB_UNDEF_REAL .or. obliqr == SHR_ORB_UNDEF_REAL .or. &
          mvelpp == SHR_ORB_UNDEF_REAL .or. lambm0 == SHR_ORB_UNDEF_REAL) then


### PR DESCRIPTION
move orbital calculations to the noupc caps

- The orbital updates have now been moved to every model cap that requires an orbital calculation. This is required since the run sequence in nuopc is not done in hard-wired code (like cpl7) but rather in an run sequence ascii file. So calls to update the orbital calculation cannot be done in one place (like in the cpl7 driver. 
- Component caps that had orbital dependencies were modified - and round-off level differences appeared in some cases.
- This PR is dependent on the CIME PR #3373

Testing Completed: testlist_drv.xml
- New baselines were created for jan20 that only had differences from the orbital migration to the caps.
- The latest baselines jan26 are bfb with jan20.

app_cesm-cmeps HASH: fe19c4e

