### PR TITLE
ww3 additions to fd_nems.yaml

### DIFF
--- a/mediator/fd_nems.yaml
+++ b/mediator/fd_nems.yaml
@@ -597,13 +597,11 @@
        description: ww3 import 
      #
      - standard_name: surface_eastward_sea_water_velocity
-       #alias: So_u
        alias: ocn_current_zonal
        canonical_units: m s-1
        description: ww3 import 
      #
      - standard_name: surface_northward_sea_water_velocity
-       #alias: So_v
        alias: ocn_current_merid
        canonical_units: m s-1
        description: ww3 import 
@@ -619,7 +617,6 @@
        description: ww3 import 
      #
      - standard_name: sea_ice_concentration
-       #alias: Si_ifrac
        alias: ice_fraction
        canonical_units: 1
        description: ww3 import 

--- a/mediator/fd_nems.yaml
+++ b/mediator/fd_nems.yaml
@@ -355,7 +355,6 @@
      #
      - standard_name: So_s
        alias: s_surf
-       alias: sea_surface_salinity
        canonical_units: g kg-1
        description: ocean export
      #
@@ -596,6 +595,11 @@
        canonical_units: m 
        description: ww3 import 
      #
+     - standard_name: sea_surface_salinity
+       alias: s_surf
+       canonical_units: g kg-1
+       description: ww3 import
+     #
      - standard_name: surface_eastward_sea_water_velocity
        alias: ocn_current_zonal
        canonical_units: m s-1
@@ -619,7 +623,7 @@
      - standard_name: sea_ice_concentration
        alias: ice_fraction
        canonical_units: 1
-       description: ww3 import 
+       description: ww3 import
      #
      #
      # WW3 export

--- a/mediator/fd_nems.yaml
+++ b/mediator/fd_nems.yaml
@@ -355,6 +355,7 @@
      #
      - standard_name: So_s
        alias: s_surf
+       alias: sea_surface_salinity
        canonical_units: g kg-1
        description: ocean export
      #
@@ -452,6 +453,7 @@
        alias: mean_merid_moment_flx
        canonical_units: N m-2
        description: ocean import - meridional surface stress to ocean
+     #
      #
      #-----------------------------------
      # mediator fields
@@ -585,5 +587,119 @@
        canonical_units: W m-2
      - standard_name: land_mask
        canonical_units: 1
+     #
+     #-----------------------------------
+     # WW3 import
+     #-----------------------------------
+     #
+     - standard_name: sea_surface_height_above_sea_level
+       canonical_units: m 
+       description: ww3 import 
+     #
+     - standard_name: surface_eastward_sea_water_velocity
+       #alias: So_u
+       alias: ocn_current_zonal
+       canonical_units: m s-1
+       description: ww3 import 
+     #
+     - standard_name: surface_northward_sea_water_velocity
+       #alias: So_v
+       alias: ocn_current_merid
+       canonical_units: m s-1
+       description: ww3 import 
+     #
+     - standard_name: eastward_wind_at_10m_height
+       alias: inst_zonal_wind_height10m
+       canonical_units: m s-1
+       description: ww3 import 
+     #
+     - standard_name: northward_wind_at_10m_height
+       alias: inst_merid_wind_height10m
+       canonical_units: m s-1
+       description: ww3 import 
+     #
+     - standard_name: sea_ice_concentration
+       #alias: Si_ifrac
+       alias: ice_fraction
+       canonical_units: 1
+       description: ww3 import 
+     #
+     #
+     # WW3 export
+     #
+     - standard_name: wave_induced_charnock_parameter
+       canonical_units: 1
+       description: ww3 export 
+     #
      - standard_name: wave_z0_roughness_length
        canonical_units: 1
+       description: ww3 export 
+     #
+     - standard_name: northward_stokes_drift_current
+       canonical_units: m s-1
+       description: ww3 export 
+     #
+     - standard_name: eastward_stokes_drift_current
+       canonical_units: m s-1
+       description: ww3 export 
+     #
+     - standard_name: eastward_partitioned_stokes_drift_1
+       canonical_units: m s-1
+       description: ww3 export 
+     #
+     - standard_name: eastward_partitioned_stokes_drift_2
+       canonical_units: m s-1
+       description: ww3 export 
+     #
+     - standard_name: eastward_partitioned_stokes_drift_3
+       canonical_units: m s-1
+       description: ww3 export 
+     #
+     - standard_name: northward_partitioned_stokes_drift_1
+       canonical_units: m s-1
+       description: ww3 export 
+     #
+     - standard_name: northward_partitioned_stokes_drift_2
+       canonical_units: m s-1
+       description: ww3 export 
+     #
+     - standard_name: northward_partitioned_stokes_drift_3
+       canonical_units: m s-1
+       description: ww3 export 
+     #
+     - standard_name: eastward_wave_bottom_current
+       canonical_units: m s-1
+       description: ww3 export 
+     #
+     - standard_name: northward_wave_bottom_current
+       canonical_units: m s-1
+       description: ww3 export 
+     #
+     - standard_name: wave_bottom_current_radian_frequency
+       canonical_units: rad s-1
+       description: ww3 export 
+     #
+     - standard_name: eastward_wave_radiation_stress_gradient
+       canonical_units: Pa
+       description: ww3 export 
+     #
+     - standard_name: northward_wave_radiation_stress_gradient
+       canonical_units: Pa
+       description: ww3 export 
+     #
+     - standard_name: eastward_wave_radiation_stress
+       canonical_units: N m-1
+       description: ww3 export 
+     #
+     - standard_name: eastward_northward_wave_radiation_stress
+       canonical_units: N m-1
+       description: ww3 export 
+     #
+     - standard_name: wave_bottom_current_period
+       canonical_units: s
+       description: ww3 export 
+     #
+     - standard_name: northward_wave_radiation_stress
+       canonical_units: Pa
+       description: ww3 export 
+     #


### PR DESCRIPTION
### Description of changes
Adds nems-specific field names and aliases for coupling ww3 through connectors in UFS-S2S-model

### Specific notes

Contributors other than yourself, if any:
@mvertens 

CMEPS Issues Fixed (include github issue #):

Are changes expected to change answers (and if so in what way)?
No
Any User Interface Changes (namelist or namelist defaults changes)?

Testing performed if application target is CESM:(either UFS-S2S or CESM testing is required):
- [ ] (required) CIME_DRIVER=nuopc scripts_regression_tests.py
   - machines:
   - details (e.g. failed tests):
- [ ] (required) CESM testlist_drv.xml
   - machines and compilers:
   - details (e.g. failed tests):
- [ ] (optional) CESM prealpha test
   - machines and compilers
   - details (e.g. failed tests):

Testing performed if application target is UFS-S2S:
- [X] (required) UFS-S2S testing
   - description: baselines created
   - details (e.g. failed tests):

Hashes used for testing:
- [ ] CESM:
  - repository to check out: https://github.com/ESCOMP/CESM.git
  - branch: nuopc_dev
  - hash:
- [x ] UFS-S2S, then umbrella repostiory to check out and associated hash:
  - repository to check out: https://github.com/DeniseWorthen/ufs-s2s-model
  - branch:feature/cmeps_altrt
  - hash: e42cc24f
