### PR TITLE
Add EXTRA_MACHDIR and NONLOCAL xml variables

### DIFF
--- a/cime_config/config_component.xml
+++ b/cime_config/config_component.xml
@@ -61,6 +61,15 @@
     <desc>full pathname of case</desc>
   </entry>
 
+  <entry id="NONLOCAL">
+    <type>logical</type>
+    <valid_values>TRUE,FALSE</valid_values>
+    <default_value>FALSE</default_value>
+    <group>case_def</group>
+    <file>env_case.xml</file>
+    <desc>user is not on the requested machine</desc>
+  </entry>
+
   <entry id="CASETOOLS">
     <type>char</type>
     <default_value>$CASEROOT/Tools</default_value>

--- a/cime_config/config_component.xml
+++ b/cime_config/config_component.xml
@@ -1659,6 +1659,14 @@
     <desc>Machines directory location</desc>
   </entry>
 
+  <entry id="EXTRA_MACHDIR">
+    <type>char</type>
+    <default_value></default_value>
+    <group>case_def</group>
+    <file>env_case.xml</file>
+    <desc>Path to an extra directory containing supplementary machines files</desc>
+  </entry>
+
   <entry id="RUNDIR">
     <type>char</type>
     <default_value>$CIME_OUTPUT_ROOT/$CASE/run</default_value>


### PR DESCRIPTION
Change Description:

Add EXTRA_MACHDIR and NONLOCAL xml variables.

This is needed to work with the changes in
https://github.com/ESMCI/cime/pull/3508

This exactly mimics the change to config_component.xml in the mct driver in that cime PR.

Testing Completed:
Just ran `CIME_DRIVER=nuopc ./scripts_regression_tests.py J_TestCreateNewcase`

CIME HASH: `f69fa6d11`
