### PR TITLE
Update TFREEZE_SALTWATER_OPTION value for MOM6

### DIFF
--- a/cime_config/config_component_cesm.xml
+++ b/cime_config/config_component_cesm.xml
@@ -545,6 +545,9 @@
     <type>char</type>
     <valid_values>minus1p8,linear_salt,mushy</valid_values>
     <default_value>mushy</default_value>
+    <values match="last">
+      <value compset="_MOM6">linear_salt</value>
+    </values>
     <group>run_physics</group>
     <file>env_run.xml</file>
     <desc>Freezing point calculation for salt water.</desc>


### PR DESCRIPTION
Changes the default value of TFREEZE_SALTWATER_OPTION for MOM6 from mushy to linear_salt.

Test suite: SMS.CMOM.T62_t061, SMS.C.T62_t061
Test baseline:
Test namelist changes: changes xml var TFREEZE_SALTWATER_OPTION for MOM6 only
Test status: changes answers for MOM6 only
