### PR TITLE
fix for NEMS app

### DIFF
--- a/mediator/Makefile
+++ b/mediator/Makefile
@@ -30,13 +30,14 @@ clean:
 med_kind_mod.o : 
 med_constants_mod.o : med_kind_mod.o
 esmFlds.o : med_kind_mod.o
-esmFldsExchange_cesm_mod.o : med_kind_mod.o med_methods_mod.o esmFlds.o med_internalstate_mod.o med_utils_mod.o   
-eesmFldsExchange_nems_mod.o : med_kind_mod.o med_methods_mod.o esmFlds.o med_internalstate_mod.o med_utils_mod.o   
+esmFldsExchange_cesm_mod.o : med_kind_mod.o med_methods_mod.o esmFlds.o med_internalstate_mod.o med_utils_mod.o
+esmFldsExchange_nems_mod.o : med_kind_mod.o med_methods_mod.o esmFlds.o med_internalstate_mod.o med_utils_mod.o
+esmFldsExchange_hafs_mod.o : med_kind_mod.o med_methods_mod.o esmFlds.o med_internalstate_mod.o med_utils_mod.o
 med.o : med_kind_mod.o med_phases_profile_mod.o med_utils_mod.o med_phases_prep_rof_mod.o med_phases_aofluxes_mod.o \
    med_phases_prep_ice_mod.o med_fraction_mod.o med_map_mod.o med_constants_mod.o med_phases_prep_wav_mod.o \
    med_phases_prep_lnd_mod.o med_phases_history_mod.o med_phases_ocnalb_mod.o med_phases_restart_mod.o \
-   med_time_mod.o med_internalstate_mod.o med_phases_prep_atm_mod.o esmFldsExchange_cesm_mod.o esmFldsExchange_nems_mod.o\
-   med_phases_prep_glc_mod.o esmFlds.o med_io_mod.o med_methods_mod.o med_phases_prep_ocn_mod.o   
+   med_time_mod.o med_internalstate_mod.o med_phases_prep_atm_mod.o esmFldsExchange_cesm_mod.o esmFldsExchange_nems_mod.o \
+   esmFldsExchange_hafs_mod.o med_phases_prep_glc_mod.o esmFlds.o med_io_mod.o med_methods_mod.o med_phases_prep_ocn_mod.o
 med_fraction_mod.o : med_kind_mod.o med_utils_mod.o med_internalstate_mod.o med_constants_mod.o med_map_mod.o med_methods_mod.o esmFlds.o   
 med_internalstate_mod.o : med_kind_mod.o esmFlds.o   
 med_io_mod.o : med_kind_mod.o med_methods_mod.o med_constants_mod.o med_internalstate_mod.o med_utils_mod.o   

--- a/mediator/med.F90
+++ b/mediator/med.F90
@@ -2184,7 +2184,7 @@ contains
   subroutine med_grid_write(grid, fileName, rc)
 
     use ESMF, only : ESMF_Grid, ESMF_Array, ESMF_ArrayBundle
-    use ESMF, only : ESMF_ArrayBundleCreate
+    use ESMF, only : ESMF_ArrayBundleCreate, ESMF_GridGet
     use ESMF, only : ESMF_GridGetCoord, ESMF_ArraySet, ESMF_ArrayBundleAdd
     use ESMF, only : ESMF_GridGetItem, ESMF_ArrayBundleWrite, ESMF_ArrayBundleDestroy
     use ESMF, only : ESMF_STAGGERLOC_CENTER, ESMF_STAGGERLOC_CORNER
@@ -2198,149 +2198,157 @@ contains
     ! local variables
     type(ESMF_Array) :: array
     type(ESMF_ArrayBundle) :: arrayBundle
+    integer :: tileCount
     logical :: isPresent
     character(len=*), parameter :: subname='(module_MED_Map:med_grid_write)'
     !-------------------------------------------------------------------------------
 
     rc = ESMF_SUCCESS
 
-    ! Create arraybundle to store grid information
-    arrayBundle = ESMF_ArrayBundleCreate(rc=rc)
+    ! Check that the grid has tiles or not
+    ! Currently only supports single tile
+    call ESMF_GridGet(grid, tileCount=tileCount, rc=rc)
     if (chkerr(rc,__LINE__,u_FILE_u)) return
 
-    ! Query grid for center stagger
-    ! Coordinates
-    call ESMF_GridGetCoord(grid, staggerLoc=ESMF_STAGGERLOC_CENTER, &
-          isPresent=isPresent, rc=rc)
-    if (chkerr(rc,__LINE__,u_FILE_u)) return
-
-    if (isPresent) then
-      call ESMF_GridGetCoord(grid, coordDim=1, &
-           staggerLoc=ESMF_STAGGERLOC_CENTER, array=array, rc=rc)
+    if (tileCount .eq. 1) then
+      ! Create arraybundle to store grid information
+      arrayBundle = ESMF_ArrayBundleCreate(rc=rc)
       if (chkerr(rc,__LINE__,u_FILE_u)) return
 
-      call ESMF_ArraySet(array, name="lon_center", rc=rc)
+      ! Query grid for center stagger
+      ! Coordinates
+      call ESMF_GridGetCoord(grid, staggerLoc=ESMF_STAGGERLOC_CENTER, &
+            isPresent=isPresent, rc=rc)
       if (chkerr(rc,__LINE__,u_FILE_u)) return
 
-      call ESMF_ArrayBundleAdd(arrayBundle, (/array/), rc=rc)
+      if (isPresent) then
+        call ESMF_GridGetCoord(grid, coordDim=1, &
+             staggerLoc=ESMF_STAGGERLOC_CENTER, array=array, rc=rc)
+        if (chkerr(rc,__LINE__,u_FILE_u)) return
+
+        call ESMF_ArraySet(array, name="lon_center", rc=rc)
+        if (chkerr(rc,__LINE__,u_FILE_u)) return
+
+        call ESMF_ArrayBundleAdd(arrayBundle, (/array/), rc=rc)
+        if (chkerr(rc,__LINE__,u_FILE_u)) return
+
+        call ESMF_GridGetCoord(grid, coordDim=2, &
+             staggerLoc=ESMF_STAGGERLOC_CENTER, array=array, rc=rc)
+        if (chkerr(rc,__LINE__,u_FILE_u)) return
+
+        call ESMF_ArraySet(array, name="lat_center", rc=rc)
+        if (chkerr(rc,__LINE__,u_FILE_u)) return
+
+        call ESMF_ArrayBundleAdd(arrayBundle, (/array/), rc=rc)
+        if (chkerr(rc,__LINE__,u_FILE_u)) return
+      endif
+
+
+      ! Mask
+      call ESMF_GridGetItem(grid, itemflag=ESMF_GRIDITEM_MASK, &
+           staggerLoc=ESMF_STAGGERLOC_CENTER, isPresent=isPresent, rc=rc)
       if (chkerr(rc,__LINE__,u_FILE_u)) return
 
-      call ESMF_GridGetCoord(grid, coordDim=2, &
-           staggerLoc=ESMF_STAGGERLOC_CENTER, array=array, rc=rc)
+      if (isPresent) then
+        call ESMF_GridGetItem(grid, staggerLoc=ESMF_STAGGERLOC_CENTER, &
+             itemflag=ESMF_GRIDITEM_MASK, array=array, rc=rc)
+        if (chkerr(rc,__LINE__,u_FILE_u)) return
+
+        call ESMF_ArraySet(array, name="mask_center", rc=rc)
+        if (chkerr(rc,__LINE__,u_FILE_u)) return
+
+        call ESMF_ArrayBundleAdd(arrayBundle, (/array/), rc=rc)
+        if (chkerr(rc,__LINE__,u_FILE_u)) return
+      endif
+
+      ! Area
+      call ESMF_GridGetItem(grid, itemflag=ESMF_GRIDITEM_AREA, &
+           staggerLoc=ESMF_STAGGERLOC_CENTER, isPresent=isPresent, rc=rc)
       if (chkerr(rc,__LINE__,u_FILE_u)) return
 
-      call ESMF_ArraySet(array, name="lat_center", rc=rc)
+      if (isPresent) then
+        call ESMF_GridGetItem(grid, staggerLoc=ESMF_STAGGERLOC_CENTER, &
+             itemflag=ESMF_GRIDITEM_AREA, array=array, rc=rc)
+        if (chkerr(rc,__LINE__,u_FILE_u)) return
+
+        call ESMF_ArraySet(array, name="area_center", rc=rc)
+        if (chkerr(rc,__LINE__,u_FILE_u)) return
+
+        call ESMF_ArrayBundleAdd(arrayBundle, (/array/), rc=rc)
+        if (chkerr(rc,__LINE__,u_FILE_u)) return
+      endif
+
+      ! Query grid for corner stagger
+      ! Coordinates
+      call ESMF_GridGetCoord(grid, staggerLoc=ESMF_STAGGERLOC_CORNER, &
+            isPresent=isPresent, rc=rc)
       if (chkerr(rc,__LINE__,u_FILE_u)) return
 
-      call ESMF_ArrayBundleAdd(arrayBundle, (/array/), rc=rc)
-      if (chkerr(rc,__LINE__,u_FILE_u)) return
-    endif
+      if (isPresent) then
+        call ESMF_GridGetCoord(grid, coordDim=1, &
+             staggerLoc=ESMF_STAGGERLOC_CORNER, array=array, rc=rc)
+        if (chkerr(rc,__LINE__,u_FILE_u)) return
 
+        call ESMF_ArraySet(array, name="lon_corner", rc=rc)
+        if (chkerr(rc,__LINE__,u_FILE_u)) return
 
-    ! Mask
-    call ESMF_GridGetItem(grid, itemflag=ESMF_GRIDITEM_MASK, &
-         staggerLoc=ESMF_STAGGERLOC_CENTER, isPresent=isPresent, rc=rc)
-    if (chkerr(rc,__LINE__,u_FILE_u)) return
+        call ESMF_ArrayBundleAdd(arrayBundle, (/array/), rc=rc)
+        if (chkerr(rc,__LINE__,u_FILE_u)) return
 
-    if (isPresent) then
-      call ESMF_GridGetItem(grid, staggerLoc=ESMF_STAGGERLOC_CENTER, &
-           itemflag=ESMF_GRIDITEM_MASK, array=array, rc=rc)
-      if (chkerr(rc,__LINE__,u_FILE_u)) return
+        call ESMF_GridGetCoord(grid, coordDim=2, &
+             staggerLoc=ESMF_STAGGERLOC_CORNER, array=array, rc=rc)
+        if (chkerr(rc,__LINE__,u_FILE_u)) return
 
-      call ESMF_ArraySet(array, name="mask_center", rc=rc)
-      if (chkerr(rc,__LINE__,u_FILE_u)) return
+        call ESMF_ArraySet(array, name="lat_corner", rc=rc)
+        if (chkerr(rc,__LINE__,u_FILE_u)) return
 
-      call ESMF_ArrayBundleAdd(arrayBundle, (/array/), rc=rc)
-      if (chkerr(rc,__LINE__,u_FILE_u)) return
-    endif
+        call ESMF_ArrayBundleAdd(arrayBundle, (/array/), rc=rc)
+        if (chkerr(rc,__LINE__,u_FILE_u)) return
+      endif
 
-    ! Area
-    call ESMF_GridGetItem(grid, itemflag=ESMF_GRIDITEM_AREA, &
-         staggerLoc=ESMF_STAGGERLOC_CENTER, isPresent=isPresent, rc=rc)
-    if (chkerr(rc,__LINE__,u_FILE_u)) return
-
-    if (isPresent) then
-      call ESMF_GridGetItem(grid, staggerLoc=ESMF_STAGGERLOC_CENTER, &
-           itemflag=ESMF_GRIDITEM_AREA, array=array, rc=rc)
+      ! Mask
+      call ESMF_GridGetItem(grid, itemflag=ESMF_GRIDITEM_MASK, &
+           staggerLoc=ESMF_STAGGERLOC_CORNER, isPresent=isPresent, rc=rc)
       if (chkerr(rc,__LINE__,u_FILE_u)) return
 
-      call ESMF_ArraySet(array, name="area_center", rc=rc)
+      if (isPresent) then
+        call ESMF_GridGetItem(grid, staggerLoc=ESMF_STAGGERLOC_CORNER, &
+             itemflag=ESMF_GRIDITEM_MASK, array=array, rc=rc)
+        if (chkerr(rc,__LINE__,u_FILE_u)) return
+
+        call ESMF_ArraySet(array, name="mask_corner", rc=rc)
+        if (chkerr(rc,__LINE__,u_FILE_u)) return
+
+        call ESMF_ArrayBundleAdd(arrayBundle, (/array/), rc=rc)
+        if (chkerr(rc,__LINE__,u_FILE_u)) return
+      endif
+
+      ! Area
+      call ESMF_GridGetItem(grid, itemflag=ESMF_GRIDITEM_AREA, &
+           staggerLoc=ESMF_STAGGERLOC_CORNER, isPresent=isPresent, rc=rc)
       if (chkerr(rc,__LINE__,u_FILE_u)) return
 
-      call ESMF_ArrayBundleAdd(arrayBundle, (/array/), rc=rc)
-      if (chkerr(rc,__LINE__,u_FILE_u)) return
-    endif
+      if (isPresent) then
+        call ESMF_GridGetItem(grid, staggerLoc=ESMF_STAGGERLOC_CORNER, &
+             itemflag=ESMF_GRIDITEM_AREA, array=array, rc=rc)
+        if (chkerr(rc,__LINE__,u_FILE_u)) return
 
-    ! Query grid for corner stagger
-    ! Coordinates
-    call ESMF_GridGetCoord(grid, staggerLoc=ESMF_STAGGERLOC_CORNER, &
-          isPresent=isPresent, rc=rc)
-    if (chkerr(rc,__LINE__,u_FILE_u)) return
+        call ESMF_ArraySet(array, name="area_corner", rc=rc)
+        if (chkerr(rc,__LINE__,u_FILE_u)) return
 
-    if (isPresent) then
-      call ESMF_GridGetCoord(grid, coordDim=1, &
-           staggerLoc=ESMF_STAGGERLOC_CORNER, array=array, rc=rc)
-      if (chkerr(rc,__LINE__,u_FILE_u)) return
+        call ESMF_ArrayBundleAdd(arrayBundle, (/array/), rc=rc)
+        if (chkerr(rc,__LINE__,u_FILE_u)) return
+      endif
 
-      call ESMF_ArraySet(array, name="lon_corner", rc=rc)
-      if (chkerr(rc,__LINE__,u_FILE_u)) return
-
-      call ESMF_ArrayBundleAdd(arrayBundle, (/array/), rc=rc)
+      ! Write arraybundle to file
+      call ESMF_ArrayBundleWrite(arrayBundle, &
+           fileName=trim(fileName), overwrite=.true., rc=rc)
       if (chkerr(rc,__LINE__,u_FILE_u)) return
 
-      call ESMF_GridGetCoord(grid, coordDim=2, &
-           staggerLoc=ESMF_STAGGERLOC_CORNER, array=array, rc=rc)
+      ! Destroy arraybundle
+      call ESMF_ArrayBundleDestroy(arrayBundle, rc=rc)
       if (chkerr(rc,__LINE__,u_FILE_u)) return
-
-      call ESMF_ArraySet(array, name="lat_corner", rc=rc)
-      if (chkerr(rc,__LINE__,u_FILE_u)) return
-
-      call ESMF_ArrayBundleAdd(arrayBundle, (/array/), rc=rc)
-      if (chkerr(rc,__LINE__,u_FILE_u)) return
-    endif
-
-    ! Mask
-    call ESMF_GridGetItem(grid, itemflag=ESMF_GRIDITEM_MASK, &
-         staggerLoc=ESMF_STAGGERLOC_CORNER, isPresent=isPresent, rc=rc)
-    if (chkerr(rc,__LINE__,u_FILE_u)) return
-
-    if (isPresent) then
-      call ESMF_GridGetItem(grid, staggerLoc=ESMF_STAGGERLOC_CORNER, &
-           itemflag=ESMF_GRIDITEM_MASK, array=array, rc=rc)
-      if (chkerr(rc,__LINE__,u_FILE_u)) return
-
-      call ESMF_ArraySet(array, name="mask_corner", rc=rc)
-      if (chkerr(rc,__LINE__,u_FILE_u)) return
-
-      call ESMF_ArrayBundleAdd(arrayBundle, (/array/), rc=rc)
-      if (chkerr(rc,__LINE__,u_FILE_u)) return
-    endif
-
-    ! Area
-    call ESMF_GridGetItem(grid, itemflag=ESMF_GRIDITEM_AREA, &
-         staggerLoc=ESMF_STAGGERLOC_CORNER, isPresent=isPresent, rc=rc)
-    if (chkerr(rc,__LINE__,u_FILE_u)) return
-
-    if (isPresent) then
-      call ESMF_GridGetItem(grid, staggerLoc=ESMF_STAGGERLOC_CORNER, &
-           itemflag=ESMF_GRIDITEM_AREA, array=array, rc=rc)
-      if (chkerr(rc,__LINE__,u_FILE_u)) return
-
-      call ESMF_ArraySet(array, name="area_corner", rc=rc)
-      if (chkerr(rc,__LINE__,u_FILE_u)) return
-
-      call ESMF_ArrayBundleAdd(arrayBundle, (/array/), rc=rc)
-      if (chkerr(rc,__LINE__,u_FILE_u)) return
-    endif
-
-    ! Write arraybundle to file
-    call ESMF_ArrayBundleWrite(arrayBundle, &
-         fileName=trim(fileName), overwrite=.true., rc=rc)
-    if (chkerr(rc,__LINE__,u_FILE_u)) return
-
-    ! Destroy arraybundle
-    call ESMF_ArrayBundleDestroy(arrayBundle, rc=rc)
-    if (chkerr(rc,__LINE__,u_FILE_u)) return
+    end if
 
   end subroutine med_grid_write
 


### PR DESCRIPTION
### Description of changes
It fixes issues related to the latest CMEPS PR #68 for the NEMS application.

### Specific notes

Contributors other than yourself, if any:

CMEPS Issues Fixed (include github issue #): https://github.com/ESCOMP/CMEPS/issues/68

Are changes expected to change answers (and if so in what way)? No

Any User Interface Changes (namelist or namelist defaults changes)? No

Testing performed if application target is CESM:(either UFS-S2S or CESM testing is required):
- [x] (required) CIME_DRIVER=nuopc scripts_regression_tests.py
   - machines: Cheyenne
   - details (e.g. failed tests): master (cf4e44c)
```
======================================================================
FAIL: test_bless_test_results (__main__.Q_TestBlessTestResults)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "./scripts/tests/scripts_regression_tests.py", line 1779, in test_bless_test_results
    msg="Cmd '%s' failed to display failed test %s in output:\n%s" % (cpr_cmd, test_name, output))
AssertionError: Cmd '/glade/scratch/turuncu/CESM/cime/scripts/Tools/compare_test_results --test-root /glade/scratch/turuncu/scripts_regression_test.20200608_160247 -t fake_testing_only_20200608_163822-20200608_164415 2>&1' failed to display failed test TESTRUNDIFFRESUBMIT_P1.f19_g16_rx1.A in output:
FAIL TESTRUNDIFFRESUBMIT_P1.f19_g16_rx1.A.cheyenne_intel NLCOMP See /glade/scratch/turuncu/scripts_regression_test.20200608_160247/TESTRUNDIFFRESUBMIT_P1.f19_g16_rx1.A.cheyenne_intel.C.fake_testing_only_20200608_163822-20200608_164415/compare.log.fake_testing_only_20200608_163822.20200608_164521
PASS TESTRUNDIFFRESUBMIT_P1.f19_g16_rx1.A.cheyenne_intel BASELINE

======================================================================
FAIL: test_rebless_namelist (__main__.Q_TestBlessTestResults)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "./scripts/tests/scripts_regression_tests.py", line 1875, in test_rebless_namelist
    verify_perms(self, self._baseline_area)
  File "./scripts/tests/scripts_regression_tests.py", line 87, in verify_perms
    test_obj.assertTrue(st.st_mode & osstat.S_IWGRP, msg="file {} is not group writeable".format(full_path))
AssertionError: file /glade/scratch/turuncu/scripts_regression_test.20200608_160247/baselines/fake_testing_only_20200608_163822/TESTRUNDIFFRESUBMIT_P1.f19_g16_rx1.A.cheyenne_intel/cpl.log.gz is not group writeable
```
- [x] (required) CESM testlist_drv.xml
   - machines and compilers: Cheyenne (MPT - 2.21 and Intel Compiler - 19.0.5)
   - details (e.g. failed tests): qcmd -l walltime=4:00:00 -- ./create_test --xml-testlist ../src/drivers/nuopc/cime_config/testdefs/testlist_drv.xml --xml-machine cheyenne --xml-category nuopc --compare apr26 --baseline-root /glade/p/cesmdata/cseg/nuopc_baselines
Just getting NLFAIL and FIELDLIST field lists differ (otherwise bit-for-bit), which seem normal. FIELDLIST is related with adding new variable to data atmosphere.

- [ ] (optional) CESM prealpha test
   - machines and compilers
   - details (e.g. failed tests):

Testing performed if application target is UFS-S2S:
- [x] (required) UFS-S2S testing
   - description: run cold start w/ nems_fix branch successfully (/glade/scratch/worthen/testfix). 
   - details (e.g. failed tests):

Hashes used for testing:
- [x] CESM:
  - repository to check out: https://github.com/ESCOMP/CESM.git
  - branch: nuopc_dev
  - hash: CIME updated to master (cf4e44c) and CMEPS updated master and merged with nems_fix branch
- [ ] UFS-S2S, then umbrella repostiory to check out and associated hash:
  - repository to check out:
  - branch:
  - hash:
