### PR TITLE
Set default ROF_NCPL for mizuroute

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,11 @@
 *.o
 *.obj
 
+# Python compiled files
+*.pyc
+cime_config/buildnmlc
+cime_config/buildexec
+
 # Precompiled Headers
 *.gch
 *.pch

--- a/cime_config/config_component_cesm.xml
+++ b/cime_config/config_component_cesm.xml
@@ -333,6 +333,7 @@
       <value compset="_DATM.*_MOM6.*_DROF">$ATM_NCPL</value>
       <value compset="_DATM.*_DOCN%SOM">$ATM_NCPL</value>
       <value compset="_DATM.*_SLND.*_DICE.*_DOCN">$ATM_NCPL</value>
+      <value compset="_MIZUROUTE_">1</value>
       <value compset="_DATM%CPLHIST.+POP\d">8</value>
       <value compset="_DATM%CPLHIST.+MOM\d">8</value>
       <value compset="_XATM.*_XLND.*_XICE.*_XOCN">$ATM_NCPL</value>


### PR DESCRIPTION
Change Description:

Set the default ROF_NCPL for mizuRoute.

Testing Completed: SMS_D_P1x1_Vnuopc_Ld5.5x5_amazon_r05.I2000Clm50SpMizGs.cheyenne_intel.mizuroute-default

  this test requires branches for mizuRoute, ctsm, and cime.
Running
 env CIME_DRIVER=nuopc scripts_regression_tests.py
 is failing, but I don't think it's because of my changes.

CIME HASH: cime5.8.23-10-g916d9927b
