### PR TITLE
cleanup and changes to be consistent with nems 

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,9 +6,14 @@ Contributors other than yourself, if any:
 
 CMEPS Issues Fixed (include github issue #):
 
-Are changes expected to change answers (and if so in what way)?
+Are changes expected to change answers?
+ - [ ] bit for bit
+ - [ ] different at roundoff level
+ - [ ] more substantial 
 
 Any User Interface Changes (namelist or namelist defaults changes)?
+ - [ ] Yes
+ - [ ] No
 
 Testing performed if application target is CESM:(either UFS-S2S or CESM testing is required):
 - [ ] (required) CIME_DRIVER=nuopc scripts_regression_tests.py

--- a/cime_config/buildexe
+++ b/cime_config/buildexe
@@ -49,7 +49,14 @@ def _main_func():
         if valid:
             valid_comps.append(item)
 
-    if len(valid_comps) == 2 and  "dwav" not in case.get_value("COMP_WAV") and "dlnd" not in case.get_value("COMP_LND"):
+    datamodel_in_compset = ("datm" in case.get_value("COMP_ATM") or
+                            "dice" in case.get_value("COMP_ICE") or
+                            "dlnd" in case.get_value("COMP_LND") or
+                            "docn" in case.get_value("COMP_OCN") or
+                            "drof" in case.get_value("COMP_ROF") or
+                            "dwav" in case.get_value("COMP_WAV"))
+
+    if len(valid_comps) == 2 and not datamodel_in_compset:
         skip_mediator = True
     else:
         skip_mediator = False

--- a/cime_config/buildexe
+++ b/cime_config/buildexe
@@ -49,12 +49,11 @@ def _main_func():
         if valid:
             valid_comps.append(item)
 
-    datamodel_in_compset = ("datm" in case.get_value("COMP_ATM") or
-                            "dice" in case.get_value("COMP_ICE") or
-                            "dlnd" in case.get_value("COMP_LND") or
-                            "docn" in case.get_value("COMP_OCN") or
-                            "drof" in case.get_value("COMP_ROF") or
-                            "dwav" in case.get_value("COMP_WAV"))
+    datamodel_in_compset = False 
+    for comp in comp_classes:
+        dcompname = "d"+comp.lower()
+        if dcompname in case.get_value("COMP_{}".format(comp):
+                                       datamodel_in_compset = True
 
     if len(valid_comps) == 2 and not datamodel_in_compset:
         skip_mediator = True

--- a/cime_config/buildexe
+++ b/cime_config/buildexe
@@ -54,7 +54,7 @@ def _main_func():
     for comp in comp_classes:
         dcompname = "d"+comp.lower()
         if dcompname in case.get_value("COMP_{}".format(comp)):
-                                       datamodel_in_compset = True
+            datamodel_in_compset = True
 
     if len(valid_comps) == 2 and not datamodel_in_compset:
         skip_mediator = True

--- a/cime_config/buildexe
+++ b/cime_config/buildexe
@@ -41,7 +41,8 @@ def _main_func():
 
     # Determine valid components
     valid_comps = []
-    for item in case.get_values("COMP_CLASSES"):
+    comp_classes = case.get_values("COMP_CLASSES")
+    for item in comp_classes:
         comp = case.get_value("COMP_" + item)
         valid = True
         if comp == 's' + item.lower():
@@ -52,7 +53,7 @@ def _main_func():
     datamodel_in_compset = False 
     for comp in comp_classes:
         dcompname = "d"+comp.lower()
-        if dcompname in case.get_value("COMP_{}".format(comp):
+        if dcompname in case.get_value("COMP_{}".format(comp)):
                                        datamodel_in_compset = True
 
     if len(valid_comps) == 2 and not datamodel_in_compset:

--- a/cime_config/buildnml
+++ b/cime_config/buildnml
@@ -238,9 +238,10 @@ def _create_drv_namelists(case, infile, confdir, nmlgen, files):
 
     # Determine if there are any data components in the compset
     datamodel_in_compset = False 
+    comp_classes = case.get_values("COMP_CLASSES")
     for comp in comp_classes:
         dcompname = "d"+comp.lower()
-        if dcompname in case.get_value("COMP_{}".format(comp):
+        if dcompname in case.get_value("COMP_{}".format(comp)):
                                        datamodel_in_compset = True
 
     # Determine if will skip the mediator and then set the

--- a/cime_config/buildnml
+++ b/cime_config/buildnml
@@ -237,14 +237,11 @@ def _create_drv_namelists(case, infile, confdir, nmlgen, files):
             valid_comps.append(item)
 
     # Determine if there are any data components in the compset
-    datamodel_in_compset = ("datm" in case.get_value("COMP_ATM") or
-                            "dice" in case.get_value("COMP_ICE") or
-                            "dlnd" in case.get_value("COMP_LND") or
-                            "docn" in case.get_value("COMP_OCN") or
-                            "drof" in case.get_value("COMP_ROF") or
-                            "dwav" in case.get_value("COMP_WAV"))
-
-
+    datamodel_in_compset = False 
+    for comp in comp_classes:
+        dcompname = "d"+comp.lower()
+        if dcompname in case.get_value("COMP_{}".format(comp):
+                                       datamodel_in_compset = True
 
     # Determine if will skip the mediator and then set the
     # driver rpointer file if there is only one non-stub component then skip mediator

--- a/cime_config/buildnml
+++ b/cime_config/buildnml
@@ -242,7 +242,7 @@ def _create_drv_namelists(case, infile, confdir, nmlgen, files):
     for comp in comp_classes:
         dcompname = "d"+comp.lower()
         if dcompname in case.get_value("COMP_{}".format(comp)):
-                                       datamodel_in_compset = True
+            datamodel_in_compset = True
 
     # Determine if will skip the mediator and then set the
     # driver rpointer file if there is only one non-stub component then skip mediator

--- a/cime_config/buildnml
+++ b/cime_config/buildnml
@@ -236,15 +236,27 @@ def _create_drv_namelists(case, infile, confdir, nmlgen, files):
         if valid:
             valid_comps.append(item)
 
-    # set the driver rpointer file if there is only one non-stub component then skip mediator 
-   
-    if len(valid_comps) == 2 and  "dwav" not in case.get_value("COMP_WAV") and "dlnd" not in case.get_value("COMP_LND"):
+    # Determine if there are any data components in the compset
+    datamodel_in_compset = ("datm" in case.get_value("COMP_ATM") or
+                            "dice" in case.get_value("COMP_ICE") or
+                            "dlnd" in case.get_value("COMP_LND") or
+                            "docn" in case.get_value("COMP_OCN") or
+                            "drof" in case.get_value("COMP_ROF") or
+                            "dwav" in case.get_value("COMP_WAV"))
+
+
+
+    # Determine if will skip the mediator and then set the
+    # driver rpointer file if there is only one non-stub component then skip mediator
+    if len(valid_comps) == 2 and not datamodel_in_compset:
+        # skip the mediator if there is a prognostic component and all other components are stub
         skip_mediator = True
         valid_comps.remove("CPL")
         nmlgen.set_value('mediator_present', value='.false.')
         nmlgen.set_value("drv_restart_pointer", value="none")
         nmlgen.set_value("component_list", value=" ".join(valid_comps))
     else:
+        # do not skip mediator if there is a data component but all other components are stub
         skip_mediator = False
         nmlgen.set_value("drv_restart_pointer", value="rpointer.cpl")
         valid_comps_string = " ".join(valid_comps)
@@ -252,13 +264,13 @@ def _create_drv_namelists(case, infile, confdir, nmlgen, files):
 
     logger.info("Writing nuopc_runseq for components {}".format(valid_comps))
     nuopc_config_file = os.path.join(confdir, "nuopc.runconfig")
-    nmlgen.write_nuopc_config_file(nuopc_config_file, data_list_path=data_list_path) 
+    nmlgen.write_nuopc_config_file(nuopc_config_file, data_list_path=data_list_path)
 
     #--------------------------------
-    # (3.1) Update nuopc.runconfig file if component needs it 
+    # (3.1) Update nuopc.runconfig file if component needs it
     #--------------------------------
 
-    # Read nuopc.runconfig 
+    # Read nuopc.runconfig
     with open(nuopc_config_file, 'r') as f:
         lines_cpl = f.readlines()
 
@@ -268,7 +280,8 @@ def _create_drv_namelists(case, infile, confdir, nmlgen, files):
         if comp != 'CPL' and case.get_value("COMP_{}".format(comp)) != 'd'+comp.lower():
             # Read *.configure file for component
             caseroot = case.get_value('CASEROOT')
-            comp_config_file = os.path.join(caseroot,"Buildconf","{}conf".format(case.get_value("COMP_{}".format(comp))),"{}.configure".format(case.get_value("COMP_{}".format(comp))))
+            comp_config_file = os.path.join(caseroot,"Buildconf","{}conf".format(case.get_value("COMP_{}".format(comp))),
+                                            "{}.configure".format(case.get_value("COMP_{}".format(comp))))
             if os.path.isfile(comp_config_file):
                 with open(comp_config_file, 'r') as f:
                     lines_comp = f.readlines()
@@ -359,7 +372,7 @@ def _create_runseq(case, coupling_times, valid_comps):
 
     else:
 
-        if len(valid_comps) == 1: 
+        if len(valid_comps) == 1:
 
             # Create run sequence with no mediator
             outfile = open(os.path.join(caseroot, "CaseDocs", "nuopc.runseq"), "w")
@@ -371,7 +384,7 @@ def _create_runseq(case, coupling_times, valid_comps):
             outfile.write (":: \n")
             outfile.close()
             shutil.copy(os.path.join(caseroot, "CaseDocs", "nuopc.runseq"), rundir)
-            
+
         else:
 
             # Create a run sequence file appropriate for target compset
@@ -389,7 +402,7 @@ def _create_runseq(case, coupling_times, valid_comps):
                 from runseq_TG import gen_runseq
             elif (comp_atm == 'ufsatm' and comp_ocn == "mom" and comp_ice == 'cice'):
                 from runseq_NEMS import gen_runseq
-            else: 
+            else:
                 from runseq_general import gen_runseq
 
             # create the run sequence
@@ -473,7 +486,7 @@ def _create_component_modelio_namelists(confdir, case, files):
                     outfile.write("     {}{}{}".format("logfile = ", logfile,"\n"))
                     outfile.write("::\n\n")
 
-                    # also write out a driver log file 
+                    # also write out a driver log file
                     if model == 'cpl':
                         name = "DRV"
                         logfile = 'drv' + inst_string + ".log." + str(lid)

--- a/cime_config/config_pes.xml
+++ b/cime_config/config_pes.xml
@@ -207,4 +207,3 @@
     </mach>
   </grid>
 </config_pes>
-

--- a/cime_config/namelist_definition_drv_flds.xml
+++ b/cime_config/namelist_definition_drv_flds.xml
@@ -4,7 +4,7 @@
 
 <entry_id version="2.0">
 
-  <!-- 
+  <!--
        The following lists all of the namelist variables that can appear in the Buildconf/xxxconf/drv_flds_in
        files, where xxx = [cam, clm, ...]. The driver buildnml treats all of these files as user_nl_cpl files
        for generating the driver drv_flds_in file, which will appear in CaseDocs and in $RUNDIR.

--- a/cime_config/runseq/driver_config.py
+++ b/cime_config/runseq/driver_config.py
@@ -4,10 +4,10 @@
 class DriverConfig(dict):
 
     ###############################################
-    def __init__(self, case, coupling_times): 
+    def __init__(self, case, coupling_times):
     ###############################################
-        # this initializes the dictionary  
-        super(DriverConfig,self).__init__() 
+        # this initializes the dictionary
+        super(DriverConfig,self).__init__()
 
         self['atm'] = self.__compute_atm(case, coupling_times)
         self['glc'] = self.__compute_glc(case, coupling_times)
@@ -36,7 +36,7 @@ class DriverConfig(dict):
 
         # TODO: need to put in special logical for adiabatic mode - where the atmosphere does
         # does not really send anything to the mediator
-        # This will be the case if (case.get_value('COMP_OCN') == 'socn'): 
+        # This will be the case if (case.get_value('COMP_OCN') == 'socn'):
         # In this case - a special run sequence should be written
 
         return (run_atm, med_to_atm, coupling_times["atm_cpl_dt"])
@@ -95,7 +95,7 @@ class DriverConfig(dict):
         if (comp_ice == 'sice'):
             run_ice = False
             med_to_ice = False
-        
+
         return (run_ice, med_to_ice, coupling_times["ice_cpl_dt"])
 
     ###############################################
@@ -181,4 +181,3 @@ class DriverConfig(dict):
             med_to_wav = if_prognostic
 
         return (run_wav, med_to_wav, coupling_times["wav_cpl_dt"])
-

--- a/cime_config/runseq/gen_runseq.py
+++ b/cime_config/runseq/gen_runseq.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 class RunSeq:
-    def __init__(self, outfile): 
+    def __init__(self, outfile):
         self.__time_loop = list()
         self.__outfile_name = outfile
         self.__outfile = None
@@ -10,7 +10,7 @@ class RunSeq:
         self.__outfile = open(self.__outfile_name, "w")
         self.__outfile.write("runSeq:: \n")
         return self
-    
+
     def __exit__(self, *_):
         self.__exit_sequence()
         self.__outfile.close()
@@ -50,10 +50,8 @@ class RunSeq:
                 self.__outfile.write ("  MED med_phases_restart_write        \n" )
                 self.__outfile.write ("  MED med_phases_profile              \n" )
             self.__outfile.write ("@ \n" )
-            
+
     def __exit_sequence(self):
         while self.__time_loop:
             self.leave_time_loop(True)
         self.__outfile.write ("::\n" )
-
-

--- a/cime_config/runseq/runseq_D.py
+++ b/cime_config/runseq/runseq_D.py
@@ -21,12 +21,12 @@ def gen_runseq(case, coupling_times):
     driver_config = DriverConfig(case, coupling_times)
     run_atm, med_to_atm, atm_cpl_time = driver_config['atm']
     run_ice, med_to_ice, ice_cpl_time = driver_config['ice']
-    run_ocn, med_to_ocn, ocn_cpl_time = driver_config['ocn']  
+    run_ocn, med_to_ocn, ocn_cpl_time = driver_config['ocn']
     run_rof, _         , _            = driver_config['rof']
 
     if ice_cpl_time != atm_cpl_time:
         expect(False,"for D compsets require that ice_cpl_time equal atm_cpl_time")
-        
+
     with RunSeq(os.path.join(caseroot, "CaseDocs", "nuopc.runseq")) as runseq:
 
         runseq.enter_time_loop(ocn_cpl_time, newtime=((ocn_cpl_time)))

--- a/cime_config/runseq/runseq_TG.py
+++ b/cime_config/runseq/runseq_TG.py
@@ -38,7 +38,7 @@ def gen_runseq(case, coupling_times):
         runseq.add_action ("GLC"                            , run_glc)
         runseq.add_action ("GLC -> MED :remapMethod=redist" , run_glc)
         runseq.add_action ("MED med_phases_history_write"   , True)
-        
+
         runseq.leave_time_loop(True)
-        
+
     shutil.copy(os.path.join(caseroot, "CaseDocs", "nuopc.runseq"), rundir)

--- a/cime_config/runseq/runseq_general.py
+++ b/cime_config/runseq/runseq_general.py
@@ -27,7 +27,7 @@ def gen_runseq(case, coupling_times):
     run_ice, med_to_ice, ice_cpl_time = driver_config['ice']
     run_glc, med_to_glc, glc_cpl_time = driver_config['glc']
     run_lnd, med_to_lnd, lnd_cpl_time = driver_config['lnd']
-    run_ocn, med_to_ocn, ocn_cpl_time = driver_config['ocn']  
+    run_ocn, med_to_ocn, ocn_cpl_time = driver_config['ocn']
     run_rof, med_to_rof, rof_cpl_time = driver_config['rof']
     run_wav, med_to_wav, wav_cpl_time = driver_config['wav']
 
@@ -43,10 +43,10 @@ def gen_runseq(case, coupling_times):
         expect(False, "assume that rof_cpl_time is always greater than or equal to ocn_cpl_time")
 
     rof_outer_loop = run_rof and rof_cpl_time > atm_cpl_time
-    ocn_outer_loop = run_ocn and ocn_cpl_time > atm_cpl_time  
+    ocn_outer_loop = run_ocn and ocn_cpl_time > atm_cpl_time
 
     inner_loop = ((atm_cpl_time < ocn_cpl_time) or
-                  (atm_cpl_time < rof_cpl_time) or 
+                  (atm_cpl_time < rof_cpl_time) or
                   (run_glc and atm_cpl_time < glc_cpl_time) or
                   atm_cpl_time == ocn_cpl_time)
 
@@ -75,7 +75,7 @@ def gen_runseq(case, coupling_times):
 
         runseq.add_action("MED med_phases_prep_ocn_accum_avg"  , med_to_ocn and ocn_outer_loop)
         runseq.add_action("MED -> OCN :remapMethod=redist"     , med_to_ocn and ocn_outer_loop)
-        
+
         #------------------
         runseq.enter_time_loop(atm_cpl_time, newtime=inner_loop)
         #------------------

--- a/mediator/esmFlds.F90
+++ b/mediator/esmFlds.F90
@@ -46,7 +46,7 @@ module esmflds
   ! Set coupling mode
   !-----------------------------------------------
 
-  character(len=10), public :: coupling_mode ! valid values are [cesm,nems_orig,nems_frac,hafs]
+  character(len=CS), public :: coupling_mode ! valid values are [cesm,nems_orig,nems_frac,nems_orig_data,hafs]
 
   !-----------------------------------------------
   ! PUblic methods

--- a/mediator/fd_cesm.yaml
+++ b/mediator/fd_cesm.yaml
@@ -684,7 +684,7 @@
        description: sea-ice export to atm
      #
      - standard_name: Si_t
-       alias: sea_ice_temperature
+       alias: sea_ice_surface_temperature
        canonical_units: K
        description: sea-ice export
      #

--- a/mediator/fd_nems.yaml
+++ b/mediator/fd_nems.yaml
@@ -43,6 +43,22 @@
      # section: atmosphere export
      #-----------------------------------
      #
+     - standard_name: Faxa_bcph
+       canonical_units: kg m-2 s-1
+       description: atmosphere export
+     #
+     - standard_name: Faxa_dstdry
+       canonical_units: kg m-2 s-1
+       description: atmosphere export
+     #
+     - standard_name: Faxa_dstwet
+       canonical_units: kg m-2 s-1
+       description: atmosphere export
+     #
+     #-----------------------------------
+     # section: atmosphere export
+     #-----------------------------------
+     #
      - standard_name: Faxa_swdn
        alias: mean_down_sw_flx
        canonical_units: W m-2
@@ -105,7 +121,11 @@
      - standard_name: Sa_pslv
        alias: inst_pres_height_surface
        canonical_units: Pa
-       description: atmosphere export - instataneous pressure land and sea surface
+       description: atmosphere export - instantaneous pressure land and sea surface
+     #
+     - standard_name: Sa_ptem
+       canonical_units: K
+       description: atmosphere export - bottom layer potential temperature
      #
      - standard_name: Sa_shum
        alias: inst_spec_humid_height_lowest
@@ -200,6 +220,18 @@
        canonical_units: N m-2
        description: sea-ice export - air ice meridional stress
      #
+     - standard_name: Fioi_bcphi
+       canonical_units: kg m-2 s-1
+       description: sea-ice export to ocean - hydrophilic black carbon flux to ocean
+     #
+     - standard_name: Fioi_bcpho
+       canonical_units: kg m-2 s-1
+       description: sea-ice export to ocean - hydrophobic black carbon flux to ocean
+     #
+     - standard_name: Fioi_flxdst
+       canonical_units: kg m-2 s-1
+       description: sea-ice export to ocean - dust aerosol flux to ocean
+     #
      - standard_name: Fioi_melth
        alias: net_heat_flx_to_ocn
        canonical_units: W m-2
@@ -209,6 +241,11 @@
        alias: mean_fresh_water_to_ocean_rate
        canonical_units: kg m-2 s-1
        description: sea-ice export to ocean - fresh water to ocean (h2o flux from melting)
+     #
+     - standard_name: Fioi_meltw_wiso
+       alias: mean_fresh_water_to_ocean_rate_wiso
+       canonical_units: kg m-2 s-1
+       description: sea-ice export to ocean - fresh water to ocean (h2o flux from melting) for 16O, 18O, HDO
      #
      - standard_name: Fioi_salt
        alias: mean_salt_rate
@@ -280,6 +317,10 @@
        canonical_units: 1
        description: sea-ice export - ice mask
      #
+     - standard_name: Si_qref
+       canonical_units: kg kg-1
+       description: sea-ice export to atm
+     #
      - standard_name: Si_t
        alias: sea_ice_surface_temperature
        canonical_units: K
@@ -298,6 +339,10 @@
        canonical_units: m
        description: sea-ice export
          volume of ice per unit area
+     #
+     - standard_name: Si_snowh
+       canonical_units: m
+       description: sea-ice export - surface_snow_water_equivalent
      #
      - standard_name: Si_vsno
        alias: mean_snow_volume
@@ -452,7 +497,6 @@
        alias: mean_merid_moment_flx
        canonical_units: N m-2
        description: ocean import - meridional surface stress to ocean
-     #
      #
      #-----------------------------------
      # mediator fields

--- a/mediator/med.F90
+++ b/mediator/med.F90
@@ -413,7 +413,7 @@ contains
     mastertask = .false.
     if (localPet == 0) mastertask=.true.
 
-    ! Determine mediator logunit 
+    ! Determine mediator logunit
     if (mastertask) then
        call NUOPC_CompAttributeGet(gcomp, name="diro", value=diro, isPresent=isPresent, isSet=isSet, rc=rc)
        if (chkerr(rc,__LINE__,u_FILE_u)) return
@@ -1383,7 +1383,7 @@ contains
             ! Convert grid to mesh
             if (.not. meshcreated) then
                if (dbug_flag > 20) then
-                 call med_grid_write(grid, trim(fieldName)//'_premesh.nc', rc) 
+                 call med_grid_write(grid, trim(fieldName)//'_premesh.nc', rc)
                  if (ChkErr(rc,__LINE__,u_FILE_u)) return
                end if
 
@@ -1520,10 +1520,8 @@ contains
     character(CL)                      :: cvalue
     character(CL)                      :: start_type
     logical                            :: read_restart
-    logical                            :: LocalDone
-    logical,save                       :: atmDone = .false.
-    logical,save                       :: ocnDone = .false.
-    logical,save                       :: allDone = .false.
+    logical                            :: allDone = .false.
+    logical,save                       :: compDone(ncomps)
     logical,save                       :: first_call = .true.
     real(r8)                           :: real_nx, real_ny
     character(len=CX)                  :: msgString
@@ -1814,61 +1812,26 @@ contains
       call med_map_MapNorm_init(gcomp, logunit, rc)
       if (ChkErr(rc,__LINE__,u_FILE_u)) return
 
-      first_call = .false.
+      !---------------------------------------
+      ! Set the data initialize flag to false
+      !---------------------------------------
 
       call NUOPC_CompAttributeSet(gcomp, name="InitializeDataComplete", value="false", rc=rc)
       if (ChkErr(rc,__LINE__,u_FILE_u)) return
-      return
+
+      !---------------------------------------
+      ! Set the first call flag to false
+      !---------------------------------------
+
+      first_call = .false.
+
+      !---------------------------------------
+      ! *** Now return ****
+      !---------------------------------------
+
+      RETURN
 
     endif  ! end first_call if-block
-
-    !---------------------------------------
-    ! Initialize mediator fields and infodata
-    ! This is called every loop around DataInitialize
-    !---------------------------------------
-
-    call ESMF_GridCompGet(gcomp, vm=vm, rc=rc)
-    if (chkerr(rc,__LINE__,u_FILE_u)) return
-
-    do n1 = 1,ncomps
-       LocalDone = .true.
-       if (is_local%wrap%comp_present(n1) .and. ESMF_StateIsCreated(is_local%wrap%NStateImp(n1),rc=rc)) then
-
-          call ESMF_StateGet(is_local%wrap%NStateImp(n1), itemCount=fieldCount, rc=rc)
-          if (ChkErr(rc,__LINE__,u_FILE_u)) return
-
-          allocate(fieldNameList(fieldCount))
-          call ESMF_StateGet(is_local%wrap%NStateImp(n1), itemNameList=fieldNameList, rc=rc)
-          if (ChkErr(rc,__LINE__,u_FILE_u)) return
-
-          do n=1, fieldCount
-             call ESMF_StateGet(is_local%wrap%NStateImp(n1), itemName=fieldNameList(n), field=field, rc=rc)
-             if (ChkErr(rc,__LINE__,u_FILE_u)) return
-
-             atCorrectTime = NUOPC_IsAtTime(field, time, rc=rc)
-             if (ChkErr(rc,__LINE__,u_FILE_u)) return
-
-             if (atCorrectTime) then
-                if (fieldNameList(n) == is_local%wrap%flds_scalar_name) then
-                   call ESMF_LogWrite(trim(subname)//" MED - Initialize-Data-Dependency CSTI "//trim(compname(n1)), &
-                        ESMF_LOGMSG_INFO, rc=rc)
-                   if (ChkErr(rc,__LINE__,u_FILE_u)) return
-                endif
-             else
-                LocalDone=.false.
-             endif
-          enddo
-          deallocate(fieldNameList)
-
-          if (LocalDone) then
-             call ESMF_LogWrite(trim(subname)//" MED - Initialize-Data-Dependency Copy Import "//&
-                  trim(compname(n1)), ESMF_LOGMSG_INFO, rc=rc)
-             if (ChkErr(rc,__LINE__,u_FILE_u)) return
-             if (n1 == compocn) ocnDone = .true.
-             if (n1 == compatm) atmDone = .true.
-          endif
-       endif
-    enddo
 
     !----------------------------------------------------------
     ! Create FBfrac field bundles and initialize fractions
@@ -1882,70 +1845,107 @@ contains
     call med_fraction_set(gcomp,rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
 
-    if (is_local%wrap%comp_present(compocn) .or. is_local%wrap%comp_present(compatm)) then
-       call med_phases_ocnalb_run(gcomp, rc=rc)
-       if (ChkErr(rc,__LINE__,u_FILE_u)) return
+    !----------------------------------------------------------
+    ! Initialize ocean albedos (this is needed for cesm and hafs)
+    !----------------------------------------------------------
+
+    if (trim(coupling_mode(1:5)) /= 'nems_') then
+       if (is_local%wrap%comp_present(compocn) .or. is_local%wrap%comp_present(compatm)) then
+          call med_phases_ocnalb_run(gcomp, rc=rc)
+          if (ChkErr(rc,__LINE__,u_FILE_u)) return
+       end if
     end if
+
+    !---------------------------------------
+    ! Loop over components and determine if they are at correct time
+    !---------------------------------------
+
+    do n1 = 1,ncomps
+       compDone(n1) = .true. ! even if component is not present
+       if (is_local%wrap%comp_present(n1) .and. ESMF_StateIsCreated(is_local%wrap%NStateImp(n1),rc=rc)) then
+          call ESMF_StateGet(is_local%wrap%NStateImp(n1), itemCount=fieldCount, rc=rc)
+          if (ChkErr(rc,__LINE__,u_FILE_u)) return
+          allocate(fieldNameList(fieldCount))
+          call ESMF_StateGet(is_local%wrap%NStateImp(n1), itemNameList=fieldNameList, rc=rc)
+          if (ChkErr(rc,__LINE__,u_FILE_u)) return
+          do n=1, fieldCount
+             call ESMF_StateGet(is_local%wrap%NStateImp(n1), itemName=fieldNameList(n), field=field, rc=rc)
+             if (ChkErr(rc,__LINE__,u_FILE_u)) return
+             atCorrectTime = NUOPC_IsAtTime(field, time, rc=rc)
+             if (ChkErr(rc,__LINE__,u_FILE_u)) return
+             if (.not. atCorrectTime) then
+                compDone(n1) = .false.
+             endif
+          enddo
+          deallocate(fieldNameList)
+       endif
+    enddo
 
     !---------------------------------------
     ! Carry out data dependency for atm initialization if needed
     !---------------------------------------
 
-    if (.not. is_local%wrap%comp_present(compocn)) ocnDone = .true.
-    if (.not. is_local%wrap%comp_present(compatm)) atmDone = .true.
-
-    if (.not. atmDone .and. ocnDone .and. is_local%wrap%comp_present(compatm)) then
-
-       atmDone = .true.  ! reset if an item is found that is not done
-       call ESMF_StateGet(is_local%wrap%NStateImp(compatm), itemCount=fieldCount, rc=rc)
-       if (ChkErr(rc,__LINE__,u_FILE_u)) return
-       allocate(fieldNameList(fieldCount))
-       call ESMF_StateGet(is_local%wrap%NStateImp(compatm), itemNameList=fieldNameList, rc=rc)
-       if (ChkErr(rc,__LINE__,u_FILE_u)) return
-       do n=1, fieldCount
-          call ESMF_StateGet(is_local%wrap%NStateImp(compatm), itemName=fieldNameList(n), field=field, rc=rc)
-          if (ChkErr(rc,__LINE__,u_FILE_u)) return
-          atCorrectTime = NUOPC_IsAtTime(field, time, rc=rc)
-          if (ChkErr(rc,__LINE__,u_FILE_u)) return
-          if (.not. atCorrectTime) then
-             ! If any atm import fields are not time stamped correctly, then dependency is not satisified - must return to atm
-             call ESMF_LogWrite("MED - Initialize-Data-Dependency from ATM NOT YET SATISFIED!!!", ESMF_LOGMSG_INFO, rc=rc)
-             if (ChkErr(rc,__LINE__,u_FILE_u)) return
-             atmdone = .false.
-             exit  ! break out of the loop when first not satisfied found
-          endif
-       enddo
-       deallocate(fieldNameList)
-
-       if (.not. atmdone) then  ! atmdone is not true
-          ! do the merge to the atmospheric component
-          call med_phases_prep_atm(gcomp, rc=rc)
-          if (ChkErr(rc,__LINE__,u_FILE_u)) return
-
-          ! change 'Updated' attribute to true for ALL exportState fields
-          call ESMF_StateGet(is_local%wrap%NStateExp(compatm), itemCount=fieldCount, rc=rc)
+    if (is_local%wrap%comp_present(compatm)) then
+       if (.not. compDone(compatm) .and. compDone(compocn)) then
+          compDone(compatm) = .true.  ! reset if an item is found that is not done
+          call ESMF_StateGet(is_local%wrap%NStateImp(compatm), itemCount=fieldCount, rc=rc)
           if (ChkErr(rc,__LINE__,u_FILE_u)) return
           allocate(fieldNameList(fieldCount))
-          call ESMF_StateGet(is_local%wrap%NStateExp(compatm), itemNameList=fieldNameList, rc=rc)
+          call ESMF_StateGet(is_local%wrap%NStateImp(compatm), itemNameList=fieldNameList, rc=rc)
           if (ChkErr(rc,__LINE__,u_FILE_u)) return
           do n=1, fieldCount
-             call ESMF_StateGet(is_local%wrap%NStateExp(compatm), itemName=fieldNameList(n), field=field, rc=rc)
+             call ESMF_StateGet(is_local%wrap%NStateImp(compatm), itemName=fieldNameList(n), field=field, rc=rc)
              if (ChkErr(rc,__LINE__,u_FILE_u)) return
-             call NUOPC_SetAttribute(field, name="Updated", value="true", rc=rc)
+             atCorrectTime = NUOPC_IsAtTime(field, time, rc=rc)
              if (ChkErr(rc,__LINE__,u_FILE_u)) return
-          end do
+             if (.not. atCorrectTime) then
+                ! If any atm import fields are not time stamped correctly,
+                ! then dependency is not satisified - must return to atm
+                call ESMF_LogWrite("MED - Initialize-Data-Dependency from ATM NOT YET SATISFIED!!!", &
+                     ESMF_LOGMSG_INFO, rc=rc)
+                if (ChkErr(rc,__LINE__,u_FILE_u)) return
+                if (mastertask) then
+                   write(logunit,'(A)') trim(subname)//"MED - Initialize-Data-Dependency from ATM NOT YET SATISFIED!!!"
+                end if
+                compDone(compatm) = .false.
+                exit  ! break out of the loop when first not satisfied found
+             endif
+          enddo
           deallocate(fieldNameList)
 
-          ! Connectors will be automatically called between the mediator and atm until allDone is true
-          call ESMF_LogWrite("MED - Initialize-Data-Dependency Sending Data to ATM", ESMF_LOGMSG_INFO, rc=rc)
-          if (ChkErr(rc,__LINE__,u_FILE_u)) return
-      endif
-    endif
+          if (.not. compDone(compatm)) then  ! atmdone is not true
+             ! do the merge to the atmospheric component
+             call med_phases_prep_atm(gcomp, rc=rc)
+             if (ChkErr(rc,__LINE__,u_FILE_u)) return
+
+             ! change 'Updated' attribute to true for ALL exportState fields
+             call ESMF_StateGet(is_local%wrap%NStateExp(compatm), itemCount=fieldCount, rc=rc)
+             if (ChkErr(rc,__LINE__,u_FILE_u)) return
+             allocate(fieldNameList(fieldCount))
+             call ESMF_StateGet(is_local%wrap%NStateExp(compatm), itemNameList=fieldNameList, rc=rc)
+             if (ChkErr(rc,__LINE__,u_FILE_u)) return
+             do n=1, fieldCount
+                call ESMF_StateGet(is_local%wrap%NStateExp(compatm), itemName=fieldNameList(n), field=field, rc=rc)
+                if (ChkErr(rc,__LINE__,u_FILE_u)) return
+                call NUOPC_SetAttribute(field, name="Updated", value="true", rc=rc)
+                if (ChkErr(rc,__LINE__,u_FILE_u)) return
+             end do
+             deallocate(fieldNameList)
+
+             ! Connectors will be automatically called between the mediator and atm until allDone is true
+             call ESMF_LogWrite("MED - Initialize-Data-Dependency Sending Data to ATM", ESMF_LOGMSG_INFO, rc=rc)
+             if (ChkErr(rc,__LINE__,u_FILE_u)) return
+          endif
+       endif
+    end if
+
+    !---------------------------------------
+    ! Loop over components again and determine if all are at the correct time
+    !---------------------------------------
 
     allDone = .true.
     do n1 = 1,ncomps
        if (is_local%wrap%comp_present(n1) .and. ESMF_StateIsCreated(is_local%wrap%NStateImp(n1),rc=rc)) then
-
           call ESMF_StateGet(is_local%wrap%NStateImp(n1), itemCount=fieldCount, rc=rc)
           if (ChkErr(rc,__LINE__,u_FILE_u)) return
           allocate(fieldNameList(fieldCount))
@@ -1958,27 +1958,29 @@ contains
              if (ChkErr(rc,__LINE__,u_FILE_u)) return
              if (.not. atCorrectTime) then
                 allDone=.false.
+                if (mastertask) then
+                   write(logunit,'(A)') trim(subname)//" MED - Initialize-Data-Dependency check Failed for "//&
+                        trim(compname(n1))
+                end if
              endif
           enddo
           deallocate(fieldNameList)
        endif
-
     enddo
-
-    ! set InitializeDataComplete Component Attribute to "true", indicating
-    ! to the driver that this Component has fully initialized its data
-
     if (allDone) then
+       ! set InitializeDataComplete Component Attribute to "true", indicating
+       ! to the driver that this Component has fully initialized its data
        call NUOPC_CompAttributeSet(gcomp, name="InitializeDataComplete", value="true", rc=rc)
        if (ChkErr(rc,__LINE__,u_FILE_u)) return
-
        call ESMF_LogWrite("MED - Initialize-Data-Dependency allDone check Passed", ESMF_LOGMSG_INFO, rc=rc)
        if (ChkErr(rc,__LINE__,u_FILE_u)) return
+    end if
 
-       !---------------------------------------
-       ! Create component dimensions in mediator internal state
-       !---------------------------------------
+    !---------------------------------------
+    ! Create component dimensions in mediator internal state
+    !---------------------------------------
 
+    if (allDone) then
        if (mastertask) write(logunit,*)
        do n1 = 1,ncomps
           if (is_local%wrap%comp_present(n1) .and. ESMF_StateIsCreated(is_local%wrap%NStateImp(n1),rc=rc)) then

--- a/mediator/med_fraction_mod.F90
+++ b/mediator/med_fraction_mod.F90
@@ -2,7 +2,7 @@ module med_fraction_mod
 
   !-----------------------------------------------------------------------------
   ! Mediator Component.
-  ! Sets fracations on all component grids
+  ! Sets fractions on all component grids
   !  the fractions fields are now afrac, ifrac, ofrac, lfrac, and lfrin.
   !    afrac = fraction of atm on a grid
   !    lfrac = fraction of lnd on a grid
@@ -142,23 +142,7 @@ module med_fraction_mod
   character(len=5),parameter,dimension(1) :: fraclist_w = (/'wfrac'/)
 
   !--- standard ---
-  real(R8),parameter :: eps_fracsum = 1.0e-02      ! allowed error in sum of fracs
-  real(R8),parameter :: eps_fracval = 1.0e-02      ! allowed error in any frac +- 0,1
-  real(R8),parameter :: eps_fraclim = 1.0e-03      ! truncation limit in fractions_a(lfrac)
-  logical ,parameter :: atm_frac_correct = .false. ! turn on frac correction on atm grid
-
-  !--- standard plus atm fraction consistency ---
-  !  real(R8),parameter :: eps_fracsum = 1.0e-12   ! allowed error in sum of fracs
-  !  real(R8),parameter :: eps_fracval = 1.0e-02   ! allowed error in any frac +- 0,1
-  !  real(R8),parameter :: eps_fraclim = 1.0e-03   ! truncation limit in fractions_a(lfrac)
-  !  logical ,parameter :: atm_frac_correct = .true. ! turn on frac correction on atm grid
-
-  !--- unconstrained and area conserving? ---
-  !  real(R8),parameter :: eps_fracsum = 1.0e-12   ! allowed error in sum of fracs
-  !  real(R8),parameter :: eps_fracval = 1.0e-02   ! allowed error in any frac +- 0,1
-  !  real(R8),parameter :: eps_fraclim = 1.0e-20   ! truncation limit in fractions_a(lfrac)
-  !  logical ,parameter :: atm_frac_correct = .true. ! turn on frac correction on atm grid
-
+  real(R8)    , parameter :: eps_fraclim = 1.0e-03      ! truncation limit in fractions_a(lfrac)
   character(*), parameter :: u_FILE_u =  &
        __FILE__
 
@@ -174,9 +158,10 @@ contains
     use ESMF                  , only : ESMF_LogWrite, ESMF_LOGMSG_INFO, ESMF_SUCCESS
     use ESMF                  , only : ESMF_GridCompGet, ESMF_StateIsCreated
     use ESMF                  , only : ESMF_FieldBundle, ESMF_FieldBundleIsCreated, ESMF_FieldBundleDestroy
+    use esmFlds               , only : coupling_mode
     use esmFlds               , only : compatm, compocn, compice, complnd
     use esmFlds               , only : comprof, compglc, compwav, compname
-    use esmFlds               , only : mapconsf, mapfcopy
+    use esmFlds               , only : mapconsf, mapfcopy, mapnstod_consf
     use med_map_mod           , only : med_map_Fractions_init, med_map_RH_is_created
     use med_internalstate_mod , only : InternalState
     use perf_mod              , only : t_startf, t_stopf
@@ -289,6 +274,7 @@ contains
              endif
           end if
        end do
+
     end if
 
     !---------------------------------------
@@ -359,7 +345,7 @@ contains
     end if
 
     !---------------------------------------
-    ! Set 'ifrac' in FBFrac(compice) and BFrac(compatm)
+    ! Set 'ifrac' in FBFrac(compice) and FBFrac(compatm)
     !---------------------------------------
 
     if (is_local%wrap%comp_present(compice)) then
@@ -443,17 +429,11 @@ contains
 
           if (.not. is_local%wrap%comp_present(complnd)) then
              lfrac(:) = 0.0_R8
-             if (atm_frac_correct) then
-                ofrac(:) = 1.0_R8
-             end if
           else
              do n = 1,size(lfrac)
                 lfrac(n) = 1.0_R8 - ofrac(n)
                 if (abs(lfrac(n)) < eps_fraclim) then
                    lfrac(n) = 0.0_R8
-                   if (atm_frac_correct) then
-                      ofrac(n) = 1.0_R8
-                   end if
                 end if
              end do
           end if
@@ -469,9 +449,6 @@ contains
              ofrac(n) = 1.0_R8 - lfrac(n)
              if (abs(ofrac(n)) < eps_fraclim) then
                 ofrac(n) = 0.0_R8
-                if (atm_frac_correct) then
-                   lfrac(n) = 1.0_R8
-                endif
              end if
           end do
 
@@ -627,7 +604,7 @@ contains
     use ESMF                  , only : ESMF_LogWrite, ESMF_LOGMSG_INFO, ESMF_SUCCESS
     use ESMF                  , only : ESMF_REGION_TOTAL, ESMF_REGION_SELECT
     use esmFlds               , only : compatm, compocn, compice, compname
-    use esmFlds               , only : mapconsf, mapnstod, mapfcopy
+    use esmFlds               , only : mapconsf, mapnstod, mapfcopy, mapnstod_consf
     use esmFlds               , only : coupling_mode
     use med_internalstate_mod , only : InternalState
     use med_map_mod           , only : med_map_Fractions_init, med_map_RH_is_created
@@ -641,7 +618,6 @@ contains
     type(InternalState)        :: is_local
     real(r8), pointer          :: lfrac(:)
     real(r8), pointer          :: ifrac(:)
-    real(r8), pointer          :: ifrac_nstod(:)
     real(r8), pointer          :: ofrac(:)
     real(r8), pointer          :: Si_ifrac(:)
     real(r8), pointer          :: Si_imask(:)
@@ -719,12 +695,8 @@ contains
        ! set ifrac = Si_ifrac * Si_imask
        ifrac(:) = Si_ifrac(:) * Si_imask(:)
 
-       if (trim(coupling_mode) == 'nems_orig') then
-          ofrac(:) = 1._r8 - ifrac(:)
-       else
-          ! set ofrac = Si_imask - ifrac
-          ofrac(:) = Si_imask(:) - ifrac(:)
-       end if
+       ! set ofrac = Si_imask - ifrac
+       ofrac(:) = Si_imask(:) - ifrac(:)
 
        ! -------------------------------------------
        ! Set FBfrac(compocn)
@@ -751,94 +723,38 @@ contains
        ! -------------------------------------------
        ! Set FBfrac(compatm)
        ! -------------------------------------------
+
        if (is_local%wrap%comp_present(compatm)) then
-
-          if (trim(coupling_mode) == 'nems_orig') then
-
-             ! Map 'ifrac' from FBfrac(compice) to FBfrac(compatm)
-             call FB_FieldRegrid(&
-                  is_local%wrap%FBfrac(compice), 'ifrac', &
-                  is_local%wrap%FBfrac(compatm), 'ifrac', &
-                  is_local%wrap%RH(compice,compatm,:),mapnstod, rc=rc)
-             if (ChkErr(rc,__LINE__,u_FILE_u)) return
-             call FB_getFldPtr(is_local%wrap%FBfrac(compatm), 'ifrac', ifrac_nstod, rc=rc)
-             if (ChkErr(rc,__LINE__,u_FILE_u)) return
-
-             call FB_FieldRegrid(&
-                  is_local%wrap%FBfrac(compice), 'ifrac', &
-                  is_local%wrap%FBfrac(compatm), 'ifrac', &
-                  is_local%wrap%RH(compice,compatm,:),mapconsf, rc=rc)
-             if (ChkErr(rc,__LINE__,u_FILE_u)) return
-
-             ! Determine ifrac on atm grid
-             call FB_getFldPtr(is_local%wrap%FBfrac(compatm), 'ifrac', ifrac, rc=rc)
-             if (ChkErr(rc,__LINE__,u_FILE_u)) return
-             where (ifrac .eq. 0.0_R8 .and. abs(ifrac_nstod) .gt.  0.0_R8)
-                ifrac = ifrac_nstod
-             endwhere
-
-             ! Determine ofrac and lfrac on atm grid - set ofrac=1-ifrac and lfrac=0
-             call FB_getFldPtr(is_local%wrap%FBfrac(compatm), 'ofrac', ofrac, rc=rc)
-             if (ChkErr(rc,__LINE__,u_FILE_u)) return
-             call FB_getFldPtr(is_local%wrap%FBfrac(compatm), 'lfrac', lfrac, rc=rc)
-             if (ChkErr(rc,__LINE__,u_FILE_u)) return
-             ofrac(:) = 1.0_R8 - ifrac(:)
-             lfrac(:) = 0.0_R8
-
+          if (trim(coupling_mode) == 'nems_orig' ) then
+             maptype = mapnstod_consf
           else
-
              if (med_map_RH_is_created(is_local%wrap%RH(compice,compatm,:),mapfcopy, rc=rc)) then
-                ! TODO (mvertens, 2019-11-20): this is not being used when ice and atm are on the same grid
-                ! - this needs to be implemented
                 maptype = mapfcopy
              else
                 maptype = mapconsf
              end if
+          end if
 
-             ! Map 'ifrac' from FBfrac(compice) to FBfrac(compatm)
-             if (is_local%wrap%med_coupling_active(compice,compatm)) then
-                call FB_FieldRegrid(&
-                     is_local%wrap%FBfrac(compice), 'ifrac', &
-                     is_local%wrap%FBfrac(compatm), 'ifrac', &
-                     is_local%wrap%RH(compice,compatm,:),maptype, rc=rc)
-                if (ChkErr(rc,__LINE__,u_FILE_u)) return
-             end if
+          ! Map 'ifrac' from FBfrac(compice) to FBfrac(compatm)
+          if (is_local%wrap%med_coupling_active(compice,compatm)) then
+             call FB_FieldRegrid(&
+                  is_local%wrap%FBfrac(compice), 'ifrac', &
+                  is_local%wrap%FBfrac(compatm), 'ifrac', &
+                  is_local%wrap%RH(compice,compatm,:),maptype, rc=rc)
+             if (ChkErr(rc,__LINE__,u_FILE_u)) return
+          end if
 
-             ! Map 'ofrac' from FBfrac(compice) to FBfrac(compatm)
-             if (is_local%wrap%med_coupling_active(compocn,compatm)) then
-                call FB_FieldRegrid(&
-                     is_local%wrap%FBfrac(compice), 'ofrac', &
-                     is_local%wrap%FBfrac(compatm), 'ofrac', &
-                     is_local%wrap%RH(compice,compatm,:),maptype, rc=rc)
-                if (ChkErr(rc,__LINE__,u_FILE_u)) return
-             end if
-
-             ! Note: 'lfrac' from FBFrac(compatm) is just going to be in the init
-             if ( is_local%wrap%med_coupling_active(compice,compatm) .and. &
-                  is_local%wrap%med_coupling_active(compocn,compatm) ) then
-
-                if (atm_frac_correct) then
-                   call FB_getFldPtr(is_local%wrap%FBfrac(compatm), 'ifrac', ifrac, rc=rc)
-                   if (ChkErr(rc,__LINE__,u_FILE_u)) return
-
-                   call FB_getFldPtr(is_local%wrap%FBfrac(compatm), 'ofrac', ofrac, rc=rc)
-                   if (ChkErr(rc,__LINE__,u_FILE_u)) return
-
-                   call FB_getFldPtr(is_local%wrap%FBfrac(compatm), 'lfrac', lfrac, rc=rc)
-                   if (ChkErr(rc,__LINE__,u_FILE_u)) return
-                   where (ifrac + ofrac > 0.0_R8)
-                      ifrac = ifrac * ((1.0_R8 - lfrac)/(ofrac+ifrac))
-                      ofrac = ofrac * ((1.0_R8 - lfrac)/(ofrac+ifrac))
-                   elsewhere
-                      ifrac = 0.0_R8
-                      ofrac = 0.0_R8
-                   end where
-                endif
-             endif
-
+          ! Map 'ofrac' from FBfrac(compice) to FBfrac(compatm)
+          if (is_local%wrap%med_coupling_active(compocn,compatm)) then
+             call FB_FieldRegrid(&
+                  is_local%wrap%FBfrac(compice), 'ofrac', &
+                  is_local%wrap%FBfrac(compatm), 'ofrac', &
+                  is_local%wrap%RH(compice,compatm,:),maptype, rc=rc)
+             if (ChkErr(rc,__LINE__,u_FILE_u)) return
           end if
        end if
-    end if
+
+    end if ! end of if present compice
 
     !---------------------------------------
     ! Diagnostic output

--- a/mediator/med_fraction_mod.F90
+++ b/mediator/med_fraction_mod.F90
@@ -725,6 +725,7 @@ contains
        ! -------------------------------------------
 
        if (is_local%wrap%comp_present(compatm)) then
+
           if (trim(coupling_mode) == 'nems_orig' ) then
              maptype = mapnstod_consf
           else

--- a/mediator/med_map_mod.F90
+++ b/mediator/med_map_mod.F90
@@ -161,7 +161,7 @@ contains
              srcMaskValue = ispval_mask
              if (n1 == compocn .or. n1 == compice) srcMaskValue = 0
              if (n2 == compocn .or. n2 == compice) dstMaskValue = 0
-          else if (coupling_mode(1:5) == 'nems_') then
+          else if (coupling_mode(1:4) == 'nems') then
              if (n1 == compatm .and. (n2 == compocn .or. n2 == compice)) then
                 srcMaskValue = 1
                 dstMaskValue = 0
@@ -225,7 +225,7 @@ contains
                          if (mastertask) then
                             write(llogunit,'(3A)') subname,trim(string),' RH redist '
                          end if
-                         call ESMF_LogWrite(trim(subname) // trim(string) // ' RH redist ', ESMF_LOGMSG_INFO)
+                         call ESMF_LogWrite(subname // trim(string) // ' RH redist ', ESMF_LOGMSG_INFO)
                          call ESMF_FieldRedistStore(fldsrc, flddst, &
                               routehandle=is_local%wrap%RH(n1,n2,mapindex), &
                               ignoreUnmatchedIndices = .true., rc=rc)

--- a/mediator/med_merge_mod.F90
+++ b/mediator/med_merge_mod.F90
@@ -287,7 +287,7 @@ contains
     if (chkerr(rc,__LINE__,u_FILE_u)) return
     if (dbug_flag > 1) then
        write(msg,*)trim(subname),'input field ',trim(FBfld),' has rank ',lrank_input
-       call ESMF_LogWrite(msg, ESMF_LOGMSG_ERROR)
+       call ESMF_LogWrite(msg, ESMF_LOGMSG_INFO)
     end if
 
     if (lrank_input == 1) then

--- a/mediator/med_phases_prep_atm_mod.F90
+++ b/mediator/med_phases_prep_atm_mod.F90
@@ -162,13 +162,7 @@ contains
                FBMed1=is_local%wrap%FBMed_ocnalb_a, &
                FBMed2=is_local%wrap%FBMed_aoflux_a, rc=rc)
           if (ChkErr(rc,__LINE__,u_FILE_u)) return
-       else if (trim(coupling_mode) == 'nems_orig') then
-          call med_merge_auto(trim(compname(compatm)), &
-               is_local%wrap%FBExp(compatm), is_local%wrap%FBFrac(compatm), &
-               is_local%wrap%FBImp(:,compatm), fldListTo(compatm), &
-               FBMed1=is_local%wrap%FBMed_aoflux_a, rc=rc)
-          if (ChkErr(rc,__LINE__,u_FILE_u)) return
-       else if (trim(coupling_mode) == 'nems_frac') then
+       else if (trim(coupling_mode) == 'nems_frac' .or. trim(coupling_mode) == 'nems_orig') then
           call med_merge_auto(trim(compname(compatm)), &
                is_local%wrap%FBExp(compatm), is_local%wrap%FBFrac(compatm), &
                is_local%wrap%FBImp(:,compatm), fldListTo(compatm), rc=rc)

--- a/mediator/med_phases_prep_ice_mod.F90
+++ b/mediator/med_phases_prep_ice_mod.F90
@@ -168,22 +168,25 @@ contains
 
        call ESMF_StateGet(is_local%wrap%NStateImp(compatm), trim(is_local%wrap%flds_scalar_name), itemType, rc=rc)
        if (chkerr(rc,__LINE__,u_FILE_u)) return
+
        if (itemType /= ESMF_STATEITEM_NOTFOUND) then
-          ! send nextsw_cday to ice - first obtain it from atm import 
-          call State_GetScalar(&
-               scalar_value=nextsw_cday, &
-               scalar_id=is_local%wrap%flds_scalar_index_nextsw_cday, &
-               state=is_local%wrap%NstateImp(compatm), &
-               flds_scalar_name=is_local%wrap%flds_scalar_name, &
-               flds_scalar_num=is_local%wrap%flds_scalar_num, rc=rc)
-          if (chkerr(rc,__LINE__,u_FILE_u)) return
-          call State_SetScalar(&
-               scalar_value=nextsw_cday, &
-               scalar_id=is_local%wrap%flds_scalar_index_nextsw_cday, &
-               state=is_local%wrap%NstateExp(compice), &
-               flds_scalar_name=is_local%wrap%flds_scalar_name, &
-               flds_scalar_num=is_local%wrap%flds_scalar_num, rc=rc)
-          if (chkerr(rc,__LINE__,u_FILE_u)) return
+          if (is_local%wrap%flds_scalar_index_nextsw_cday .ne. 0) then
+             ! send nextsw_cday to ice - first obtain it from atm import 
+             call State_GetScalar(&
+                  scalar_value=nextsw_cday, &
+                  scalar_id=is_local%wrap%flds_scalar_index_nextsw_cday, &
+                  state=is_local%wrap%NstateImp(compatm), &
+                  flds_scalar_name=is_local%wrap%flds_scalar_name, &
+                  flds_scalar_num=is_local%wrap%flds_scalar_num, rc=rc)
+             if (chkerr(rc,__LINE__,u_FILE_u)) return
+             call State_SetScalar(&
+                  scalar_value=nextsw_cday, &
+                  scalar_id=is_local%wrap%flds_scalar_index_nextsw_cday, &
+                  state=is_local%wrap%NstateExp(compice), &
+                  flds_scalar_name=is_local%wrap%flds_scalar_name, &
+                  flds_scalar_num=is_local%wrap%flds_scalar_num, rc=rc)
+             if (chkerr(rc,__LINE__,u_FILE_u)) return
+          end if
        end if
 
        !---------------------------------------

--- a/mediator/med_phases_prep_ocn_mod.F90
+++ b/mediator/med_phases_prep_ocn_mod.F90
@@ -33,6 +33,10 @@ module med_phases_prep_ocn_mod
   public :: med_phases_prep_ocn_accum_fast
   public :: med_phases_prep_ocn_accum_avg
 
+  private :: med_phases_prep_ocn_custom_cesm
+  private :: med_phases_prep_ocn_custom_nems
+  private :: med_phases_prep_ocn_custom_nemsdata
+
   character(*), parameter :: u_FILE_u  = &
        __FILE__
 
@@ -46,10 +50,8 @@ contains
     ! Map all fields in from relevant source components to the ocean grid
     !---------------------------------------
 
-    use ESMF , only : ESMF_GridComp, ESMF_Clock, ESMF_Time
-    use ESMF , only : ESMF_LogWrite, ESMF_LOGMSG_INFO,ESMF_SUCCESS
-    use ESMF , only : ESMF_GridCompGet, ESMF_ClockGet, ESMF_TimeGet, ESMF_ClockPrint
-    use ESMF , only : ESMF_FieldBundleGet
+    use ESMF , only : ESMF_GridComp, ESMF_GridCompGet
+    use ESMF , only : ESMF_LogWrite, ESMF_LOGMSG_INFO, ESMF_SUCCESS
 
     ! input/output variables
     type(ESMF_GridComp)  :: gcomp
@@ -58,37 +60,29 @@ contains
     ! local variables
     type(InternalState)         :: is_local
     integer                     :: n1, ncnt
-    integer                     :: dbrc
     character(len=*), parameter :: subname='(med_phases_prep_ocn_map)'
     !-------------------------------------------------------------------------------
 
+    rc = ESMF_SUCCESS
+
     call t_startf('MED:'//subname)
     if (dbug_flag > 20) then
-       call ESMF_LogWrite(subname//' called', ESMF_LOGMSG_INFO, rc=dbrc)
+       call ESMF_LogWrite(subname//' called', ESMF_LOGMSG_INFO)
     end if
-    rc = ESMF_SUCCESS
     call memcheck(subname, 5, mastertask)
 
-    !---------------------------------------
-    ! --- Get the internal state
-    !---------------------------------------
-
+    ! Get the internal state
     nullify(is_local%wrap)
     call ESMF_GridCompGetInternalState(gcomp, is_local, rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
 
-    !---------------------------------------
-    ! --- Count the number of fields outside of scalar data, if zero, then return
-    !---------------------------------------
+    ! Count the number of fields outside of scalar data, if zero, then return
     call FB_getNumFlds(is_local%wrap%FBExp(compocn), trim(subname)//"FBexp(compocn)", ncnt, rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
 
     if (ncnt > 0) then
 
-       !---------------------------------------
-       !--- map all fields in FBImp that have active ocean coupling to the ocean grid
-       !---------------------------------------
-
+       ! map all fields in FBImp that have active ocean coupling to the ocean grid
        do n1 = 1,ncomps
           if (is_local%wrap%med_coupling_active(n1,compocn)) then
              call med_map_FB_Regrid_Norm( &
@@ -107,17 +101,15 @@ contains
 
     call t_stopf('MED:'//subname)
     if (dbug_flag > 20) then
-       call ESMF_LogWrite(subname//' done', ESMF_LOGMSG_INFO, rc=dbrc)
+       call ESMF_LogWrite(subname//' done', ESMF_LOGMSG_INFO)
     end if
 
   end subroutine med_phases_prep_ocn_map
 
   !-----------------------------------------------------------------------------
-
   subroutine med_phases_prep_ocn_merge(gcomp, rc)
 
-    use ESMF , only : ESMF_GridComp, ESMF_FieldBundleGet
-    use ESMF , only : ESMF_LogWrite, ESMF_LOGMSG_INFO, ESMF_SUCCESS
+    use ESMF , only : ESMF_GridComp, ESMF_LogWrite, ESMF_LOGMSG_INFO, ESMF_SUCCESS
     use ESMF , only : ESMF_FAILURE,  ESMF_LOGMSG_ERROR
 
     ! input/output variables
@@ -127,78 +119,34 @@ contains
     ! local variables
     type(InternalState) :: is_local
     integer             :: n, ncnt
-    real(R8)            :: c1,c2,c3,c4
-    real(R8), pointer   :: dataptr(:)
-    real(R8), pointer   :: dataptr_o(:)
-    real(R8), pointer   :: ifrac(:), ofrac(:)
-    real(R8), pointer   :: ifracr(:), ofracr(:)
-    real(R8), pointer   :: avsdr(:), avsdf(:)
-    real(R8), pointer   :: anidr(:), anidf(:)
-    real(R8), pointer   :: Faxa_swvdf(:), Faxa_swndf(:)
-    real(R8), pointer   :: Faxa_swvdr(:), Faxa_swndr(:)
-    real(R8), pointer   :: Foxx_swnet(:)
-    real(R8), pointer   :: Foxx_swnet_afracr(:)
-    real(R8), pointer   :: Foxx_swnet_vdr(:), Foxx_swnet_vdf(:)
-    real(R8), pointer   :: Foxx_swnet_idr(:), Foxx_swnet_idf(:)
-    real(R8), pointer   :: Fioi_swpen_vdr(:), Fioi_swpen_vdf(:)
-    real(R8), pointer   :: Fioi_swpen_idr(:), Fioi_swpen_idf(:)
-    real(R8), pointer   :: Fioi_swpen(:)
-    real(R8)            :: ifrac_scaled, ofrac_scaled
-    real(R8)            :: ifracr_scaled, ofracr_scaled
-    real(R8)            :: frac_sum
-    real(R8)            :: albvis_dir, albvis_dif
-    real(R8)            :: albnir_dir, albnir_dif
-    real(R8)            :: fswabsv, fswabsi
-    logical             :: export_swnet_by_bands
-    logical             :: import_swpen_by_bands
-    logical             :: export_swnet_afracr
-    logical             :: first_precip_fact_call = .true.
-    real(R8)            :: precip_fact
-    integer             :: lsize
-    integer             :: dbrc
-    character(CS)       :: cvalue
-    real(R8), pointer   :: ocnwgt1(:)   ! NEMS_orig_data
-    real(R8), pointer   :: icewgt1(:)   ! NEMS_orig_data
-    real(R8), pointer   :: wgtp01(:)    ! NEMS_orig_data
-    real(R8), pointer   :: wgtm01(:)    ! NEMS_orig_data
-    real(R8), pointer   :: customwgt(:) ! NEMS_orig_data
-    character(len=64), allocatable :: fldnames(:)
-    real(R8)        , parameter    :: const_lhvap = 2.501e6_R8  ! latent heat of evaporation ~ J/kg
-    real(R8)        , parameter    :: albdif = 0.06_r8          ! 60 deg reference albedo, diffuse
     character(len=*), parameter    :: subname='(med_phases_prep_ocn_merge)'
-    logical :: compare_to_mct = .false. ! Set the following to true if want to compare directly to MCT
     !---------------------------------------
 
     call t_startf('MED:'//subname)
     if (dbug_flag > 20) then
-       call ESMF_LogWrite(subname//' called', ESMF_LOGMSG_INFO, rc=dbrc)
+       call ESMF_LogWrite(subname//' called', ESMF_LOGMSG_INFO)
     end if
     rc = ESMF_SUCCESS
     call memcheck(subname, 5, mastertask)
 
-    !---------------------------------------
-    ! --- Get the internal state
-    !---------------------------------------
-
+    ! Get the internal state
     nullify(is_local%wrap)
     call ESMF_GridCompGetInternalState(gcomp, is_local, rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
 
-    !---------------------------------------
-    ! --- Count the number of fields outside of scalar data, if zero, then return
-    !---------------------------------------
-
+    ! Count the number of fields outside of scalar data, if zero, then return
     call FB_getNumFlds(is_local%wrap%FBExp(compocn), trim(subname)//"FBexp(compocn)", ncnt, rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
 
     if (ncnt > 0) then
 
        !---------------------------------------
-       !--- auto merges to ocn
+       ! merges to ocean
        !---------------------------------------
 
+       ! auto merges to ocn
        if (trim(coupling_mode) == 'cesm' .or. &
-           trim(coupling_mode) == 'nems_orig_data' .or. & 
+           trim(coupling_mode) == 'nems_orig_data' .or. &
            trim(coupling_mode) == 'hafs') then
           call med_merge_auto(trim(compname(compocn)), &
                is_local%wrap%FBExp(compocn), is_local%wrap%FBFrac(compocn), &
@@ -212,415 +160,40 @@ contains
           if (ChkErr(rc,__LINE__,u_FILE_u)) return
        end if
 
-       !---------------------------------------
-       !--- custom calculations
-       !---------------------------------------
-
+       ! custom merges to ocean
        if (trim(coupling_mode) == 'cesm' .or. trim(coupling_mode) == 'hafs') then
-
-          !-------------
-          ! Compute netsw for ocean
-          !-------------
-
-          ! netsw_for_ocn = downsw_from_atm * (1-ocn_albedo) * (1-ice_fraction) + pensw_from_ice * (ice_fraction)
-
-          ! Input from atm
-          call FB_GetFldPtr(is_local%wrap%FBImp(compatm,compocn), 'Faxa_swvdr', Faxa_swvdr, rc=rc)
+          call med_phases_prep_ocn_custom_cesm(gcomp, rc)
           if (ChkErr(rc,__LINE__,u_FILE_u)) return
-          call FB_GetFldPtr(is_local%wrap%FBImp(compatm,compocn), 'Faxa_swndr', Faxa_swndr, rc=rc)
+       else if (trim(coupling_mode) == 'nems_orig' .or. trim(coupling_mode) == 'nems_frac') then
+          call med_phases_prep_ocn_custom_nems(gcomp, rc)
           if (ChkErr(rc,__LINE__,u_FILE_u)) return
-          call FB_GetFldPtr(is_local%wrap%FBImp(compatm,compocn), 'Faxa_swvdf', Faxa_swvdf, rc=rc)
+       else if (trim(coupling_mode) == 'nems_orig_data') then
+          call med_phases_prep_ocn_custom_nemsdata(gcomp, rc)
           if (ChkErr(rc,__LINE__,u_FILE_u)) return
-          call FB_GetFldPtr(is_local%wrap%FBImp(compatm,compocn), 'Faxa_swndf', Faxa_swndf, rc=rc)
-          if (ChkErr(rc,__LINE__,u_FILE_u)) return
-          lsize = size(Faxa_swvdr)
-
-          ! Input from mediator, ice-covered ocean and open ocean fractions
-          call FB_GetFldPtr(is_local%wrap%FBfrac(compocn), 'ifrac' , ifrac, rc=rc)
-          if (ChkErr(rc,__LINE__,u_FILE_u)) return
-          call FB_GetFldPtr(is_local%wrap%FBfrac(compocn), 'ofrac' , ofrac, rc=rc)
-          if (ChkErr(rc,__LINE__,u_FILE_u)) return
-
-          ! Input from mediator, ocean albedos
-          call FB_GetFldPtr(is_local%wrap%FBMed_ocnalb_o, 'So_avsdr' , avsdr, rc=rc)
-          if (ChkErr(rc,__LINE__,u_FILE_u)) return
-          call FB_GetFldPtr(is_local%wrap%FBMed_ocnalb_o, 'So_anidr' , anidr, rc=rc)
-          if (ChkErr(rc,__LINE__,u_FILE_u)) return
-          call FB_GetFldPtr(is_local%wrap%FBMed_ocnalb_o, 'So_avsdf' , avsdf, rc=rc)
-          if (ChkErr(rc,__LINE__,u_FILE_u)) return
-          call FB_GetFldPtr(is_local%wrap%FBMed_ocnalb_o, 'So_anidf' , anidf, rc=rc)
-          if (ChkErr(rc,__LINE__,u_FILE_u)) return
-          call FB_GetFldPtr(is_local%wrap%FBfrac(compocn), 'ifrad' , ifracr, rc=rc)
-          if (ChkErr(rc,__LINE__,u_FILE_u)) return
-          call FB_GetFldPtr(is_local%wrap%FBfrac(compocn), 'ofrad' , ofracr, rc=rc)
-          if (ChkErr(rc,__LINE__,u_FILE_u)) return
-
-          ! Input from ice
-          if (is_local%wrap%comp_present(compice)) then
-             call FB_GetFldPtr(is_local%wrap%FBImp(compice,compocn), 'Fioi_swpen', Fioi_swpen, rc=rc)
-             if (ChkErr(rc,__LINE__,u_FILE_u)) return
-             if (FB_fldchk(is_local%wrap%FBImp(compice,compice), 'Fioi_swpen_vdr', rc=rc)) then
-                import_swpen_by_bands = .true.
-                call FB_GetFldPtr(is_local%wrap%FBImp(compice,compocn), 'Fioi_swpen_vdr', Fioi_swpen_vdr, rc=rc)
-                if (ChkErr(rc,__LINE__,u_FILE_u)) return
-                call FB_GetFldPtr(is_local%wrap%FBImp(compice,compocn), 'Fioi_swpen_vdf', Fioi_swpen_vdf, rc=rc)
-                if (ChkErr(rc,__LINE__,u_FILE_u)) return
-                call FB_GetFldPtr(is_local%wrap%FBImp(compice,compocn), 'Fioi_swpen_idr', Fioi_swpen_idr, rc=rc)
-                if (ChkErr(rc,__LINE__,u_FILE_u)) return
-                call FB_GetFldPtr(is_local%wrap%FBImp(compice,compocn), 'Fioi_swpen_idf', Fioi_swpen_idf, rc=rc)
-                if (ChkErr(rc,__LINE__,u_FILE_u)) return
-             else
-                import_swpen_by_bands = .false.
-             end if
-          end if
-
-          ! Output to ocean swnet
-          if (FB_fldchk(is_local%wrap%FBExp(compocn), 'Foxx_swnet', rc=rc)) then
-             call FB_GetFldPtr(is_local%wrap%FBExp(compocn), 'Foxx_swnet',  Foxx_swnet, rc=rc)
-             if (ChkErr(rc,__LINE__,u_FILE_u)) return
-          else
-             lsize = size(Faxa_swvdr)
-             allocate(Foxx_swnet(lsize))
-          end if
-
-          ! Output to ocean swnet by radiation bands
-          if (FB_fldchk(is_local%wrap%FBExp(compocn), 'Foxx_swnet_vdr', rc=rc)) then
-             export_swnet_by_bands = .true.
-             call FB_GetFldPtr(is_local%wrap%FBExp(compocn), 'Foxx_swnet_vdr', Foxx_swnet_vdr, rc=rc)
-             if (ChkErr(rc,__LINE__,u_FILE_u)) return
-             call FB_GetFldPtr(is_local%wrap%FBExp(compocn), 'Foxx_swnet_vdf', Foxx_swnet_vdf, rc=rc)
-             if (ChkErr(rc,__LINE__,u_FILE_u)) return
-             call FB_GetFldPtr(is_local%wrap%FBExp(compocn), 'Foxx_swnet_idr', Foxx_swnet_idr, rc=rc)
-             if (ChkErr(rc,__LINE__,u_FILE_u)) return
-             call FB_GetFldPtr(is_local%wrap%FBExp(compocn), 'Foxx_swnet_idf', Foxx_swnet_idf, rc=rc)
-             if (ChkErr(rc,__LINE__,u_FILE_u)) return
-          else
-             export_swnet_by_bands = .false.
-          end if
-
-          ! Swnet without swpen from sea-ice
-          if ( FB_fldchk(is_local%wrap%FBExp(compocn), 'Foxx_swnet_afracr',rc=rc)) then
-             call FB_GetFldPtr(is_local%wrap%FBExp(compocn), 'Foxx_swnet_afracr', Foxx_swnet_afracr, rc=rc)
-             if (ChkErr(rc,__LINE__,u_FILE_u)) return
-             export_swnet_afracr = .true.
-          else
-             export_swnet_afracr = .false.
-          end if
-
-          do n = 1,lsize
-
-             ! Determine ocean albedos
-             albvis_dir = avsdr(n)
-             albvis_dif = avsdf(n)
-             albnir_dir = anidr(n)
-             albnir_dif = anidf(n)
-
-             ! Compute total swnet to ocean independent of swpen from sea-ice
-             fswabsv  = Faxa_swvdr(n) * (1.0_R8 - albvis_dir) + Faxa_swvdf(n) * (1.0_R8 - albvis_dif)
-             fswabsi  = Faxa_swndr(n) * (1.0_R8 - albnir_dir) + Faxa_swndf(n) * (1.0_R8 - albnir_dif)
-             Foxx_swnet(n) = fswabsv + fswabsi
-
-             ! Add swpen from sea ice if sea ice is present
-             if (is_local%wrap%comp_present(compice)) then
-
-                ifrac_scaled = ifrac(n)
-                ofrac_scaled = ofrac(n)
-                frac_sum = ifrac(n) + ofrac(n)
-                if (frac_sum /= 0._R8) then
-                   ifrac_scaled = ifrac(n) / (frac_sum)
-                   ofrac_scaled = ofrac(n) / (frac_sum)
-                endif
-
-                ifracr_scaled = ifracr(n)
-                ofracr_scaled = ofracr(n)
-                frac_sum = ifracr(n) + ofracr(n)
-                if (frac_sum /= 0._R8) then
-                   ifracr_scaled = ifracr(n) / (frac_sum)
-                   ofracr_scaled = ofracr(n) / (frac_sum)
-                endif
-
-                Foxx_swnet(n) = ofracr_scaled*(fswabsv + fswabsi) + ifrac_scaled*Fioi_swpen(n)
-
-                if (export_swnet_afracr) then
-                   Foxx_swnet_afracr(n) = ofracr_scaled*(fswabsv + fswabsi)
-                end if
-
-                ! To compare to mct
-                if (compare_to_mct) then
-                   c1 = 0.285
-                   c2 = 0.285
-                   c3 = 0.215
-                   c4 = 0.215
-                   Foxx_swnet_vdr(n) = c1 * Foxx_swnet(n)
-                   Foxx_swnet_vdf(n) = c2 * Foxx_swnet(n)
-                   Foxx_swnet_idr(n) = c3 * Foxx_swnet(n)
-                   Foxx_swnet_idf(n) = c4 * Foxx_swnet(n)
-                else
-                   if (export_swnet_by_bands) then
-                      if (import_swpen_by_bands) then
-                         ! use each individual band for swpen coming from the sea-ice
-                         Foxx_swnet_vdr(n) = Faxa_swvdr(n)*(1.0_R8-albvis_dir)*ofracr_scaled + Fioi_swpen_vdr(n)*ifrac_scaled
-                         Foxx_swnet_vdf(n) = Faxa_swvdf(n)*(1.0_R8-albvis_dif)*ofracr_scaled + Fioi_swpen_vdf(n)*ifrac_scaled
-                         Foxx_swnet_idr(n) = Faxa_swndr(n)*(1.0_R8-albnir_dir)*ofracr_scaled + Fioi_swpen_idr(n)*ifrac_scaled
-                         Foxx_swnet_idf(n) = Faxa_swndf(n)*(1.0_R8-albnir_dif)*ofracr_scaled + Fioi_swpen_idf(n)*ifrac_scaled
-                      else
-                         ! scale total Foxx_swnet to get contributions from each band
-                         c1 = 0.285
-                         c2 = 0.285
-                         c3 = 0.215
-                         c4 = 0.215
-                         Foxx_swnet_vdr(n) = c1 * Foxx_swnet(n)
-                         Foxx_swnet_vdf(n) = c2 * Foxx_swnet(n)
-                         Foxx_swnet_idr(n) = c3 * Foxx_swnet(n)
-                         Foxx_swnet_idf(n) = c4 * Foxx_swnet(n)
-                      end if
-                   end if
-                end if
-
-             end if  ! if sea-ice is present
-          end do
-
-          ! Deallocate Foxx_swnet if it was allocated in this subroutine
-          if (.not. FB_fldchk(is_local%wrap%FBExp(compocn), 'Foxx_swnet', rc=rc)) then
-             deallocate(Foxx_swnet)
-          end if
-
-          ! Output to ocean per ice thickness fraction and sw penetrating into ocean
-          if ( FB_fldchk(is_local%wrap%FBExp(compocn), 'Sf_afrac', rc=rc)) then
-             call FB_GetFldPtr(is_local%wrap%FBExp(compocn), 'Sf_afrac', fldptr1=dataptr_o, rc=rc)
-             if (ChkErr(rc,__LINE__,u_FILE_u)) return
-             dataptr_o(:) = ofrac(:)
-          end if
-          if ( FB_fldchk(is_local%wrap%FBExp(compocn), 'Sf_afracr', rc=rc)) then
-             call FB_GetFldPtr(is_local%wrap%FBExp(compocn), 'Sf_afracr', fldptr1=dataptr_o, rc=rc)
-             if (ChkErr(rc,__LINE__,u_FILE_u)) return
-             dataptr_o(:) = ofracr(:)
-          end if
-
-          !-------------
-          ! application of precipitation factor from ocean
-          !-------------
-          precip_fact = 1.0_R8
-          if (precip_fact /= 1.0_R8) then
-             if (first_precip_fact_call .and. mastertask) then
-                write(logunit,'(a)')'(merge_to_ocn): Scaling rain, snow, liquid and ice runoff by precip_fact '
-                first_precip_fact_call = .false.
-             end if
-             write(cvalue,*) precip_fact
-             call ESMF_LogWrite(trim(subname)//" precip_fact is "//trim(cvalue), ESMF_LOGMSG_INFO, rc=dbrc)
-
-             allocate(fldnames(4))
-             fldnames = (/'Faxa_rain','Faxa_snow', 'Foxx_rofl', 'Foxx_rofi'/)
-             do n = 1,size(fldnames)
-                if (FB_fldchk(is_local%wrap%FBExp(compocn), trim(fldnames(n)), rc=rc)) then
-                   call FB_GetFldPtr(is_local%wrap%FBExp(compocn), trim(fldnames(n)) , dataptr, rc=rc)
-                   if (ChkErr(rc,__LINE__,u_FILE_u)) return
-                   dataptr(:) = dataptr(:) * precip_fact
-                end if
-             end do
-             deallocate(fldnames)
-          end if
-       end if
-
-       !-------------
-       ! Custom calculation for nems_orig or nems_frac
-       !-------------
-
-       if (trim(coupling_mode) == 'nems_orig' .or. trim(coupling_mode) == 'nems_frac') then
-
-          ! get ice and open ocean fractions on the ocn mesh
-          call FB_GetFldPtr(is_local%wrap%FBfrac(compocn), 'ifrac' , ifrac, rc=rc)
-          if (ChkErr(rc,__LINE__,u_FILE_u)) return
-          call FB_GetFldPtr(is_local%wrap%FBfrac(compocn), 'ofrac' , ofrac, rc=rc)
-          if (ChkErr(rc,__LINE__,u_FILE_u)) return
-
-          lsize = size(ofrac)
-          allocate(customwgt(lsize))
-
-          call med_merge_field(is_local%wrap%FBExp(compocn),      'Faxa_rain',  &
-               FBinA=is_local%wrap%FBImp(compatm,compocn), fnameA='Faxa_rain' , wgtA=ofrac, rc=rc)
-          if (ChkErr(rc,__LINE__,u_FILE_u)) return
-          call med_merge_field(is_local%wrap%FBExp(compocn),      'Faxa_snow',  &
-               FBinA=is_local%wrap%FBImp(compatm,compocn), fnameA='Faxa_snow' , wgtA=ofrac, rc=rc)
-          if (ChkErr(rc,__LINE__,u_FILE_u)) return
-          call med_merge_field(is_local%wrap%FBExp(compocn),      'Faxa_lwnet',  &
-               FBinA=is_local%wrap%FBImp(compatm,compocn), fnameA='Faxa_lwnet', wgtA=ofrac, rc=rc)
-          if (ChkErr(rc,__LINE__,u_FILE_u)) return
-
-          customwgt(:) = -ofrac(:) / const_lhvap
-          call med_merge_field(is_local%wrap%FBExp(compocn),      'Faxa_evap', &
-               FBinA=is_local%wrap%FBImp(compatm,compocn), fnameA='Faxa_lat' , wgtA=customwgt, rc=rc)
-          if (ChkErr(rc,__LINE__,u_FILE_u)) return
-
-          customwgt(:) = -ofrac(:)
-          call med_merge_field(is_local%wrap%FBExp(compocn),      'Faxa_sen',  &
-               FBinA=is_local%wrap%FBImp(compatm,compocn), fnameA='Faxa_sen', wgtA=customwgt, rc=rc)
-          if (ChkErr(rc,__LINE__,u_FILE_u)) return
-          call med_merge_field(is_local%wrap%FBExp(compocn),      'Foxx_taux',  &
-               FBinA=is_local%wrap%FBImp(compice,compocn), fnameA='Fioi_taux' , wgtA=ifrac, &
-               FBinB=is_local%wrap%FBImp(compatm,compocn), fnameB='Faxa_taux' , wgtB=customwgt, rc=rc)
-          if (ChkErr(rc,__LINE__,u_FILE_u)) return
-          call med_merge_field(is_local%wrap%FBExp(compocn),      'Foxx_tauy',  &
-               FBinA=is_local%wrap%FBImp(compice,compocn), fnameA='Fioi_tauy' , wgtA=ifrac, &
-               FBinB=is_local%wrap%FBImp(compatm,compocn), fnameB='Faxa_tauy' , wgtB=customwgt, rc=rc)
-          if (ChkErr(rc,__LINE__,u_FILE_u)) return
-
-
-          ! netsw_for_ocn = [downsw_from_atm*(1-ice_fraction)*(1-ocn_albedo)] + [pensw_from_ice*(ice_fraction)]
-          customwgt(:) = ofrac(:) * (1.0 - 0.06)
-          call med_merge_field(is_local%wrap%FBExp(compocn),      'Foxx_swnet_vdr', &
-               FBinA=is_local%wrap%FBImp(compatm,compocn), fnameA='Faxa_swvdr'    , wgtA=customwgt, &
-               FBinB=is_local%wrap%FBImp(compice,compocn), fnameB='Fioi_swpen_vdr', wgtB=ifrac, rc=rc)
-          if (ChkErr(rc,__LINE__,u_FILE_u)) return
-          call med_merge_field(is_local%wrap%FBExp(compocn),      'Foxx_swnet_vdf', &
-               FBinA=is_local%wrap%FBImp(compatm,compocn), fnameA='Faxa_swvdf'    , wgtA=customwgt, &
-               FBinB=is_local%wrap%FBImp(compice,compocn), fnameB='Fioi_swpen_vdf', wgtB=ifrac, rc=rc)
-          if (ChkErr(rc,__LINE__,u_FILE_u)) return
-          call med_merge_field(is_local%wrap%FBExp(compocn),      'Foxx_swnet_idr', &
-               FBinA=is_local%wrap%FBImp(compatm,compocn), fnameA='Faxa_swndr'    , wgtA=customwgt, &
-               FBinB=is_local%wrap%FBImp(compice,compocn), fnameB='Fioi_swpen_idr', wgtB=ifrac, rc=rc)
-          if (ChkErr(rc,__LINE__,u_FILE_u)) return
-          call med_merge_field(is_local%wrap%FBExp(compocn),      'Foxx_swnet_idf', &
-               FBinA=is_local%wrap%FBImp(compatm,compocn), fnameA='Faxa_swndf'    , wgtA=customwgt, &
-               FBinB=is_local%wrap%FBImp(compice,compocn), fnameB='Fioi_swpen_idf', wgtB=ifrac, rc=rc)
-          if (ChkErr(rc,__LINE__,u_FILE_u)) return
-
-          deallocate(customwgt)
-
-       end if  ! end of nems_orig or nems_frac
-
-       !-------------
-       ! Custom calculation for nems_orig_data
-       !-------------
-
-       if (trim(coupling_mode) == 'nems_orig_data') then
-
-          ! open ocean (i.e. atm)  and ice fraction
-          ! ocnwgt and icewgt are the "normal" fractions
-          ! ocnwgt1, icewgt1, and wgtp01 are the fractions that switch between atm and mediator fluxes
-          ! ocnwgt1+icewgt1+wgtp01 = 1.0 always
-          ! wgtp01 and wgtm01 are the same just one is +1 and the other is -1 to change sign depending on the ice fraction.
-          !   wgtp01 = 1 and wgtm01 = -1 when ice fraction = 0
-          !   wgtp01 = 0 and wgtm01 =  0 when ice fraction > 0
-
-          allocate(ocnwgt1(lsize))
-          allocate(icewgt1(lsize))
-          allocate(wgtp01(lsize))
-          allocate(wgtm01(lsize))
-          allocate(customwgt(lsize))
-
-          do n = 1,lsize
-             if (ifrac(n) <= 0._R8) then
-                ! ice fraction is 0
-                ocnwgt1(n) =  0.0_R8
-                icewgt1(n) =  0.0_R8
-                wgtp01(n)  =  1.0_R8
-                wgtm01(n)  = -1.0_R8
-             else
-                ! ice fraction is > 0
-                ocnwgt1(n) = ofrac(n)
-                icewgt1(n) = ifrac(n)
-                wgtp01(n)  = 0.0_R8
-                wgtm01(n)  = 0.0_R8
-             end if
-
-             ! check wgts do add to 1 as expected
-             if ( abs( ofrac(n) + ifrac(n) - 1.0_R8) > 1.0e-12 .or. &
-                  abs( ocnwgt1(n) + icewgt1(n) + wgtp01(n) - 1.0_R8) > 1.0e-12 .or. &
-                  abs( ocnwgt1(n) + icewgt1(n) - wgtm01(n) - 1.0_R8) > 1.0e-12) then
-
-                write(6,100)trim(subname)//'ERROR: n, ofrac, ifrac, sum',&
-                     n,ofrac(n),ifrac(n),ofrac(n)+ifrac(n)
-                write(6,101)trim(subname)//'ERROR: n, ocnwgt1, icewgt1, wgtp01, sum ', &
-                     n,ocnwgt1(n),icewgt1(n),wgtp01(n),ocnwgt1(n)+icewgt1(n)+wgtp01(n)
-                write(6,101)trim(subname)//'ERROR: n, ocnwgt1, icewgt1, -wgtm01, sum ', &
-                     n,ocnwgt1(n),icewgt1(n),-wgtp01(n),ocnwgt1(n)+icewgt1(n)-wgtm01(n)
-100             format(a,i8,2x,3(d20.13,2x))
-101             format(a,i8,2x,4(d20.13,2x))
-
-                call ESMF_LogWrite(trim(subname)//": ERROR atm + ice fracs inconsistent", &
-                     ESMF_LOGMSG_ERROR, line=__LINE__, file=__FILE__, rc=dbrc)
-                rc = ESMF_FAILURE
-                return
-             endif
-          end do
-
-          customwgt(:) = wgtm01(:) / const_lhvap
-          call med_merge_field(is_local%wrap%FBExp(compocn),      'Faxa_evap', &
-               FBinA=is_local%wrap%FBMed_aoflux_o        , fnameA='Faox_evap', wgtA=ocnwgt1, &
-               FBinB=is_local%wrap%FBImp(compatm,compocn), fnameB='Faxa_lat' , wgtB=customwgt, rc=rc)
-          if (ChkErr(rc,__LINE__,u_FILE_u)) return
-
-          call med_merge_field(is_local%wrap%FBExp(compocn),      'Faxa_sen',    &
-               FBinA=is_local%wrap%FBMed_aoflux_o        , fnameA='Faox_sen ', wgtA=ocnwgt1, &
-               FBinC=is_local%wrap%FBImp(compatm,compocn), fnameB='Faxa_sen' , wgtB=wgtm01, rc=rc)
-
-          call med_merge_field(is_local%wrap%FBExp(compocn),      'Foxx_taux',  &
-               FBinA=is_local%wrap%FBMed_aoflux_o        , fnameA='Faox_taux ', wgtA=ocnwgt1, &
-               FBinB=is_local%wrap%FBImp(compice,compocn), fnameB='Fioi_taux' , wgtB=icewgt1, &
-               FBinC=is_local%wrap%FBImp(compatm,compocn), fnameC='Faxa_taux' , wgtC=wgtm01, rc=rc)
-
-          call med_merge_field(is_local%wrap%FBExp(compocn),      'Foxx_tauy',  &
-               FBinA=is_local%wrap%FBMed_aoflux_o        , fnameA='Faox_tauy ', wgtA=ocnwgt1, &
-               FBinB=is_local%wrap%FBImp(compice,compocn), fnameB='Fioi_tauy' , wgtB=icewgt1, &
-               FBinC=is_local%wrap%FBImp(compatm,compocn), fnameC='Faxa_tauy' , wgtC=wgtm01, rc=rc)
-
-          ! If there is no ice on the ocn gridcell (ocnwgt1=0) - sum Faxa_lwdn and Faxa_lwup
-          ! If there is ice on the ocn gridcell -  merge Faox_lwup and Faxa_lwdn and ignore Faxa_lwup
-          call med_merge_field(is_local%wrap%FBExp(compocn),      'Foxx_lwnet', &
-               FBinA=is_local%wrap%FBMed_aoflux_o        , fnameA='Faox_lwup ', wgtA=ocnwgt1, &
-               FBinB=is_local%wrap%FBImp(compatm,compocn), fnameB='Faxa_lwdn' , wgtB=ocnwgt1, &
-               FBinC=is_local%wrap%FBImp(compatm,compocn), fnameC='Faxa_lwnet', wgtC=wgtp01, rc=rc)
-
-          call med_merge_field(is_local%wrap%FBExp(compocn),      'Faxa_rain' , &
-               FBInA=is_local%wrap%FBImp(compatm,compocn), fnameA='Faxa_rain' , wgtA=ofrac, rc=rc)
-
-          call med_merge_field(is_local%wrap%FBExp(compocn),      'Faxa_snow' , &
-               FBInA=is_local%wrap%FBImp(compatm,compocn), fnameA='Faxa_snow' , wgtA=ofrac, rc=rc)
-
-          deallocate(ocnwgt1)
-          deallocate(icewgt1)
-          deallocate(wgtp01)
-          deallocate(wgtm01)
-          deallocate(customwgt)
-
        end if  ! end of nems_orig_data custom
 
-       !---------------------------------------
-       !--- diagnose output
-       !---------------------------------------
-
+       ! diagnose output
        if (dbug_flag > 1) then
-          call FB_diagnose(is_local%wrap%FBExp(compocn), &
-               string=trim(subname)//' FBexp(compocn) ', rc=rc)
+          call FB_diagnose(is_local%wrap%FBExp(compocn), string=trim(subname)//' FBexp(compocn) ', rc=rc)
           if (ChkErr(rc,__LINE__,u_FILE_u)) return
        end if
-
-       ! TODO (mvertens, 2018-12-16): document above custom calculation
-
-       !---------------------------------------
-       !--- clean up
-       !---------------------------------------
 
     endif
 
     if (dbug_flag > 20) then
-       call ESMF_LogWrite(trim(subname)//": done", ESMF_LOGMSG_INFO, rc=dbrc)
+       call ESMF_LogWrite(trim(subname)//": done", ESMF_LOGMSG_INFO)
     end if
     call t_stopf('MED:'//subname)
 
   end subroutine med_phases_prep_ocn_merge
 
   !-----------------------------------------------------------------------------
-
   subroutine med_phases_prep_ocn_accum_fast(gcomp, rc)
 
     ! Carry out fast accumulation for the ocean
 
-    use ESMF , only : ESMF_GridComp, ESMF_Clock, ESMF_Time
+    use ESMF , only : ESMF_GridComp, ESMF_GridCompGet, ESMF_Clock, ESMF_Time
     use ESMF , only : ESMF_LogWrite, ESMF_LOGMSG_INFO, ESMF_SUCCESS
-    use ESMF , only : ESMF_GridCompGet, ESMF_ClockGet, ESMF_TimeGet, ESMF_ClockPrint
-    use ESMF , only : ESMF_FieldBundleGet
 
     ! input/output variables
     type(ESMF_GridComp)  :: gcomp
@@ -629,39 +202,29 @@ contains
     ! local variables
     type(ESMF_Clock)            :: clock
     type(ESMF_Time)             :: time
-    character(len=64)           :: timestr
     type(InternalState)         :: is_local
     integer                     :: i,j,n,ncnt
-    integer                     :: dbrc
     character(len=*), parameter :: subname='(med_phases_accum_fast)'
     !---------------------------------------
-    call t_startf('MED:'//subname)
 
-    if (dbug_flag > 20) then
-       call ESMF_LogWrite(trim(subname)//": called", ESMF_LOGMSG_INFO, rc=dbrc)
-    endif
     rc = ESMF_SUCCESS
 
-    !---------------------------------------
-    ! --- Get the internal state
-    !---------------------------------------
+    call t_startf('MED:'//subname)
+    if (dbug_flag > 20) then
+       call ESMF_LogWrite(trim(subname)//": called", ESMF_LOGMSG_INFO)
+    endif
 
+    ! Get the internal state
     nullify(is_local%wrap)
     call ESMF_GridCompGetInternalState(gcomp, is_local, rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
 
-    !---------------------------------------
-    ! --- Count the number of fields outside of scalar data, if zero, then return
-    !---------------------------------------
+    ! Count the number of fields outside of scalar data, if zero, then return
     call FB_getNumFlds(is_local%wrap%FBExp(compocn), trim(subname)//"FBexp(compocn)", ncnt, rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
 
     if (ncnt > 0) then
-
-       !---------------------------------------
-       !--- ocean accumulator
-       !---------------------------------------
-
+       ! ocean accumulator
        call FB_accum(is_local%wrap%FBExpAccum(compocn), is_local%wrap%FBExp(compocn), rc=rc)
        if (ChkErr(rc,__LINE__,u_FILE_u)) return
 
@@ -672,96 +235,70 @@ contains
                string=trim(subname)//' FBExpAccum accumulation ', rc=rc)
           if (ChkErr(rc,__LINE__,u_FILE_u)) return
        end if
-
-       !---------------------------------------
-       !--- clean up
-       !---------------------------------------
     endif
 
     if (dbug_flag > 20) then
-       call ESMF_LogWrite(trim(subname)//": done", ESMF_LOGMSG_INFO, rc=dbrc)
+       call ESMF_LogWrite(trim(subname)//": done", ESMF_LOGMSG_INFO)
     end if
     call t_stopf('MED:'//subname)
 
   end subroutine med_phases_prep_ocn_accum_fast
 
   !-----------------------------------------------------------------------------
-
   subroutine med_phases_prep_ocn_accum_avg(gcomp, rc)
 
     ! Prepare the OCN import Fields.
 
-    use ESMF , only : ESMF_GridComp, ESMF_Clock, ESMF_Time
-    use ESMF , only : ESMF_LogWrite, ESMF_LOGMSG_INFO, ESMF_SUCCESS
-    use ESMF , only : ESMF_FieldBundleGet
+    use ESMF , only : ESMF_GridComp, ESMF_LogWrite, ESMF_LOGMSG_INFO, ESMF_SUCCESS
 
     ! input/output variables
     type(ESMF_GridComp)  :: gcomp
     integer, intent(out) :: rc
 
     ! local variables
-    type(ESMF_Clock)           :: clock
-    type(ESMF_Time)            :: time
-    character(len=64)          :: timestr
     type(InternalState)        :: is_local
-    integer                    :: i,j,n,ncnt
-    integer                    :: dbrc
+    integer                    :: ncnt
     character(len=*),parameter :: subname='(med_phases_prep_ocn_accum_avg)'
     !---------------------------------------
-    call t_startf('MED:'//subname)
 
-    if (dbug_flag > 20) then
-       call ESMF_LogWrite(trim(subname)//": called", ESMF_LOGMSG_INFO, rc=dbrc)
-    endif
     rc = ESMF_SUCCESS
 
-    !---------------------------------------
-    ! --- Get the internal state
-    !---------------------------------------
+    call t_startf('MED:'//subname)
+    if (dbug_flag > 20) then
+       call ESMF_LogWrite(trim(subname)//": called", ESMF_LOGMSG_INFO)
+    endif
 
+    ! Get the internal state
     nullify(is_local%wrap)
     call ESMF_GridCompGetInternalState(gcomp, is_local, rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
 
-    !---------------------------------------
-    ! --- Count the number of fields outside of scalar data, if zero, then return
-    !---------------------------------------
+    ! Count the number of fields outside of scalar data, if zero, then return
     call FB_getNumFlds(is_local%wrap%FBExpAccum(compocn), trim(subname)//"FBExpAccum(compocn)", ncnt, rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
 
     if (ncnt > 0) then
 
-       !---------------------------------------
-       !--- average ocn accumulator
-       !---------------------------------------
-
+       ! average ocn accumulator
        if (dbug_flag > 1) then
           call FB_diagnose(is_local%wrap%FBExpAccum(compocn), &
                string=trim(subname)//' FBExpAccum(compocn) before avg ', rc=rc)
           if (ChkErr(rc,__LINE__,u_FILE_u)) return
        end if
-
        call FB_average(is_local%wrap%FBExpAccum(compocn), &
             is_local%wrap%FBExpAccumCnt(compocn), rc=rc)
        if (ChkErr(rc,__LINE__,u_FILE_u)) return
-
        if (dbug_flag > 1) then
           call FB_diagnose(is_local%wrap%FBExp(compocn), &
                string=trim(subname)//' FBExpAccum(compocn) after avg ', rc=rc)
           if (ChkErr(rc,__LINE__,u_FILE_u)) return
        end if
 
-       !---------------------------------------
-       !--- copy to FBExp(compocn)
-       !---------------------------------------
-
+       ! copy to FBExp(compocn)
        call FB_copy(is_local%wrap%FBExp(compocn), is_local%wrap%FBExpAccum(compocn), rc=rc)
        if (ChkErr(rc,__LINE__,u_FILE_u)) return
 
-       !---------------------------------------
-       !--- zero accumulator
-       !---------------------------------------
-
+       ! zero accumulator
        is_local%wrap%FBExpAccumFlag(compocn) = .true.
        is_local%wrap%FBExpAccumCnt(compocn) = 0
        call FB_reset(is_local%wrap%FBExpAccum(compocn), value=czero, rc=rc)
@@ -770,10 +307,558 @@ contains
     end if
 
     if (dbug_flag > 20) then
-       call ESMF_LogWrite(trim(subname)//": done", ESMF_LOGMSG_INFO, rc=dbrc)
+       call ESMF_LogWrite(trim(subname)//": done", ESMF_LOGMSG_INFO)
     end if
     call t_stopf('MED:'//subname)
 
   end subroutine med_phases_prep_ocn_accum_avg
+
+  !-----------------------------------------------------------------------------
+  subroutine med_phases_prep_ocn_custom_cesm(gcomp, rc)
+
+    !---------------------------------------
+    ! custom calculations for cesm
+    !---------------------------------------
+
+    use ESMF , only : ESMF_GridComp
+    use ESMF , only : ESMF_LogWrite, ESMF_LOGMSG_INFO, ESMF_SUCCESS
+    use ESMF , only : ESMF_FAILURE,  ESMF_LOGMSG_ERROR
+
+    ! input/output variables
+    type(ESMF_GridComp)  :: gcomp
+    integer, intent(out) :: rc
+
+    ! local variables
+    type(InternalState) :: is_local
+    real(R8), pointer   :: ifrac(:), ofrac(:)
+    real(R8), pointer   :: ifracr(:), ofracr(:)
+    real(R8), pointer   :: avsdr(:), avsdf(:)
+    real(R8), pointer   :: anidr(:), anidf(:)
+    real(R8), pointer   :: Faxa_swvdf(:), Faxa_swndf(:)
+    real(R8), pointer   :: Faxa_swvdr(:), Faxa_swndr(:)
+    real(R8), pointer   :: Foxx_swnet(:)
+    real(R8), pointer   :: Foxx_swnet_afracr(:)
+    real(R8), pointer   :: Foxx_swnet_vdr(:), Foxx_swnet_vdf(:)
+    real(R8), pointer   :: Foxx_swnet_idr(:), Foxx_swnet_idf(:)
+    real(R8), pointer   :: Fioi_swpen_vdr(:), Fioi_swpen_vdf(:)
+    real(R8), pointer   :: Fioi_swpen_idr(:), Fioi_swpen_idf(:)
+    real(R8), pointer   :: Fioi_swpen(:)
+    real(R8), pointer   :: dataptr(:)
+    real(R8), pointer   :: dataptr_o(:)
+    real(R8)            :: frac_sum
+    real(R8)            :: ifrac_scaled, ofrac_scaled
+    real(R8)            :: ifracr_scaled, ofracr_scaled
+    logical             :: export_swnet_by_bands
+    logical             :: import_swpen_by_bands
+    logical             :: export_swnet_afracr
+    logical             :: first_precip_fact_call = .true.
+    real(R8)            :: precip_fact
+    character(CS)       :: cvalue
+    real(R8)            :: fswabsv, fswabsi
+    integer             :: n
+    integer             :: lsize
+    real(R8)            :: c1,c2,c3,c4
+    character(len=64), allocatable :: fldnames(:)
+    character(len=*), parameter    :: subname='(med_phases_prep_ocn_custom_cesm)'
+    !---------------------------------------
+
+    rc = ESMF_SUCCESS
+
+    call t_startf('MED:'//subname)
+    if (dbug_flag > 20) then
+       call ESMF_LogWrite(subname//' called', ESMF_LOGMSG_INFO)
+    end if
+    call memcheck(subname, 5, mastertask)
+
+    ! Get the internal state
+    nullify(is_local%wrap)
+    call ESMF_GridCompGetInternalState(gcomp, is_local, rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+
+    !---------------------------------------
+    ! Compute netsw for ocean
+    !---------------------------------------
+    ! netsw_for_ocn = downsw_from_atm * (1-ocn_albedo) * (1-ice_fraction) + pensw_from_ice * (ice_fraction)
+
+    ! Input from atm
+    call FB_GetFldPtr(is_local%wrap%FBImp(compatm,compocn), 'Faxa_swvdr', Faxa_swvdr, rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+    call FB_GetFldPtr(is_local%wrap%FBImp(compatm,compocn), 'Faxa_swndr', Faxa_swndr, rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+    call FB_GetFldPtr(is_local%wrap%FBImp(compatm,compocn), 'Faxa_swvdf', Faxa_swvdf, rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+    call FB_GetFldPtr(is_local%wrap%FBImp(compatm,compocn), 'Faxa_swndf', Faxa_swndf, rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+    lsize = size(Faxa_swvdr)
+
+    ! Input from mediator, ocean albedos
+    call FB_GetFldPtr(is_local%wrap%FBMed_ocnalb_o, 'So_avsdr' , avsdr, rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+    call FB_GetFldPtr(is_local%wrap%FBMed_ocnalb_o, 'So_anidr' , anidr, rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+    call FB_GetFldPtr(is_local%wrap%FBMed_ocnalb_o, 'So_avsdf' , avsdf, rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+    call FB_GetFldPtr(is_local%wrap%FBMed_ocnalb_o, 'So_anidf' , anidf, rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+
+    ! Output to ocean swnet total
+    if (FB_fldchk(is_local%wrap%FBExp(compocn), 'Foxx_swnet', rc=rc)) then
+       call FB_GetFldPtr(is_local%wrap%FBExp(compocn), 'Foxx_swnet',  Foxx_swnet, rc=rc)
+       if (ChkErr(rc,__LINE__,u_FILE_u)) return
+    else
+       lsize = size(Faxa_swvdr)
+       allocate(Foxx_swnet(lsize))
+    end if
+
+    ! Output to ocean swnet by radiation bands
+    if (FB_fldchk(is_local%wrap%FBExp(compocn), 'Foxx_swnet_vdr', rc=rc)) then
+       export_swnet_by_bands = .true.
+       call FB_GetFldPtr(is_local%wrap%FBExp(compocn), 'Foxx_swnet_vdr', Foxx_swnet_vdr, rc=rc)
+       if (ChkErr(rc,__LINE__,u_FILE_u)) return
+       call FB_GetFldPtr(is_local%wrap%FBExp(compocn), 'Foxx_swnet_vdf', Foxx_swnet_vdf, rc=rc)
+       if (ChkErr(rc,__LINE__,u_FILE_u)) return
+       call FB_GetFldPtr(is_local%wrap%FBExp(compocn), 'Foxx_swnet_idr', Foxx_swnet_idr, rc=rc)
+       if (ChkErr(rc,__LINE__,u_FILE_u)) return
+       call FB_GetFldPtr(is_local%wrap%FBExp(compocn), 'Foxx_swnet_idf', Foxx_swnet_idf, rc=rc)
+       if (ChkErr(rc,__LINE__,u_FILE_u)) return
+    else
+       export_swnet_by_bands = .false.
+    end if
+
+    ! -----------------------
+    ! If cice IS NOT PRESENT
+    ! -----------------------
+    if (.not. is_local%wrap%comp_present(compice)) then
+       ! Compute total swnet to ocean independent of swpen from sea-ice
+       do n = 1,lsize
+          fswabsv  = Faxa_swvdr(n) * (1.0_R8 - avsdr(n)) + Faxa_swvdf(n) * (1.0_R8 - avsdf(n))
+          fswabsi  = Faxa_swndr(n) * (1.0_R8 - anidr(n)) + Faxa_swndf(n) * (1.0_R8 - anidf(n))
+          Foxx_swnet(n) = fswabsv + fswabsi
+       end do
+       ! Compute sw export to ocean bands if required
+       if (export_swnet_by_bands) then
+          c1 = 0.285; c2 = 0.285; c3 = 0.215; c4 = 0.215
+          Foxx_swnet_vdr(:) = c1 * Foxx_swnet(:)
+          Foxx_swnet_vdf(:) = c2 * Foxx_swnet(:)
+          Foxx_swnet_idr(:) = c3 * Foxx_swnet(:)
+          Foxx_swnet_idf(:) = c4 * Foxx_swnet(:)
+       end if
+    end if
+
+    ! -----------------------
+    ! If cice IS PRESENT
+    ! -----------------------
+    if (is_local%wrap%comp_present(compice)) then
+
+       ! Input from mediator, ice-covered ocean and open ocean fractions
+       call FB_GetFldPtr(is_local%wrap%FBfrac(compocn), 'ifrac' , ifrac, rc=rc)
+       if (ChkErr(rc,__LINE__,u_FILE_u)) return
+       call FB_GetFldPtr(is_local%wrap%FBfrac(compocn), 'ofrac' , ofrac, rc=rc)
+       if (ChkErr(rc,__LINE__,u_FILE_u)) return
+       call FB_GetFldPtr(is_local%wrap%FBfrac(compocn), 'ifrad' , ifracr, rc=rc)
+       if (ChkErr(rc,__LINE__,u_FILE_u)) return
+       call FB_GetFldPtr(is_local%wrap%FBfrac(compocn), 'ofrad' , ofracr, rc=rc)
+       if (ChkErr(rc,__LINE__,u_FILE_u)) return
+
+       call FB_GetFldPtr(is_local%wrap%FBImp(compice,compocn), 'Fioi_swpen', Fioi_swpen, rc=rc)
+       if (ChkErr(rc,__LINE__,u_FILE_u)) return
+       if (FB_fldchk(is_local%wrap%FBImp(compice,compice), 'Fioi_swpen_vdr', rc=rc)) then
+          import_swpen_by_bands = .true.
+          call FB_GetFldPtr(is_local%wrap%FBImp(compice,compocn), 'Fioi_swpen_vdr', Fioi_swpen_vdr, rc=rc)
+          if (ChkErr(rc,__LINE__,u_FILE_u)) return
+          call FB_GetFldPtr(is_local%wrap%FBImp(compice,compocn), 'Fioi_swpen_vdf', Fioi_swpen_vdf, rc=rc)
+          if (ChkErr(rc,__LINE__,u_FILE_u)) return
+          call FB_GetFldPtr(is_local%wrap%FBImp(compice,compocn), 'Fioi_swpen_idr', Fioi_swpen_idr, rc=rc)
+          if (ChkErr(rc,__LINE__,u_FILE_u)) return
+          call FB_GetFldPtr(is_local%wrap%FBImp(compice,compocn), 'Fioi_swpen_idf', Fioi_swpen_idf, rc=rc)
+          if (ChkErr(rc,__LINE__,u_FILE_u)) return
+       else
+          import_swpen_by_bands = .false.
+       end if
+
+       ! Swnet without swpen from sea-ice
+       if ( FB_fldchk(is_local%wrap%FBExp(compocn), 'Foxx_swnet_afracr',rc=rc)) then
+          call FB_GetFldPtr(is_local%wrap%FBExp(compocn), 'Foxx_swnet_afracr', Foxx_swnet_afracr, rc=rc)
+          if (ChkErr(rc,__LINE__,u_FILE_u)) return
+          export_swnet_afracr = .true.
+       else
+          export_swnet_afracr = .false.
+       end if
+
+       do n = 1,lsize
+          ! Compute total swnet to ocean independent of swpen from sea-ice
+          fswabsv  = Faxa_swvdr(n) * (1.0_R8 - avsdr(n)) + Faxa_swvdf(n) * (1.0_R8 - avsdf(n))
+          fswabsi  = Faxa_swndr(n) * (1.0_R8 - anidr(n)) + Faxa_swndf(n) * (1.0_R8 - anidf(n))
+          Foxx_swnet(n) = fswabsv + fswabsi
+
+          ! Add swpen from sea ice
+          ifrac_scaled = ifrac(n)
+          ofrac_scaled = ofrac(n)
+          frac_sum = ifrac(n) + ofrac(n)
+          if (frac_sum /= 0._R8) then
+             ifrac_scaled = ifrac(n) / (frac_sum)
+             ofrac_scaled = ofrac(n) / (frac_sum)
+          endif
+          ifracr_scaled = ifracr(n)
+          ofracr_scaled = ofracr(n)
+          frac_sum = ifracr(n) + ofracr(n)
+          if (frac_sum /= 0._R8) then
+             ifracr_scaled = ifracr(n) / (frac_sum)
+             ofracr_scaled = ofracr(n) / (frac_sum)
+          endif
+          Foxx_swnet(n) = ofracr_scaled*(fswabsv + fswabsi) + ifrac_scaled*Fioi_swpen(n)
+
+          if (export_swnet_afracr) then
+             Foxx_swnet_afracr(n) = ofracr_scaled*(fswabsv + fswabsi)
+          end if
+
+          ! Compute sw export to ocean bands if required
+          if (export_swnet_by_bands) then
+             if (import_swpen_by_bands) then
+                ! use each individual band for swpen coming from the sea-ice
+                Foxx_swnet_vdr(n) = Faxa_swvdr(n)*(1.0_R8-avsdr(n))*ofracr_scaled + Fioi_swpen_vdr(n)*ifrac_scaled
+                Foxx_swnet_vdf(n) = Faxa_swvdf(n)*(1.0_R8-avsdf(n))*ofracr_scaled + Fioi_swpen_vdf(n)*ifrac_scaled
+                Foxx_swnet_idr(n) = Faxa_swndr(n)*(1.0_R8-anidr(n))*ofracr_scaled + Fioi_swpen_idr(n)*ifrac_scaled
+                Foxx_swnet_idf(n) = Faxa_swndf(n)*(1.0_R8-anidf(n))*ofracr_scaled + Fioi_swpen_idf(n)*ifrac_scaled
+             else
+                ! scale total Foxx_swnet to get contributions from each band
+                c1 = 0.285; c2 = 0.285; c3 = 0.215; c4 = 0.215
+                Foxx_swnet_vdr(n) = c1 * Foxx_swnet(n)
+                Foxx_swnet_vdf(n) = c2 * Foxx_swnet(n)
+                Foxx_swnet_idr(n) = c3 * Foxx_swnet(n)
+                Foxx_swnet_idf(n) = c4 * Foxx_swnet(n)
+             end if
+          end if
+       end do
+
+       ! Output to ocean per ice thickness fraction and sw penetrating into ocean
+       if ( FB_fldchk(is_local%wrap%FBExp(compocn), 'Sf_afrac', rc=rc)) then
+          call FB_GetFldPtr(is_local%wrap%FBExp(compocn), 'Sf_afrac', fldptr1=dataptr_o, rc=rc)
+          if (ChkErr(rc,__LINE__,u_FILE_u)) return
+          dataptr_o(:) = ofrac(:)
+       end if
+       if ( FB_fldchk(is_local%wrap%FBExp(compocn), 'Sf_afracr', rc=rc)) then
+          call FB_GetFldPtr(is_local%wrap%FBExp(compocn), 'Sf_afracr', fldptr1=dataptr_o, rc=rc)
+          if (ChkErr(rc,__LINE__,u_FILE_u)) return
+          dataptr_o(:) = ofracr(:)
+       end if
+
+    end if  ! if sea-ice is present
+
+    ! Deallocate Foxx_swnet if it was allocated in this subroutine
+    if (.not. FB_fldchk(is_local%wrap%FBExp(compocn), 'Foxx_swnet', rc=rc)) then
+       deallocate(Foxx_swnet)
+    end if
+
+    !---------------------------------------
+    ! application of precipitation factor from ocean
+    !---------------------------------------
+    precip_fact = 1.0_R8
+    if (precip_fact /= 1.0_R8) then
+       if (first_precip_fact_call .and. mastertask) then
+          write(logunit,'(a)')'(merge_to_ocn): Scaling rain, snow, liquid and ice runoff by precip_fact '
+          first_precip_fact_call = .false.
+       end if
+       write(cvalue,*) precip_fact
+       call ESMF_LogWrite(trim(subname)//" precip_fact is "//trim(cvalue), ESMF_LOGMSG_INFO)
+
+       allocate(fldnames(4))
+       fldnames = (/'Faxa_rain','Faxa_snow', 'Foxx_rofl', 'Foxx_rofi'/)
+       do n = 1,size(fldnames)
+          if (FB_fldchk(is_local%wrap%FBExp(compocn), trim(fldnames(n)), rc=rc)) then
+             call FB_GetFldPtr(is_local%wrap%FBExp(compocn), trim(fldnames(n)) , dataptr, rc=rc)
+             if (ChkErr(rc,__LINE__,u_FILE_u)) return
+             dataptr(:) = dataptr(:) * precip_fact
+          end if
+       end do
+       deallocate(fldnames)
+    end if
+
+    if (dbug_flag > 20) then
+       call ESMF_LogWrite(trim(subname)//": done", ESMF_LOGMSG_INFO)
+    end if
+    call t_stopf('MED:'//subname)
+
+  end subroutine med_phases_prep_ocn_custom_cesm
+
+  !-----------------------------------------------------------------------------
+  subroutine med_phases_prep_ocn_custom_nems(gcomp, rc)
+
+    ! ----------------------------------------------
+    ! Custom calculation for nems_orig or nems_frac
+    ! ----------------------------------------------
+
+    use ESMF , only : ESMF_GridComp
+    use ESMF , only : ESMF_LogWrite, ESMF_LOGMSG_INFO, ESMF_SUCCESS
+    use ESMF , only : ESMF_FAILURE,  ESMF_LOGMSG_ERROR
+
+    ! input/output variables
+    type(ESMF_GridComp)  :: gcomp
+    integer, intent(out) :: rc
+
+    ! local variables
+    type(InternalState) :: is_local
+    real(R8), pointer   :: ocnwgt1(:)
+    real(R8), pointer   :: icewgt1(:)
+    real(R8), pointer   :: wgtp01(:)
+    real(R8), pointer   :: wgtm01(:)
+    real(R8), pointer   :: customwgt(:)
+    real(R8), pointer   :: ifrac(:)
+    real(R8), pointer   :: ofrac(:)
+    integer             :: lsize
+    real(R8)        , parameter    :: const_lhvap = 2.501e6_R8  ! latent heat of evaporation ~ J/kg
+    character(len=*), parameter    :: subname='(med_phases_prep_ocn_custom_nems)'
+    !---------------------------------------
+
+    rc = ESMF_SUCCESS
+
+    call t_startf('MED:'//subname)
+    if (dbug_flag > 20) then
+       call ESMF_LogWrite(subname//' called', ESMF_LOGMSG_INFO)
+    end if
+    call memcheck(subname, 5, mastertask)
+
+    ! Get the internal state
+    nullify(is_local%wrap)
+    call ESMF_GridCompGetInternalState(gcomp, is_local, rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+
+    ! get ice and open ocean fractions on the ocn mesh
+    call FB_GetFldPtr(is_local%wrap%FBfrac(compocn), 'ifrac' , ifrac, rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+    call FB_GetFldPtr(is_local%wrap%FBfrac(compocn), 'ofrac' , ofrac, rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+
+    lsize = size(ofrac)
+    allocate(customwgt(lsize))
+
+    call med_merge_field(is_local%wrap%FBExp(compocn),      'Faxa_rain',  &
+         FBinA=is_local%wrap%FBImp(compatm,compocn), fnameA='Faxa_rain' , wgtA=ofrac, rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+    call med_merge_field(is_local%wrap%FBExp(compocn),      'Faxa_snow',  &
+         FBinA=is_local%wrap%FBImp(compatm,compocn), fnameA='Faxa_snow' , wgtA=ofrac, rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+    call med_merge_field(is_local%wrap%FBExp(compocn),      'Faxa_lwnet',  &
+         FBinA=is_local%wrap%FBImp(compatm,compocn), fnameA='Faxa_lwnet', wgtA=ofrac, rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+
+    customwgt(:) = -ofrac(:) / const_lhvap
+    call med_merge_field(is_local%wrap%FBExp(compocn),      'Faxa_evap', &
+         FBinA=is_local%wrap%FBImp(compatm,compocn), fnameA='Faxa_lat' , wgtA=customwgt, rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+
+    customwgt(:) = -ofrac(:)
+    call med_merge_field(is_local%wrap%FBExp(compocn),      'Faxa_sen',  &
+         FBinA=is_local%wrap%FBImp(compatm,compocn), fnameA='Faxa_sen', wgtA=customwgt, rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+    call med_merge_field(is_local%wrap%FBExp(compocn),      'Foxx_taux',  &
+         FBinA=is_local%wrap%FBImp(compice,compocn), fnameA='Fioi_taux' , wgtA=ifrac, &
+         FBinB=is_local%wrap%FBImp(compatm,compocn), fnameB='Faxa_taux' , wgtB=customwgt, rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+    call med_merge_field(is_local%wrap%FBExp(compocn),      'Foxx_tauy',  &
+         FBinA=is_local%wrap%FBImp(compice,compocn), fnameA='Fioi_tauy' , wgtA=ifrac, &
+         FBinB=is_local%wrap%FBImp(compatm,compocn), fnameB='Faxa_tauy' , wgtB=customwgt, rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+
+    ! netsw_for_ocn = [downsw_from_atm*(1-ice_fraction)*(1-ocn_albedo)] + [pensw_from_ice*(ice_fraction)]
+    customwgt(:) = ofrac(:) * (1.0 - 0.06)
+    call med_merge_field(is_local%wrap%FBExp(compocn),      'Foxx_swnet_vdr', &
+         FBinA=is_local%wrap%FBImp(compatm,compocn), fnameA='Faxa_swvdr'    , wgtA=customwgt, &
+         FBinB=is_local%wrap%FBImp(compice,compocn), fnameB='Fioi_swpen_vdr', wgtB=ifrac, rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+    call med_merge_field(is_local%wrap%FBExp(compocn),      'Foxx_swnet_vdf', &
+         FBinA=is_local%wrap%FBImp(compatm,compocn), fnameA='Faxa_swvdf'    , wgtA=customwgt, &
+         FBinB=is_local%wrap%FBImp(compice,compocn), fnameB='Fioi_swpen_vdf', wgtB=ifrac, rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+    call med_merge_field(is_local%wrap%FBExp(compocn),      'Foxx_swnet_idr', &
+         FBinA=is_local%wrap%FBImp(compatm,compocn), fnameA='Faxa_swndr'    , wgtA=customwgt, &
+         FBinB=is_local%wrap%FBImp(compice,compocn), fnameB='Fioi_swpen_idr', wgtB=ifrac, rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+    call med_merge_field(is_local%wrap%FBExp(compocn),      'Foxx_swnet_idf', &
+         FBinA=is_local%wrap%FBImp(compatm,compocn), fnameA='Faxa_swndf'    , wgtA=customwgt, &
+         FBinB=is_local%wrap%FBImp(compice,compocn), fnameB='Fioi_swpen_idf', wgtB=ifrac, rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+
+    deallocate(customwgt)
+
+    if (dbug_flag > 20) then
+       call ESMF_LogWrite(trim(subname)//": done", ESMF_LOGMSG_INFO)
+    end if
+    call t_stopf('MED:'//subname)
+
+  end subroutine med_phases_prep_ocn_custom_nems
+
+  !-----------------------------------------------------------------------------
+  subroutine med_phases_prep_ocn_custom_nemsdata(gcomp, rc)
+
+    ! ----------------------------------------------
+    ! Custom calculation for nems_orig_data
+    ! ----------------------------------------------
+
+    use ESMF , only : ESMF_GridComp
+    use ESMF , only : ESMF_LogWrite, ESMF_LOGMSG_INFO, ESMF_SUCCESS
+    use ESMF , only : ESMF_FAILURE,  ESMF_LOGMSG_ERROR
+
+    ! input/output variables
+    type(ESMF_GridComp)  :: gcomp
+    integer, intent(out) :: rc
+
+    ! local variables
+    type(InternalState) :: is_local
+    real(R8), pointer   :: ocnwgt1(:)   ! NEMS_orig_data
+    real(R8), pointer   :: icewgt1(:)   ! NEMS_orig_data
+    real(R8), pointer   :: wgtp01(:)    ! NEMS_orig_data
+    real(R8), pointer   :: wgtm01(:)    ! NEMS_orig_data
+    real(R8), pointer   :: customwgt(:) ! NEMS_orig_data
+    real(R8), pointer   :: ifrac(:)
+    real(R8), pointer   :: ofrac(:)
+    integer             :: lsize
+    integer             :: n
+    real(R8)        , parameter    :: const_lhvap = 2.501e6_R8  ! latent heat of evaporation ~ J/kg
+    character(len=*), parameter    :: subname='(med_phases_prep_ocn_custom_nemsdata)'
+    !---------------------------------------
+
+    rc = ESMF_SUCCESS
+
+    call t_startf('MED:'//subname)
+    if (dbug_flag > 20) then
+       call ESMF_LogWrite(subname//' called', ESMF_LOGMSG_INFO)
+    end if
+    call memcheck(subname, 5, mastertask)
+
+    ! Get the internal state
+    nullify(is_local%wrap)
+    call ESMF_GridCompGetInternalState(gcomp, is_local, rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+
+    ! get ice and open ocean fractions on the ocn mesh
+    call FB_GetFldPtr(is_local%wrap%FBfrac(compocn), 'ifrac' , ifrac, rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+    call FB_GetFldPtr(is_local%wrap%FBfrac(compocn), 'ofrac' , ofrac, rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+
+    lsize = size(ofrac)
+    allocate(customwgt(lsize))
+
+    ! open ocean (i.e. atm)  and ice fraction
+    ! ocnwgt and icewgt are the "normal" fractions
+    ! ocnwgt1, icewgt1, and wgtp01 are the fractions that switch between atm and mediator fluxes
+    ! ocnwgt1+icewgt1+wgtp01 = 1.0 always
+    ! wgtp01 and wgtm01 are the same just one is +1 and the other is -1 to change sign depending on the ice fraction.
+    !   wgtp01 = 1 and wgtm01 = -1 when ice fraction = 0
+    !   wgtp01 = 0 and wgtm01 =  0 when ice fraction > 0
+
+    allocate(ocnwgt1(lsize))
+    allocate(icewgt1(lsize))
+    allocate(wgtp01(lsize))
+    allocate(wgtm01(lsize))
+    allocate(customwgt(lsize))
+
+    do n = 1,lsize
+       if (ifrac(n) <= 0._R8) then
+          ! ice fraction is 0
+          ocnwgt1(n) =  1.0_R8
+          icewgt1(n) =  0.0_R8
+          wgtp01(n)  =  0.0_R8
+          wgtm01(n)  =  0.0_R8
+       else
+          ! ice fraction is > 0
+          ocnwgt1(n) = ofrac(n)
+          icewgt1(n) = ifrac(n)
+          wgtp01(n)  = 0.0_R8
+          wgtm01(n)  = 0.0_R8
+       end if
+
+       ! check wgts do add to 1 as expected
+       ! TODO: check if this condition is still required
+       if(ofrac(n)+ifrac(n) /= 0._R8)then
+         if ( abs( ofrac(n) + ifrac(n) - 1.0_R8) > 1.0e-12 .or. &
+              abs( ocnwgt1(n) + icewgt1(n) + wgtp01(n) - 1.0_R8) > 1.0e-12 .or. &
+              abs( ocnwgt1(n) + icewgt1(n) - wgtm01(n) - 1.0_R8) > 1.0e-12) then
+
+           write(6,100)trim(subname)//'ERROR: n, ofrac, ifrac, sum',&
+                n,ofrac(n),ifrac(n),ofrac(n)+ifrac(n)
+           write(6,101)trim(subname)//'ERROR: n, ocnwgt1, icewgt1, wgtp01, sum ', &
+                n,ocnwgt1(n),icewgt1(n),wgtp01(n),ocnwgt1(n)+icewgt1(n)+wgtp01(n)
+           write(6,101)trim(subname)//'ERROR: n, ocnwgt1, icewgt1, -wgtm01, sum ', &
+                n,ocnwgt1(n),icewgt1(n),-wgtp01(n),ocnwgt1(n)+icewgt1(n)-wgtm01(n)
+100        format(a,i8,2x,3(d20.13,2x))
+101        format(a,i8,2x,4(d20.13,2x))
+
+           call ESMF_LogWrite(trim(subname)//": ERROR atm + ice fracs inconsistent", &
+                ESMF_LOGMSG_ERROR, line=__LINE__, file=__FILE__)
+           rc = ESMF_FAILURE
+           return
+         endif
+       endif
+    end do
+
+    customwgt(:) = wgtm01(:) / const_lhvap
+    call med_merge_field(is_local%wrap%FBExp(compocn),      'Faxa_evap', &
+         FBinA=is_local%wrap%FBMed_aoflux_o        , fnameA='Faox_evap', wgtA=ocnwgt1, &
+         FBinB=is_local%wrap%FBImp(compatm,compocn), fnameB='Faxa_lat' , wgtB=customwgt, rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+    call med_merge_field(is_local%wrap%FBExp(compocn),      'Faxa_sen',    &
+         FBinA=is_local%wrap%FBMed_aoflux_o        , fnameA='Faox_sen ', wgtA=ocnwgt1, &
+         FBinB=is_local%wrap%FBImp(compatm,compocn), fnameB='Faxa_sen' , wgtB=wgtm01, rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+
+    call med_merge_field(is_local%wrap%FBExp(compocn),      'Foxx_taux',  &
+         FBinA=is_local%wrap%FBMed_aoflux_o        , fnameA='Faox_taux ', wgtA=ocnwgt1, &
+         FBinB=is_local%wrap%FBImp(compice,compocn), fnameB='Fioi_taux' , wgtB=icewgt1, &
+         FBinC=is_local%wrap%FBImp(compatm,compocn), fnameC='Faxa_taux' , wgtC=wgtm01, rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+    call med_merge_field(is_local%wrap%FBExp(compocn),      'Foxx_tauy',  &
+         FBinA=is_local%wrap%FBMed_aoflux_o        , fnameA='Faox_tauy ', wgtA=ocnwgt1, &
+         FBinB=is_local%wrap%FBImp(compice,compocn), fnameB='Fioi_tauy' , wgtB=icewgt1, &
+         FBinC=is_local%wrap%FBImp(compatm,compocn), fnameC='Faxa_tauy' , wgtC=wgtm01, rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+
+    ! If there is no ice on the ocn gridcell (ocnwgt1=0) - sum Faxa_lwdn and Faxa_lwup
+    ! If there is ice on the ocn gridcell -  merge Faox_lwup and Faxa_lwdn and ignore Faxa_lwup
+    call med_merge_field(is_local%wrap%FBExp(compocn),      'Foxx_lwnet', &
+         FBinA=is_local%wrap%FBMed_aoflux_o        , fnameA='Faox_lwup ', wgtA=ocnwgt1, &
+         FBinB=is_local%wrap%FBImp(compatm,compocn), fnameB='Faxa_lwdn' , wgtB=ocnwgt1, &
+         FBinC=is_local%wrap%FBImp(compatm,compocn), fnameC='Faxa_lwnet', wgtC=wgtp01, rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+
+    call med_merge_field(is_local%wrap%FBExp(compocn),      'Faxa_rain' , &
+         FBInA=is_local%wrap%FBImp(compatm,compocn), fnameA='Faxa_rain' , wgtA=ofrac, rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+    call med_merge_field(is_local%wrap%FBExp(compocn),      'Faxa_snow' , &
+         FBInA=is_local%wrap%FBImp(compatm,compocn), fnameA='Faxa_snow' , wgtA=ofrac, rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+
+    ! netsw_for_ocn = [downsw_from_atm*(1-ice_fraction)*(1-ocn_albedo)] + [pensw_from_ice*(ice_fraction)]
+    customwgt(:) = ofrac(:) * (1.0 - 0.06)
+    call med_merge_field(is_local%wrap%FBExp(compocn),      'Foxx_swnet_vdr', &
+         FBinA=is_local%wrap%FBImp(compatm,compocn), fnameA='Faxa_swvdr'    , wgtA=customwgt, &
+         FBinB=is_local%wrap%FBImp(compice,compocn), fnameB='Fioi_swpen_vdr', wgtB=ifrac, rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+    call med_merge_field(is_local%wrap%FBExp(compocn),      'Foxx_swnet_vdf', &
+         FBinA=is_local%wrap%FBImp(compatm,compocn), fnameA='Faxa_swvdf'    , wgtA=customwgt, &
+         FBinB=is_local%wrap%FBImp(compice,compocn), fnameB='Fioi_swpen_vdf', wgtB=ifrac, rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+    call med_merge_field(is_local%wrap%FBExp(compocn),      'Foxx_swnet_idr', &
+         FBinA=is_local%wrap%FBImp(compatm,compocn), fnameA='Faxa_swndr'    , wgtA=customwgt, &
+         FBinB=is_local%wrap%FBImp(compice,compocn), fnameB='Fioi_swpen_idr', wgtB=ifrac, rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+    call med_merge_field(is_local%wrap%FBExp(compocn),      'Foxx_swnet_idf', &
+         FBinA=is_local%wrap%FBImp(compatm,compocn), fnameA='Faxa_swndf'    , wgtA=customwgt, &
+         FBinB=is_local%wrap%FBImp(compice,compocn), fnameB='Fioi_swpen_idf', wgtB=ifrac, rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+
+    deallocate(ocnwgt1)
+    deallocate(icewgt1)
+    deallocate(wgtp01)
+    deallocate(wgtm01)
+    deallocate(customwgt)
+
+    if (dbug_flag > 20) then
+       call ESMF_LogWrite(trim(subname)//": done", ESMF_LOGMSG_INFO)
+    end if
+    call t_stopf('MED:'//subname)
+
+  end subroutine med_phases_prep_ocn_custom_nemsdata
 
 end module med_phases_prep_ocn_mod


### PR DESCRIPTION
### Description of changes
Clean up and changes to be consistent with upcoming NEMS changes 

### Specific notes
This PR also provides the ability to create compsets and tests for there is only 1 component (e.g. data) and the mediator.

Contributors other than yourself, if any: @DeniseWorthen 

CMEPS Issues Fixed (include github issue #):
None

Are changes expected to change answers (and if so in what way)?
No  - bit-for-bit

Any User Interface Changes (namelist or namelist defaults changes)?
No

Testing performed if application target is CESM:(either UFS-S2S or CESM testing is required):
- [ ] (optional) CIME_DRIVER=nuopc scripts_regression_tests.py
   - machines:
   - details (e.g. failed tests):
- [x] (required) CESM testlist_drv.xml
   - machines and compilers: cheyenne/intel
   - details (e.g. failed tests): ran testlist_drv.xml, compared to jun18 baselines and created jul05 baselines
- [ ] (optional) CESM prealpha test
   - machines and compilers
   - details (e.g. failed tests):

Testing performed if application target is UFS-S2S:
- [ ] (optional) UFS-S2S testing
   - description: this is not needed for this PR since it targets CESM
   - details (e.g. failed tests):

Hashes used for testing:
- [x] CESM:
  - repository to check out: https://github.com/ESCOMP/CESM.git
  - branch: nuopc_dev
  - hash:  30680b0
- [ ] UFS-S2S, then umbrella repostiory to check out and associated hash:
  - repository to check out:
  - branch:
  - hash:
