### PR TITLE
Change all occurrences of the __line__ macro to be uppercase __LINE__

### DIFF
--- a/mediator/med_fraction_mod.F90
+++ b/mediator/med_fraction_mod.F90
@@ -316,7 +316,7 @@ contains
                   flds_scalar_name=is_local%wrap%flds_scalar_name, &
                   FBgeom=is_local%wrap%FBImp(compatm,compatm), &
                   fieldNameList=(/'Fldtemp'/), name='FBtemp', rc=rc)
-             if (chkerr(rc,__LINE__,u_file_u)) return
+             if (chkerr(rc,__LINE__,u_FILE_u)) return
           end if
 
           ! Determine map type

--- a/mediator/med_fraction_mod.F90
+++ b/mediator/med_fraction_mod.F90
@@ -316,7 +316,7 @@ contains
                   flds_scalar_name=is_local%wrap%flds_scalar_name, &
                   FBgeom=is_local%wrap%FBImp(compatm,compatm), &
                   fieldNameList=(/'Fldtemp'/), name='FBtemp', rc=rc)
-             if (chkerr(rc,__line__,u_file_u)) return
+             if (chkerr(rc,__LINE__,u_file_u)) return
           end if
 
           ! Determine map type

--- a/mediator/med_io_mod.F90
+++ b/mediator/med_io_mod.F90
@@ -84,7 +84,7 @@ module med_io_mod
   integer                        :: pio_iotype
   integer                        :: pio_ioformat
   type(iosystem_desc_t), pointer :: io_subsystem
-  character(*),parameter         :: u_file_u = &
+  character(*),parameter         :: u_FILE_u = &
        __FILE__
 
 !=================================================================================

--- a/mediator/med_map_mod.F90
+++ b/mediator/med_map_mod.F90
@@ -498,16 +498,16 @@ contains
                            flds_scalar_name=flds_scalar_name, &
                            FBgeom=is_local%wrap%FBImp(n1,n2), &
                            fieldNameList=(/trim(normname)/), name='FBNormOne', rc=rc)
-                      if (chkerr(rc,__LINE__,u_file_u)) return
+                      if (chkerr(rc,__LINE__,u_FILE_u)) return
 
                       call FB_reset(is_local%wrap%FBNormOne(n1,n2,m), value=czero, rc=rc)
-                      if (chkerr(rc,__LINE__,u_file_u)) return
+                      if (chkerr(rc,__LINE__,u_FILE_u)) return
 
                       call FB_init(FBout=FBTmp, &
                            flds_scalar_name=flds_scalar_name, &
                            STgeom=is_local%wrap%NStateImp(n1), &
                            fieldNameList=(/trim(normname)/), name='FBTmp', rc=rc)
-                      if (chkerr(rc,__LINE__,u_file_u)) return
+                      if (chkerr(rc,__LINE__,u_FILE_u)) return
 
                       call FB_GetFldPtr(FBTmp, trim(normname), fldptr1=dataPtr, rc=rc)
                       if (chkerr(rc,__LINE__,u_FILE_u)) return
@@ -520,7 +520,7 @@ contains
                       if (chkerr(rc,__LINE__,u_FILE_u)) return
 
                       call FB_clean(FBTmp, rc=rc)
-                      if (chkerr(rc,__LINE__,u_file_u)) return
+                      if (chkerr(rc,__LINE__,u_FILE_u)) return
                    end if
                 end do
              end if
@@ -1134,27 +1134,27 @@ contains
        if (.not. ESMF_FieldBundleIsCreated(FBNormSrc)) then
           call FB_init(FBout=FBNormSrc, flds_scalar_name=flds_scalar_name, &
                FBgeom=FBSrc, fieldNameList=(/trim(mapnorm)/), name='normsrc', rc=rc)
-          if (chkerr(rc,__LINE__,u_file_u)) return
+          if (chkerr(rc,__LINE__,u_FILE_u)) return
 
           call FB_GetFldPtr(FBNormSrc, trim(mapnorm), data_srcnorm, rc=rc)
           if (chkerr(rc,__LINE__,u_FILE_u)) return
        endif
 
        call FB_reset(FBNormSrc, value=czero, rc=rc)
-       if (chkerr(rc,__LINE__,u_file_u)) return
+       if (chkerr(rc,__LINE__,u_FILE_u)) return
 
        ! create a temporary field bundle that will contain normalization on the destination grid
        if (.not. ESMF_FieldBundleIsCreated(FBNormDst)) then
           call FB_init(FBout=FBNormDst, flds_scalar_name=flds_scalar_name, &
                FBgeom=FBDst, fieldNameList=(/trim(mapnorm)/), name='normdst', rc=rc)
-          if (chkerr(rc,__LINE__,u_file_u)) return
+          if (chkerr(rc,__LINE__,u_FILE_u)) return
 
           call FB_GetFldPtr(FBFrac, trim(mapnorm), data_frac, rc=rc)
           if (chkerr(rc,__LINE__,u_FILE_u)) return
        endif
 
        call FB_reset(FBNormDst, value=czero, rc=rc)
-       if (chkerr(rc,__LINE__,u_file_u)) return
+       if (chkerr(rc,__LINE__,u_FILE_u)) return
 
        ! error checks
        if (size(data_srcnorm) /= size(data_frac)) then
@@ -1222,15 +1222,15 @@ contains
     ! Clean up temporary field bundles
     if (ESMF_FieldBundleIsCreated(FBSrcTmp)) then
        call FB_clean(FBSrcTmp, rc=rc)
-       if (chkerr(rc,__LINE__,u_file_u)) return
+       if (chkerr(rc,__LINE__,u_FILE_u)) return
     end if
     if (ESMF_FieldBundleIsCreated(FBNormSrc)) then
        call FB_clean(FBNormSrc, rc=rc)
-       if (chkerr(rc,__LINE__,u_file_u)) return
+       if (chkerr(rc,__LINE__,u_FILE_u)) return
     end if
     if (ESMF_FieldBundleIsCreated(FBNormDst)) then
        call FB_clean(FBNormDst, rc=rc)
-       if (chkerr(rc,__LINE__,u_file_u)) return
+       if (chkerr(rc,__LINE__,u_FILE_u)) return
     end if
     call t_stopf('MED:'//subname)
 

--- a/mediator/med_map_mod.F90
+++ b/mediator/med_map_mod.F90
@@ -498,16 +498,16 @@ contains
                            flds_scalar_name=flds_scalar_name, &
                            FBgeom=is_local%wrap%FBImp(n1,n2), &
                            fieldNameList=(/trim(normname)/), name='FBNormOne', rc=rc)
-                      if (chkerr(rc,__line__,u_file_u)) return
+                      if (chkerr(rc,__LINE__,u_file_u)) return
 
                       call FB_reset(is_local%wrap%FBNormOne(n1,n2,m), value=czero, rc=rc)
-                      if (chkerr(rc,__line__,u_file_u)) return
+                      if (chkerr(rc,__LINE__,u_file_u)) return
 
                       call FB_init(FBout=FBTmp, &
                            flds_scalar_name=flds_scalar_name, &
                            STgeom=is_local%wrap%NStateImp(n1), &
                            fieldNameList=(/trim(normname)/), name='FBTmp', rc=rc)
-                      if (chkerr(rc,__line__,u_file_u)) return
+                      if (chkerr(rc,__LINE__,u_file_u)) return
 
                       call FB_GetFldPtr(FBTmp, trim(normname), fldptr1=dataPtr, rc=rc)
                       if (chkerr(rc,__LINE__,u_FILE_u)) return
@@ -520,7 +520,7 @@ contains
                       if (chkerr(rc,__LINE__,u_FILE_u)) return
 
                       call FB_clean(FBTmp, rc=rc)
-                      if (chkerr(rc,__line__,u_file_u)) return
+                      if (chkerr(rc,__LINE__,u_file_u)) return
                    end if
                 end do
              end if
@@ -1134,27 +1134,27 @@ contains
        if (.not. ESMF_FieldBundleIsCreated(FBNormSrc)) then
           call FB_init(FBout=FBNormSrc, flds_scalar_name=flds_scalar_name, &
                FBgeom=FBSrc, fieldNameList=(/trim(mapnorm)/), name='normsrc', rc=rc)
-          if (chkerr(rc,__line__,u_file_u)) return
+          if (chkerr(rc,__LINE__,u_file_u)) return
 
           call FB_GetFldPtr(FBNormSrc, trim(mapnorm), data_srcnorm, rc=rc)
           if (chkerr(rc,__LINE__,u_FILE_u)) return
        endif
 
        call FB_reset(FBNormSrc, value=czero, rc=rc)
-       if (chkerr(rc,__line__,u_file_u)) return
+       if (chkerr(rc,__LINE__,u_file_u)) return
 
        ! create a temporary field bundle that will contain normalization on the destination grid
        if (.not. ESMF_FieldBundleIsCreated(FBNormDst)) then
           call FB_init(FBout=FBNormDst, flds_scalar_name=flds_scalar_name, &
                FBgeom=FBDst, fieldNameList=(/trim(mapnorm)/), name='normdst', rc=rc)
-          if (chkerr(rc,__line__,u_file_u)) return
+          if (chkerr(rc,__LINE__,u_file_u)) return
 
           call FB_GetFldPtr(FBFrac, trim(mapnorm), data_frac, rc=rc)
           if (chkerr(rc,__LINE__,u_FILE_u)) return
        endif
 
        call FB_reset(FBNormDst, value=czero, rc=rc)
-       if (chkerr(rc,__line__,u_file_u)) return
+       if (chkerr(rc,__LINE__,u_file_u)) return
 
        ! error checks
        if (size(data_srcnorm) /= size(data_frac)) then
@@ -1222,15 +1222,15 @@ contains
     ! Clean up temporary field bundles
     if (ESMF_FieldBundleIsCreated(FBSrcTmp)) then
        call FB_clean(FBSrcTmp, rc=rc)
-       if (chkerr(rc,__line__,u_file_u)) return
+       if (chkerr(rc,__LINE__,u_file_u)) return
     end if
     if (ESMF_FieldBundleIsCreated(FBNormSrc)) then
        call FB_clean(FBNormSrc, rc=rc)
-       if (chkerr(rc,__line__,u_file_u)) return
+       if (chkerr(rc,__LINE__,u_file_u)) return
     end if
     if (ESMF_FieldBundleIsCreated(FBNormDst)) then
        call FB_clean(FBNormDst, rc=rc)
-       if (chkerr(rc,__line__,u_file_u)) return
+       if (chkerr(rc,__LINE__,u_file_u)) return
     end if
     call t_stopf('MED:'//subname)
 

--- a/mediator/med_phases_prep_glc_mod.F90
+++ b/mediator/med_phases_prep_glc_mod.F90
@@ -301,11 +301,11 @@ contains
           ! -------------------------------
           call FB_init(FBglc_icemask, is_local%wrap%flds_scalar_name, &
                FBgeom=is_local%wrap%FBExp(compglc), fieldnameList=(/Sg_icemask_field/), rc=rc)
-          if (chkerr(rc,__LINE__,u_file_u)) return
+          if (chkerr(rc,__LINE__,u_FILE_u)) return
 
           call FB_init(FBlnd_icemask, is_local%wrap%flds_scalar_name, &
                FBgeom=is_local%wrap%FBImp(complnd,complnd), fieldNameList=(/Sg_icemask_field/), rc=rc)
-          if (chkerr(rc,__LINE__,u_file_u)) return
+          if (chkerr(rc,__LINE__,u_FILE_u)) return
 
           allocate(fldlist_glc2lnd_icemask%flds(1))
           fldlist_glc2lnd_icemask%flds(1)%shortname = Sg_icemask_field

--- a/mediator/med_phases_prep_glc_mod.F90
+++ b/mediator/med_phases_prep_glc_mod.F90
@@ -301,11 +301,11 @@ contains
           ! -------------------------------
           call FB_init(FBglc_icemask, is_local%wrap%flds_scalar_name, &
                FBgeom=is_local%wrap%FBExp(compglc), fieldnameList=(/Sg_icemask_field/), rc=rc)
-          if (chkerr(rc,__line__,u_file_u)) return
+          if (chkerr(rc,__LINE__,u_file_u)) return
 
           call FB_init(FBlnd_icemask, is_local%wrap%flds_scalar_name, &
                FBgeom=is_local%wrap%FBImp(complnd,complnd), fieldNameList=(/Sg_icemask_field/), rc=rc)
-          if (chkerr(rc,__line__,u_file_u)) return
+          if (chkerr(rc,__LINE__,u_file_u)) return
 
           allocate(fldlist_glc2lnd_icemask%flds(1))
           fldlist_glc2lnd_icemask%flds(1)%shortname = Sg_icemask_field

--- a/mediator/med_phases_prep_rof_mod.F90
+++ b/mediator/med_phases_prep_rof_mod.F90
@@ -394,25 +394,25 @@ contains
             flds_scalar_name=is_local%wrap%flds_scalar_name, &
             FBgeom=is_local%wrap%FBImp(complnd,complnd), &
             fieldNameList=(/trim(volr_field)/), rc=rc)
-       if (chkerr(rc,__LINE__,u_file_u)) return
+       if (chkerr(rc,__LINE__,u_FILE_u)) return
 
        call FB_init(FBout=FBrofVolr, &
             flds_scalar_name=is_local%wrap%flds_scalar_name, &
             FBgeom=is_local%wrap%FBImp(comprof,comprof), &
             fieldNameList=(/trim(volr_field)/), rc=rc)
-       if (chkerr(rc,__LINE__,u_file_u)) return
+       if (chkerr(rc,__LINE__,u_FILE_u)) return
 
        call FB_init(FBout=FBlndIrrig, &
             flds_scalar_name=is_local%wrap%flds_scalar_name, &
             FBgeom=is_local%wrap%FBImp(complnd,complnd), &
             fieldNameList=(/irrig_normalized_field, irrig_volr0_field/), rc=rc)
-       if (chkerr(rc,__LINE__,u_file_u)) return
+       if (chkerr(rc,__LINE__,u_FILE_u)) return
 
        call FB_init(FBout=FBrofIrrig, &
             flds_scalar_name=is_local%wrap%flds_scalar_name, &
             FBgeom=is_local%wrap%FBImp(comprof,comprof), &
             fieldNameList=(/irrig_normalized_field, irrig_volr0_field/), rc=rc)
-       if (chkerr(rc,__LINE__,u_file_u)) return
+       if (chkerr(rc,__LINE__,u_FILE_u)) return
 
        allocate(fldlist_lnd2rof%flds(2))
        fldlist_lnd2rof%flds(1)%shortname = irrig_normalized_field

--- a/mediator/med_phases_prep_rof_mod.F90
+++ b/mediator/med_phases_prep_rof_mod.F90
@@ -394,25 +394,25 @@ contains
             flds_scalar_name=is_local%wrap%flds_scalar_name, &
             FBgeom=is_local%wrap%FBImp(complnd,complnd), &
             fieldNameList=(/trim(volr_field)/), rc=rc)
-       if (chkerr(rc,__line__,u_file_u)) return
+       if (chkerr(rc,__LINE__,u_file_u)) return
 
        call FB_init(FBout=FBrofVolr, &
             flds_scalar_name=is_local%wrap%flds_scalar_name, &
             FBgeom=is_local%wrap%FBImp(comprof,comprof), &
             fieldNameList=(/trim(volr_field)/), rc=rc)
-       if (chkerr(rc,__line__,u_file_u)) return
+       if (chkerr(rc,__LINE__,u_file_u)) return
 
        call FB_init(FBout=FBlndIrrig, &
             flds_scalar_name=is_local%wrap%flds_scalar_name, &
             FBgeom=is_local%wrap%FBImp(complnd,complnd), &
             fieldNameList=(/irrig_normalized_field, irrig_volr0_field/), rc=rc)
-       if (chkerr(rc,__line__,u_file_u)) return
+       if (chkerr(rc,__LINE__,u_file_u)) return
 
        call FB_init(FBout=FBrofIrrig, &
             flds_scalar_name=is_local%wrap%flds_scalar_name, &
             FBgeom=is_local%wrap%FBImp(comprof,comprof), &
             fieldNameList=(/irrig_normalized_field, irrig_volr0_field/), rc=rc)
-       if (chkerr(rc,__line__,u_file_u)) return
+       if (chkerr(rc,__LINE__,u_file_u)) return
 
        allocate(fldlist_lnd2rof%flds(2))
        fldlist_lnd2rof%flds(1)%shortname = irrig_normalized_field


### PR DESCRIPTION
Change Description:
gfortran doesn't accept the lowercase __line__

Testing Completed: Just tested the build on my mac with gfortran, with:
`./create_newcase --case $scratch/test_control_0224b --compset I2000Clm50SpRsGs --res f45_f45_mg37 --run-unsupported --driver nuopc`
NOTE: This test was done with a similar set of changes off of an older version of the code (181ff1ed9dfb279e619e8a2173f43baf7bf1dce3). I have NOT tested this version directly.
(Minimum testing: CIME_DRIVER=nuopc scripts_regression_tests.py)

CIME HASH: Above testing was done with 569aa6ec8
