### PR TITLE
Minor fix for CIME interface

### DIFF
--- a/cime_config/buildnml
+++ b/cime_config/buildnml
@@ -572,7 +572,7 @@ def buildnml(case, caseroot, component):
         filename = os.path.join(fd_dir,"fd_cesm.yaml")
     elif coupling_mode == 'hafs':
         filename = os.path.join(fd_dir,"fd_hafs.yaml")
-    elif coupling_mode == 'nems':
+    elif 'nems' in coupling_mode:
         filename = os.path.join(fd_dir,"fd_nems.yaml")
     else:
         expect(False, "coupling mode currently only supports cesm, hafs and nems")

--- a/cime_config/config_component.xml
+++ b/cime_config/config_component.xml
@@ -28,7 +28,7 @@
 
   <entry id="COUPLING_MODE">
     <type>char</type>
-    <valid_values>cesm,nems_orig_active,nems_orig_data,nems_frac,hafs</valid_values>
+    <valid_values>cesm,nems_orig,nems_orig_data,nems_frac,hafs</valid_values>
     <default_value>cesm</default_value>
     <group>run_coupling</group>
     <file>env_run.xml</file>


### PR DESCRIPTION
This PR aims to fix the CIME interface for definition of coupling mode. "nems_orig_active" was not using in the CMEPS code. So, it is replaced with "nems_orig".

Contributors other than yourself, if any:

CMEPS Issues Fixed (include github issue #): CIME COUPLING_MODE option is fixed

Are changes expected to change answers?
 - [x] bit for bit
 - [ ] different at roundoff level
 - [ ] more substantial 

Any User Interface Changes (namelist or namelist defaults changes)?
 - [ ] Yes
 - [x] No

Testing performed if application target is CESM:(either UFS-S2S or CESM testing is required):
- [ ] (required) CIME_DRIVER=nuopc scripts_regression_tests.py
   - machines:
   - details (e.g. failed tests):
- [ ] (required) CESM testlist_drv.xml
   - machines and compilers:
   - details (e.g. failed tests):
- [ ] (optional) CESM prealpha test
   - machines and compilers
   - details (e.g. failed tests):

Testing performed if application target is UFS-S2S:
- [ ] (required) UFS-S2S testing
   - description:
   - details (e.g. failed tests):

Hashes used for testing:
- [ ] CESM:
  - repository to check out: https://github.com/ESCOMP/CESM.git
  - branch: nuopc_dev
  - hash:
- [ ] UFS-S2S, then umbrella repostiory to check out and associated hash:
  - repository to check out:
  - branch:
  - hash:
