### PR TITLE
changes for bugfix fractions

### DIFF
--- a/drivers/cime/esm_time_mod.F90
+++ b/drivers/cime/esm_time_mod.F90
@@ -185,7 +185,7 @@ contains
 
           if (mastertask) then
              write(logunit,*) ' NOTE: the current compset has no mediator - which provides the clock restart information'
-             write(logunit,*) '   In this case the restarts are handled solely by the component being used and' 
+             write(logunit,*) '   In this case the restarts are handled solely by the component being used and'
              write(logunit,*) '   and the driver clock will always be starting from the initial date on restart'
           end if
           curr_ymd = start_ymd
@@ -650,8 +650,7 @@ contains
    ! use netcdf here since it's serial
    status = nf90_open(restart_file, NF90_NOWRITE, ncid)
    if (status /= nf90_NoErr) then
-      print *,__FILE__,__LINE__,trim(restart_file)
-      call ESMF_LogWrite(trim(subname)//' ERROR: nf90_open', ESMF_LOGMSG_INFO)
+      call ESMF_LogWrite(trim(subname)//' ERROR: nf90_open: '//trim(restart_file), ESMF_LOGMSG_INFO)
       rc = ESMF_FAILURE
       return
    endif

--- a/mediator/esmFldsExchange_cesm_mod.F90
+++ b/mediator/esmFldsExchange_cesm_mod.F90
@@ -679,7 +679,7 @@ contains
           call addfld(fldListFr(compice)%flds, 'Faii_'//trim(suffix(n)))
           call addfld(fldListTo(compatm)%flds, 'Faxx_'//trim(suffix(n)))
        else
-          ! (non aqua-planet)
+          ! CESM (non aqua-planet)
           if ( fldchk(is_local%wrap%FBImp(complnd,complnd), 'Fall_'//trim(suffix(n)), rc=rc) .and. &
                fldchk(is_local%wrap%FBImp(compice,compice), 'Faii_'//trim(suffix(n)), rc=rc) .and. &
                fldchk(is_local%wrap%FBMed_aoflux_o        , 'Faox_'//trim(suffix(n)), rc=rc) .and. &
@@ -692,7 +692,6 @@ contains
                   mrg_from2=compice, mrg_fld2='Faii_'//trim(suffix(n)), mrg_type2='merge', mrg_fracname2='ifrac', &
                   mrg_from3=compmed, mrg_fld3='Faox_'//trim(suffix(n)), mrg_type3='merge', mrg_fracname3='ofrac')
 
-          ! (cam, aqua-planet)
           else if (fldchk(is_local%wrap%FBMed_aoflux_o, 'Faox_'//trim(suffix(n)), rc=rc) .and. &
                    fldchk(is_local%wrap%FBexp(compatm), 'Faxx_'//trim(suffix(n)), rc=rc)) then
              call addmap(fldListMed_aoflux%flds , 'Faox_'//trim(suffix(n)), compatm, mapconsf, 'ofrac', ocn2atm_fmap)
@@ -710,11 +709,10 @@ contains
        call addfld(fldListFr(complnd)%flds, 'Sl_t')
        call addfld(fldListFr(compice)%flds, 'Si_t')
        call addfld(fldListFr(compocn)%flds, 'So_t')
-
        call addfld(fldListTo(compatm)%flds, 'So_t')
        call addfld(fldListTo(compatm)%flds, 'Sx_t')
     else
-       ! merged ocn/ice/lnd temp and unmerged ocn temp
+       ! CESM - merged ocn/ice/lnd temp and unmerged ocn temp
        if (fldchk(is_local%wrap%FBexp(compatm)        , 'Sx_t', rc=rc) .and. &
            fldchk(is_local%wrap%FBImp(complnd,complnd), 'Sl_t', rc=rc) .and. &
            fldchk(is_local%wrap%FBImp(compice,compice), 'Si_t', rc=rc) .and. &
@@ -1798,11 +1796,11 @@ contains
        call addfld(fldListFr(complnd)%flds, 'Flgl_qice_elev') ! glacier ice flux               (1->glc_nec+1)
     else
        if ( fldchk(is_local%wrap%FBImp(complnd,complnd) , 'Flgl_qice_elev', rc=rc)) then
-          ! custom merging will be done here 
+          ! custom merging will be done here
           call addmap(FldListFr(complnd)%flds, 'Flgl_qice_elev', compglc, mapbilnr, 'lfrac', lnd2glc_smap)
        end if
        if ( fldchk(is_local%wrap%FBImp(complnd,complnd) , 'Sl_tsrf_elev'  , rc=rc)) then
-          ! custom merging will be done here 
+          ! custom merging will be done here
           call addmap(FldListFr(complnd)%flds, 'Sl_tsrf_elev', compglc, mapbilnr, 'lfrac', lnd2glc_smap)
        end if
        if ( fldchk(is_local%wrap%FBImp(complnd,complnd) , 'Sl_topo_elev'  , rc=rc)) then
@@ -1898,7 +1896,7 @@ contains
           call addfld(fldListFr(complnd)%flds, 'Fall_fco2_lnd')
           call addfld(fldListTo(compatm)%flds, 'Fall_fco2_lnd')
        else
-          call addmap(fldListFr(complnd)%flds, 'Fall_fco2_lnd', compatm, mapconsf, 'one', atm2lnd_smap)
+          call addmap(fldListFr(complnd)%flds, 'Fall_fco2_lnd', compatm, mapconsf, 'one', lnd2atm_fmap)
           call addmrg(fldListTo(compatm)%flds, 'Fall_fco2_lnd', &
                mrg_from1=complnd, mrg_fld1='Fall_fco2_lnd', mrg_type1='copy_with_weights', mrg_fracname1='lfrac')
        end if
@@ -1946,7 +1944,7 @@ contains
           call addfld(fldListFr(complnd)%flds, 'Fall_fco2_lnd')
           call addfld(fldListTo(compatm)%flds, 'Fall_fco2_lnd')
        else
-          call addmap(fldListFr(complnd)%flds, 'Fall_fco2_lnd', compatm, mapconsf, 'one', atm2lnd_smap)
+          call addmap(fldListFr(complnd)%flds, 'Fall_fco2_lnd', compatm, mapconsf, 'one', lnd2atm_fmap)
           call addmrg(fldListTo(compatm)%flds, 'Fall_fco2_lnd', &
                mrg_from1=complnd, mrg_fld1='Fall_fco2_lnd', mrg_type1='copy_with_weights', mrg_fracname1='lfrac')
        end if
@@ -1958,7 +1956,7 @@ contains
           call addfld(fldListFr(compocn)%flds, 'Faoo_fco2_ocn')
           call addfld(fldListTo(compatm)%flds, 'Faoo_fco2_ocn')
        else
-          call addmap(fldListFr(compocn)%flds, 'Faoo_fco2_ocn', compatm, mapconsf, 'one', atm2lnd_smap)
+          call addmap(fldListFr(compocn)%flds, 'Faoo_fco2_ocn', compatm, mapconsf, 'one', ocn2atm_fmap)
           ! custom merge in med_phases_prep_atm
        end if
     endif

--- a/mediator/esmFldsExchange_cesm_mod.F90
+++ b/mediator/esmFldsExchange_cesm_mod.F90
@@ -528,7 +528,7 @@ contains
        else
           if ( fldchk(is_local%wrap%FBExp(complnd)         , trim(fldname), rc=rc) .and. &
                fldchk(is_local%wrap%FBImp(compglc, compglc), trim(fldname), rc=rc)) then
-             call addmap(fldListFr(compglc)%flds, trim(fldname), complnd,  mapconsf, 'one', glc2lnd_smap)
+             call addmap(fldListFr(compglc)%flds, trim(fldname), complnd,  mapconsd, 'one', glc2lnd_smap)
              call addmrg(fldListTo(complnd)%flds, trim(fldname), &
                   mrg_from1=compglc, mrg_fld1=trim(fldname), mrg_type1='copy')
           end if

--- a/mediator/esmFldsExchange_cesm_mod.F90
+++ b/mediator/esmFldsExchange_cesm_mod.F90
@@ -1766,7 +1766,7 @@ contains
        else
           if ( fldchk(is_local%wrap%FBImp(complnd, complnd), trim(fldname), rc=rc) .and. &
                fldchk(is_local%wrap%FBExp(comprof)         , trim(fldname), rc=rc)) then
-             call addmap(fldListFr(complnd)%flds, trim(fldname), comprof, mapconsd, 'lfrac', lnd2rof_fmap)
+             call addmap(fldListFr(complnd)%flds, trim(fldname), comprof, mapconsf, 'lfrac', lnd2rof_fmap)
              call addmrg(fldListTo(comprof)%flds, trim(fldname), &
                   mrg_from1=complnd, mrg_fld1=trim(fldname), mrg_type1='copy_with_weights', mrg_fracname1='lfrac')
           end if

--- a/mediator/med_fraction_mod.F90
+++ b/mediator/med_fraction_mod.F90
@@ -248,7 +248,9 @@ contains
           ! Determine map type
           if (med_map_RH_is_created(is_local%wrap%RH(compatm,complnd,:),mapfcopy, rc=rc)) then
              maptype = mapfcopy
+             write(6,*)'DEBUG: maptype is mapfcopy'
           else
+             write(6,*)'DEBUG: maptype is mapconsd'
              maptype = mapconsd
              if (.not. med_map_RH_is_created(is_local%wrap%RH(complnd,compatm,:),maptype, rc=rc)) then
                 if (ESMF_FieldBundleIsCreated(is_local%wrap%FBImp(complnd,compatm))) then
@@ -418,13 +420,17 @@ contains
        if (is_local%wrap%comp_present(compatm)) then
           ! If atm -> lnd coupling is active - map 'lfrac' from FBFrac(compatm) to FBFrac(complnd)
           if (is_local%wrap%med_coupling_active(compatm,complnd)) then
-             maptype = mapconsd
-             if (.not. med_map_RH_is_created(is_local%wrap%RH(compatm,complnd,:),maptype, rc=rc)) then
-                call med_map_routehandles_init( compatm, complnd, &
-                     FBSrc=is_local%wrap%FBImp(compatm,compatm), &
-                     FBDst=is_local%wrap%FBImp(compatm,complnd), &
-                     mapindex=maptype, RouteHandle=is_local%wrap%RH, rc=rc)
-                if (ChkErr(rc,__LINE__,u_FILE_u)) return
+             if (med_map_RH_is_created(is_local%wrap%RH(compatm,complnd,:),mapfcopy, rc=rc)) then
+                maptype = mapfcopy
+             else
+                maptype = mapconsd
+                if (.not. med_map_RH_is_created(is_local%wrap%RH(compatm,complnd,:),maptype, rc=rc)) then
+                   call med_map_routehandles_init( compatm, complnd, &
+                        FBSrc=is_local%wrap%FBImp(compatm,compatm), &
+                        FBDst=is_local%wrap%FBImp(compatm,complnd), &
+                        mapindex=maptype, RouteHandle=is_local%wrap%RH, rc=rc)
+                   if (ChkErr(rc,__LINE__,u_FILE_u)) return
+                end if
              end if
              call FB_FieldRegrid(&
                   is_local%wrap%FBfrac(compatm), 'lfrac', &

--- a/mediator/med_fraction_mod.F90
+++ b/mediator/med_fraction_mod.F90
@@ -146,14 +146,15 @@ contains
     ! Initialize FBFrac(:) field bundles
 
     use ESMF                  , only : ESMF_GridComp, ESMF_Field
-    use ESMF                  , only : ESMF_LogWrite, ESMF_LOGMSG_INFO, ESMF_SUCCESS
+    use ESMF                  , only : ESMF_LogWrite, ESMF_LOGMSG_INFO, ESMF_LOGMSG_ERROR
+    use ESMF                  , only : ESMF_SUCCESS, ESMF_FAILURE
     use ESMF                  , only : ESMF_GridCompGet, ESMF_StateIsCreated
     use ESMF                  , only : ESMF_FieldBundle, ESMF_FieldBundleIsCreated, ESMF_FieldBundleDestroy
     use esmFlds               , only : coupling_mode
     use esmFlds               , only : compatm, compocn, compice, complnd
     use esmFlds               , only : comprof, compglc, compwav, compname
     use esmFlds               , only : mapfcopy, mapconsd, mapnstod_consd
-    use med_map_mod           , only : med_map_fractions_init, med_map_rh_is_created
+    use med_map_mod           , only : med_map_routehandles_init, med_map_rh_is_created
     use med_internalstate_mod , only : InternalState
     use perf_mod              , only : t_startf, t_stopf
 
@@ -251,10 +252,10 @@ contains
              maptype = mapconsd
              if (.not. med_map_RH_is_created(is_local%wrap%RH(complnd,compatm,:),maptype, rc=rc)) then
                 if (ESMF_FieldBundleIsCreated(is_local%wrap%FBImp(complnd,compatm))) then
-                   call med_map_Fractions_init( gcomp, complnd, compatm, &
+                   call med_map_routehandles_init( complnd, compatm, &
                         FBSrc=is_local%wrap%FBImp(complnd,complnd), &
                         FBDst=is_local%wrap%FBImp(complnd,compatm), &
-                        RouteHandle=is_local%wrap%RH(complnd,compatm,maptype), rc=rc)
+                        mapindex=maptype, RouteHandle=is_local%wrap%RH, rc=rc)
                    if (ChkErr(rc,__LINE__,u_FILE_u)) return
                 else
                    ! Note - need to do the following if
@@ -264,10 +265,10 @@ contains
                         FBgeom=is_local%wrap%FBImp(compatm,compatm), &
                         fieldNameList=(/'Fldtemp'/), name='FBtemp', rc=rc)
                    if (chkerr(rc,__LINE__,u_FILE_u)) return
-                   call med_map_Fractions_init( gcomp, complnd, compatm, &
+                   call med_map_routehandles_init( complnd, compatm, &
                         FBSrc=is_local%wrap%FBImp(complnd,complnd), &
                         FBDst=FBtemp, &
-                        RouteHandle=is_local%wrap%RH(complnd,compatm,maptype), rc=rc)
+                        mapindex=maptype, RouteHandle=is_local%wrap%RH, rc=rc)
                    if (ChkErr(rc,__LINE__,u_FILE_u)) return
                    call ESMF_FieldBundleDestroy(FBtemp, rc=rc)
                    if (ChkErr(rc,__LINE__,u_FILE_u)) return
@@ -310,10 +311,10 @@ contains
                 maptype = mapconsd
              end if
              if (.not. med_map_RH_is_created(is_local%wrap%RH(compice,compatm,:),maptype, rc=rc)) then
-                call med_map_Fractions_init( gcomp, compice, compatm, &
+                call med_map_routehandles_init( compice, compatm, &
                      FBSrc=is_local%wrap%FBImp(compice,compice), &
                      FBDst=is_local%wrap%FBImp(compice,compatm), &
-                     RouteHandle=is_local%wrap%RH(compice,compatm,maptype), rc=rc)
+                     mapindex=maptype, RouteHandle=is_local%wrap%RH, rc=rc)
                 if (ChkErr(rc,__LINE__,u_FILE_u)) return
              end if
           end if
@@ -352,10 +353,10 @@ contains
                 maptype = mapconsd
              end if
              if (.not. med_map_RH_is_created(is_local%wrap%RH(compocn,compatm,:),maptype, rc=rc)) then
-                call med_map_Fractions_init( gcomp, compocn, compatm, &
+                call med_map_routehandles_init( compocn, compatm, &
                      FBSrc=is_local%wrap%FBImp(compocn,compocn), &
                      FBDst=is_local%wrap%FBImp(compocn,compatm), &
-                     RouteHandle=is_local%wrap%RH(compocn,compatm,maptype), rc=rc)
+                     mapindex=maptype, RouteHandle=is_local%wrap%RH, rc=rc)
                 if (ChkErr(rc,__LINE__,u_FILE_u)) return
              end if
           end if
@@ -419,10 +420,10 @@ contains
           if (is_local%wrap%med_coupling_active(compatm,complnd)) then
              maptype = mapconsd
              if (.not. med_map_RH_is_created(is_local%wrap%RH(compatm,complnd,:),maptype, rc=rc)) then
-                call med_map_Fractions_init( gcomp, compatm, complnd, &
+                call med_map_routehandles_init( compatm, complnd, &
                      FBSrc=is_local%wrap%FBImp(compatm,compatm), &
                      FBDst=is_local%wrap%FBImp(compatm,complnd), &
-                     RouteHandle=is_local%wrap%RH(compatm,complnd,maptype), rc=rc)
+                     mapindex=maptype, RouteHandle=is_local%wrap%RH, rc=rc)
                 if (ChkErr(rc,__LINE__,u_FILE_u)) return
              end if
              call FB_FieldRegrid(&
@@ -465,10 +466,10 @@ contains
        if (is_local%wrap%comp_present(complnd)) then
           maptype = mapconsd
           if (.not. med_map_RH_is_created(is_local%wrap%RH(complnd,comprof,:),maptype, rc=rc)) then
-             call med_map_Fractions_init( gcomp, complnd, comprof, &
+             call med_map_routehandles_init( complnd, comprof, &
                   FBSrc=is_local%wrap%FBImp(complnd,complnd), &
                   FBDst=is_local%wrap%FBImp(complnd,comprof), &
-                  RouteHandle=is_local%wrap%RH(complnd,comprof,maptype), rc=rc)
+                  mapindex=maptype, RouteHandle=is_local%wrap%RH, rc=rc)
              if (ChkErr(rc,__LINE__,u_FILE_u)) return
           end if
           call FB_FieldRegrid(&
@@ -501,10 +502,10 @@ contains
        if ( is_local%wrap%comp_present(complnd) .and. is_local%wrap%med_coupling_active(complnd,compglc)) then
           maptype = mapconsd
           if (.not. med_map_RH_is_created(is_local%wrap%RH(complnd,compglc,:),maptype, rc=rc)) then
-             call med_map_Fractions_init( gcomp, complnd, compglc, &
+             call med_map_routehandles_init( complnd, compglc, &
                   FBSrc=is_local%wrap%FBImp(complnd,complnd), &
                   FBDst=is_local%wrap%FBImp(complnd,compglc), &
-                  RouteHandle=is_local%wrap%RH(complnd,compglc,maptype), rc=rc)
+                  mapindex=maptype, RouteHandle=is_local%wrap%RH, rc=rc)
              if (ChkErr(rc,__LINE__,u_FILE_u)) return
           end if
           call FB_FieldRegrid(&
@@ -539,10 +540,10 @@ contains
                   name='FBImp'//trim(compname(compice))//'_'//trim(compname(compocn)), rc=rc)
              if (ChkErr(rc,__LINE__,u_FILE_u)) return
           end if
-          call med_map_Fractions_init( gcomp, compice, compocn, &
+          call med_map_routehandles_init(compice, compocn, &
                FBSrc=is_local%wrap%FBImp(compice,compice), &
                FBDst=is_local%wrap%FBImp(compice,compocn), &
-               RouteHandle=is_local%wrap%RH(compice,compocn,mapfcopy), rc=rc)
+               mapindex=mapfcopy, RouteHandle=is_local%wrap%RH, rc=rc)
           if (ChkErr(rc,__LINE__,u_FILE_u)) return
        end if
        if (.not. med_map_RH_is_created(is_local%wrap%RH(compocn,compice,:),mapfcopy, rc=rc)) then
@@ -553,10 +554,10 @@ contains
                   name='FBImp'//trim(compname(compocn))//'_'//trim(compname(compice)), rc=rc)
              if (ChkErr(rc,__LINE__,u_FILE_u)) return
           end if
-          call med_map_Fractions_init( gcomp, compocn, compice, &
+          call med_map_routehandles_init( compocn, compice, &
                FBSrc=is_local%wrap%FBImp(compocn,compocn), &
                FBDst=is_local%wrap%FBImp(compocn,compice), &
-               RouteHandle=is_local%wrap%RH(compocn,compice,mapfcopy), rc=rc)
+               mapindex=mapfcopy, RouteHandle=is_local%wrap%RH, rc=rc)
           if (ChkErr(rc,__LINE__,u_FILE_u)) return
        end if
     end if
@@ -596,7 +597,7 @@ contains
     use esmFlds               , only : mapfcopy, mapconsd, mapnstod_consd
     use esmFlds               , only : coupling_mode
     use med_internalstate_mod , only : InternalState
-    use med_map_mod           , only : med_map_Fractions_init, med_map_RH_is_created
+    use med_map_mod           , only : med_map_RH_is_created
     use perf_mod              , only : t_startf, t_stopf
 
     ! input/output variables

--- a/mediator/med_fraction_mod.F90
+++ b/mediator/med_fraction_mod.F90
@@ -242,15 +242,13 @@ contains
        if (ChkErr(rc,__LINE__,u_FILE_u)) return
        lfrin(:) = Sl_lfrin(:)
 
-       ! Set 'lfrin for FBFrac(compatm) 
+       ! Set 'lfrin for FBFrac(compatm)
        ! The following is just an initial "guess", updated later
        if (is_local%wrap%comp_present(compatm) .and. (is_local%wrap%med_coupling_active(compatm,complnd))) then
           ! Determine map type
           if (med_map_RH_is_created(is_local%wrap%RH(compatm,complnd,:),mapfcopy, rc=rc)) then
              maptype = mapfcopy
-             write(6,*)'DEBUG: maptype is mapfcopy'
           else
-             write(6,*)'DEBUG: maptype is mapconsd'
              maptype = mapconsd
              if (.not. med_map_RH_is_created(is_local%wrap%RH(complnd,compatm,:),maptype, rc=rc)) then
                 if (ESMF_FieldBundleIsCreated(is_local%wrap%FBImp(complnd,compatm))) then
@@ -306,7 +304,7 @@ contains
           if (med_map_RH_is_created(is_local%wrap%RH(compice,compatm,:),mapfcopy, rc=rc)) then
              ! If ice and atm are on the same mesh - a redist route handle has already been created
              maptype = mapfcopy
-          else 
+          else
              if (trim(coupling_mode) == 'nems_orig' ) then
                 maptype = mapnstod_consd
              else
@@ -393,7 +391,7 @@ contains
                    lfrac(n) = 0.0_R8
                 end if
              end do
-          else 
+          else
              ! If the ocean or ice are absent, then simply set 'lfrac' to 'lfrin' for FBFrac(compatm)
              do n = 1,size(lfrac)
                 lfrac(n) = lfrin(n)
@@ -403,7 +401,7 @@ contains
                 end if
              end do
           end if
-       else  
+       else
           ! land is not present
           call FB_getFldPtr(is_local%wrap%FBfrac(compatm), 'lfrac', lfrac, rc=rc)
           lfrac(:) = 0.0_R8
@@ -439,7 +437,7 @@ contains
              if (ChkErr(rc,__LINE__,u_FILE_u)) return
           end if
        else
-          ! If the atm ->lnd coupling is not active - simply set 'lfrac' to 'lfrin' 
+          ! If the atm ->lnd coupling is not active - simply set 'lfrac' to 'lfrin'
           call FB_getFldPtr(is_local%wrap%FBfrac(complnd), 'lfrin', lfrin, rc=rc)
           if (ChkErr(rc,__LINE__,u_FILE_u)) return
           call FB_getFldPtr(is_local%wrap%FBfrac(complnd), 'lfrac', lfrac, rc=rc)

--- a/mediator/med_fraction_mod.F90
+++ b/mediator/med_fraction_mod.F90
@@ -114,6 +114,7 @@ module med_fraction_mod
   use med_methods_mod   , only : FB_fldChk      => med_methods_FB_fldChk
   use med_map_mod       , only : FB_FieldRegrid => med_map_FB_Field_Regrid
   use esmFlds           , only : ncomps
+  use med_internalstate_mod, only : mastertask, logunit
 
   implicit none
   private
@@ -418,17 +419,13 @@ contains
        if (is_local%wrap%comp_present(compatm)) then
           ! If atm -> lnd coupling is active - map 'lfrac' from FBFrac(compatm) to FBFrac(complnd)
           if (is_local%wrap%med_coupling_active(compatm,complnd)) then
-             if (med_map_RH_is_created(is_local%wrap%RH(compatm,complnd,:),mapfcopy, rc=rc)) then
-                maptype = mapfcopy
-             else
-                maptype = mapconsd
-                if (.not. med_map_RH_is_created(is_local%wrap%RH(compatm,complnd,:),maptype, rc=rc)) then
-                   call med_map_routehandles_init( compatm, complnd, &
-                        FBSrc=is_local%wrap%FBImp(compatm,compatm), &
-                        FBDst=is_local%wrap%FBImp(compatm,complnd), &
-                        mapindex=maptype, RouteHandle=is_local%wrap%RH, rc=rc)
-                   if (ChkErr(rc,__LINE__,u_FILE_u)) return
-                end if
+             maptype = mapconsd
+             if (.not. med_map_RH_is_created(is_local%wrap%RH(compatm,complnd,:),maptype, rc=rc)) then
+                call med_map_routehandles_init( compatm, complnd, &
+                     FBSrc=is_local%wrap%FBImp(compatm,compatm), &
+                     FBDst=is_local%wrap%FBImp(compatm,complnd), &
+                     mapindex=maptype, RouteHandle=is_local%wrap%RH, rc=rc)
+                if (ChkErr(rc,__LINE__,u_FILE_u)) return
              end if
              call FB_FieldRegrid(&
                   is_local%wrap%FBfrac(compatm), 'lfrac', &
@@ -703,24 +700,20 @@ contains
 
           ! Map 'ifrac' from FBfrac(compice) to FBfrac(compatm)
           if (is_local%wrap%med_coupling_active(compice,compatm)) then
-             if (is_local%wrap%med_coupling_active(compice,compatm)) then
-                call FB_FieldRegrid(&
-                     is_local%wrap%FBfrac(compice), 'ifrac', &
-                     is_local%wrap%FBfrac(compatm), 'ifrac', &
-                     is_local%wrap%RH(compice,compatm,:), maptype, rc=rc)
-                if (ChkErr(rc,__LINE__,u_FILE_u)) return
-             end if
+             call FB_FieldRegrid(&
+                  is_local%wrap%FBfrac(compice), 'ifrac', &
+                  is_local%wrap%FBfrac(compatm), 'ifrac', &
+                  is_local%wrap%RH(compice,compatm,:), maptype, rc=rc)
+             if (ChkErr(rc,__LINE__,u_FILE_u)) return
           end if
 
           ! Map 'ofrac' from FBfrac(compice) to FBfrac(compatm)
           if (is_local%wrap%med_coupling_active(compocn,compatm)) then
-             if (is_local%wrap%med_coupling_active(compocn,compatm)) then
-                call FB_FieldRegrid(&
-                     is_local%wrap%FBfrac(compocn), 'ofrac', &
-                     is_local%wrap%FBfrac(compatm), 'ofrac', &
-                     is_local%wrap%RH(compocn,compatm,:), maptype, rc=rc)
-                if (ChkErr(rc,__LINE__,u_FILE_u)) return
-             end if
+             call FB_FieldRegrid(&
+                  is_local%wrap%FBfrac(compocn), 'ofrac', &
+                  is_local%wrap%FBfrac(compatm), 'ofrac', &
+                  is_local%wrap%RH(compocn,compatm,:), maptype, rc=rc)
+             if (ChkErr(rc,__LINE__,u_FILE_u)) return
           end if
        end if ! end of if present compatm
 

--- a/mediator/med_map_mod.F90
+++ b/mediator/med_map_mod.F90
@@ -58,9 +58,8 @@ module med_map_mod
 
   ! private module variables
 
-  character(len=CS)       :: flds_scalar_name
+  character(len=CL)       :: flds_scalar_name
   integer                 :: srcTermProcessing_Value = 0 ! should this be a module variable?
-  logical                 :: mastertask
   character(*), parameter :: u_FILE_u  = &
        __FILE__
 
@@ -354,13 +353,13 @@ contains
 
   end subroutine med_map_RouteHandles_init_esmflds
 
-!================================================================================                   
+!================================================================================
   subroutine med_map_routehandles_init_field(n1, n2, FBsrc, FBdst, mapindex, RouteHandle, rc)
 
     !---------------------------------------------
     ! Initialize initialize additional route handles
     ! for mapping fractions
-    ! 
+    !
     !---------------------------------------------
 
     use ESMF , only : ESMF_LogWrite, ESMF_LOGMSG_INFO, ESMF_SUCCESS, ESMF_LogFlush
@@ -406,7 +405,7 @@ contains
        write(logunit,'(3A)') subname, trim(string),&
             ' RH regrid for '//trim(mapname)//' computed on the fly'
     end if
-    
+
     if (trim(coupling_mode) == 'cesm') then
        dstMaskValue = ispval_mask
        srcMaskValue = ispval_mask
@@ -529,7 +528,7 @@ contains
 
   end subroutine med_map_routehandles_init_field
 
-!================================================================================                   
+!================================================================================
   logical function med_map_RH_is_created_RH3d(RHs,n1,n2,mapindex,rc)
 
     use ESMF  , only : ESMF_RouteHandle
@@ -552,7 +551,7 @@ contains
 
   end function med_map_RH_is_created_RH3d
 
-!================================================================================                   
+!================================================================================
 
   logical function med_map_RH_is_created_RH1d(RHs,mapindex,rc)
 
@@ -737,7 +736,7 @@ contains
     type(ESMF_Field)      :: frac_field_dst
     real(R8), allocatable :: data_srctmp(:)
     real(R8), allocatable :: data_srctmp_1d(:)
-    real(R8), allocatable :: data_srctmp_2d(:,:)  
+    real(R8), allocatable :: data_srctmp_2d(:,:)
     real(R8), pointer     :: data_src_1d(:)
     real(R8), pointer     :: data_src_2d(:,:)
     real(R8), pointer     :: data_frac(:)
@@ -955,7 +954,7 @@ contains
              if (lrank == 1) then
                 data_src_1d(:) = data_srctmp_1d(:)
              elseif (lrank == 2) then
-                data_src_2d(:,:) = data_srctmp_2d(:,:) 
+                data_src_2d(:,:) = data_srctmp_2d(:,:)
              end if
 
              ! regrid fraction from source to dest

--- a/mediator/med_map_mod.F90
+++ b/mediator/med_map_mod.F90
@@ -6,7 +6,7 @@ module med_map_mod
   use ESMF                  , only : ESMF_LOGMSG_ERROR, ESMF_LOGMSG_INFO, ESMF_LogWrite
   use esmFlds               , only : mapbilnr, mapconsf, mapconsd, mappatch, mapfcopy
   use esmFlds               , only : mapunset, mapnames, nmappers
-  use esmFlds               , only : mapnstod, mapnstod_consd, mapnstod_consf
+  use esmFlds               , only : mapnstod, mapnstod_consd, mapnstod_consf, mapnstod_consd
   use esmFlds               , only : ncomps, compatm, compice, compocn, compname
   use esmFlds               , only : mapfcopy, mapconsd, mapconsf, mapnstod
   use esmFlds               , only : mapuv_with_cart3d
@@ -35,13 +35,17 @@ module med_map_mod
   private
 
   ! public routines
-  public :: med_map_RouteHandles_init
+  public :: med_map_routehandles_init
   public :: med_map_RH_is_created
-  public :: med_map_fractions_init
   public :: med_map_MapNorm_init
   public :: med_map_FB_Regrid_Norm
   public :: med_map_FB_Field_Regrid
   public :: med_map_Field_Regrid
+
+  interface med_map_routehandles_init
+     module procedure med_map_routehandles_init_esmflds
+     module procedure med_map_routehandles_init_field
+  end interface
 
   interface med_map_FB_Regrid_norm
      module procedure med_map_FB_Regrid_Norm_All
@@ -64,7 +68,7 @@ module med_map_mod
 contains
 !================================================================================
 
-  subroutine med_map_RouteHandles_init(gcomp, llogunit, rc)
+  subroutine med_map_RouteHandles_init_esmflds(gcomp, llogunit, rc)
 
     !---------------------------------------------
     ! Initialize route handles in the mediator
@@ -319,7 +323,8 @@ contains
                             if (chkerr(rc,__LINE__,u_FILE_u)) return
                          end if
                          !if (associated(unmappedDstList)) then
-                         !   write(logMsg,*) trim(subname),trim(string),'     number of unmapped dest points = ', size(unmappedDstList)
+                         !   write(logMsg,*) trim(subname),trim(string),&
+                         !      number of unmapped dest points = ', size(unmappedDstList)
                          !   call ESMF_LogWrite(trim(logMsg), ESMF_LOGMSG_INFO)
                          !end if
                       end if
@@ -347,10 +352,184 @@ contains
     endif
     call t_stopf('MED:'//subname)
 
-  end subroutine med_map_RouteHandles_init
+  end subroutine med_map_RouteHandles_init_esmflds
 
 !================================================================================                   
+  subroutine med_map_routehandles_init_field(n1, n2, FBsrc, FBdst, mapindex, RouteHandle, rc)
 
+    !---------------------------------------------
+    ! Initialize initialize additional route handles
+    ! for mapping fractions
+    ! 
+    !---------------------------------------------
+
+    use ESMF , only : ESMF_LogWrite, ESMF_LOGMSG_INFO, ESMF_SUCCESS, ESMF_LogFlush
+    use ESMF , only : ESMF_GridComp, ESMF_FieldBundle, ESMF_RouteHandle, ESMF_Field
+    use ESMF , only : ESMF_GridComp, ESMF_VM, ESMF_Field, ESMF_PoleMethod_Flag, ESMF_POLEMETHOD_ALLAVG
+    use ESMF , only : ESMF_GridCompGet, ESMF_VMGet, ESMF_FieldSMMStore
+    use ESMF , only : ESMF_FieldRedistStore, ESMF_FieldRegridStore, ESMF_REGRIDMETHOD_BILINEAR
+    use ESMF , only : ESMF_REGRIDMETHOD_CONSERVE, ESMF_NORMTYPE_DSTAREA, ESMF_NORMTYPE_FRACAREA
+    use ESMF , only : ESMF_UNMAPPEDACTION_IGNORE, ESMF_REGRIDMETHOD_NEAREST_STOD
+    use ESMF , only : ESMF_REGRIDMETHOD_PATCH
+
+    ! input/output variables
+    integer                , intent(in)    :: n1
+    integer                , intent(in)    :: n2
+    type(ESMF_FieldBundle) , intent(in)    :: FBsrc
+    type(ESMF_FieldBundle) , intent(in)    :: fBdst
+    integer                , intent(in)    :: mapindex
+    type(ESMF_RouteHandle) , intent(inout) :: RouteHandle(:,:,:)
+    integer                , intent(out)   :: rc
+
+    ! local variables
+    type(ESMF_Field)   :: fldsrc
+    type(ESMF_Field)   :: flddst
+    character(len=CS)  :: string
+    character(len=CS)  :: mapname
+    integer            :: SrcMaskValue
+    integer            :: DstMaskValue
+    type(ESMF_PoleMethod_Flag), parameter :: polemethod=ESMF_POLEMETHOD_ALLAVG
+    character(len=*), parameter :: subname=' (module_med_map: med_map_routehandles_init) '
+    !---------------------------------------------
+
+    call t_startf('MED:'//subname)
+    rc = ESMF_SUCCESS
+    if (dbug_flag > 1) then
+       call ESMF_LogWrite("Initializing RHs not yet created and needed", &
+            ESMF_LOGMSG_INFO)
+       call ESMF_LogFlush()
+    endif
+
+    mapname = trim(mapnames(mapindex))
+    if (mastertask) then
+       string = trim(compname(n1))//"2"//trim(compname(n2))//'_weights'
+       write(logunit,'(3A)') subname, trim(string),&
+            ' RH regrid for '//trim(mapname)//' computed on the fly'
+    end if
+    
+    if (trim(coupling_mode) == 'cesm') then
+       dstMaskValue = ispval_mask
+       srcMaskValue = ispval_mask
+       if (n1 == compocn .or. n1 == compice) srcMaskValue = 0
+       if (n2 == compocn .or. n2 == compice) dstMaskValue = 0
+    else if (coupling_mode(1:4) == 'nems') then
+       if (n1 == compatm .and. (n2 == compocn .or. n2 == compice)) then
+          srcMaskValue = 1
+          dstMaskValue = 0
+       else if (n2 == compatm .and. (n1 == compocn .or. n1 == compice)) then
+          srcMaskValue = 0
+          dstMaskValue = 1
+       else if ((n1 == compocn .and. n2 == compice) .or. (n1 == compice .and. n2 == compocn)) then
+          srcMaskValue = 0
+          dstMaskValue = 0
+       else
+          ! TODO: what should the condition be here?
+          dstMaskValue = ispval_mask
+          srcMaskValue = ispval_mask
+       end if
+    else if (trim(coupling_mode) == 'hafs') then
+       dstMaskValue = ispval_mask
+       srcMaskValue = ispval_mask
+       if (n1 == compocn .or. n1 == compice) srcMaskValue = 0
+       if (n2 == compocn .or. n2 == compice) dstMaskValue = 0
+    end if
+
+    call FB_getFieldN(FBsrc, 1, fldsrc, rc)
+    if (chkerr(rc,__LINE__,u_FILE_u)) return
+    call FB_getFieldN(FBDst, 1, flddst, rc)
+    if (chkerr(rc,__LINE__,u_FILE_u)) return
+
+    ! Create route handle on the fly
+    if (mastertask) write(logunit,'(3A)') subname,trim(string),&
+         ' RH regrid for '//trim(mapname)//' computed on the fly'
+    call ESMF_LogWrite(subname // trim(string) //&
+         ' RH regrid for '//trim(mapname)//' computed on the fly', ESMF_LOGMSG_INFO)
+
+    if (mapindex == mapfcopy) then
+       if (mastertask) then
+          write(logunit,'(3A)') subname,trim(string),' RH redist '
+       end if
+       call ESMF_LogWrite(subname // trim(string) // ' RH redist ', ESMF_LOGMSG_INFO)
+       call ESMF_FieldRedistStore(fldsrc, flddst, &
+            routehandle=routehandle(n1,n2,mapindex), &
+            ignoreUnmatchedIndices = .true., rc=rc)
+       if (chkerr(rc,__LINE__,u_FILE_u)) return
+    else if (mapindex == mapbilnr) then
+       call ESMF_FieldRegridStore(fldsrc, flddst, &
+            routehandle=routehandle(n1,n2,mapindex), &
+            srcMaskValues=(/srcMaskValue/), &
+            dstMaskValues=(/dstMaskValue/), &
+            regridmethod=ESMF_REGRIDMETHOD_BILINEAR, &
+            polemethod=polemethod, &
+            srcTermProcessing=srcTermProcessing_Value, &
+            ignoreDegenerate=.true., &
+            unmappedaction=ESMF_UNMAPPEDACTION_IGNORE, rc=rc)
+       if (chkerr(rc,__LINE__,u_FILE_u)) return
+    else if (mapindex == mapconsf .or. mapindex == mapnstod_consf) then
+       call ESMF_FieldRegridStore(fldsrc, flddst, &
+            routehandle=routehandle(n1,n2,mapconsf), &
+            srcMaskValues=(/srcMaskValue/), &
+            dstMaskValues=(/dstMaskValue/), &
+            regridmethod=ESMF_REGRIDMETHOD_CONSERVE, &
+            normType=ESMF_NORMTYPE_FRACAREA, &
+            srcTermProcessing=srcTermProcessing_Value, &
+            ignoreDegenerate=.true., &
+            unmappedaction=ESMF_UNMAPPEDACTION_IGNORE, &
+            rc=rc)
+       if (chkerr(rc,__LINE__,u_FILE_u)) return
+    else if (mapindex == mapconsd .or. mapindex == mapnstod_consd) then
+       call ESMF_FieldRegridStore(fldsrc, flddst, &
+            routehandle=routehandle(n1,n2,mapconsd), &
+            srcMaskValues=(/srcMaskValue/), &
+            dstMaskValues=(/dstMaskValue/), &
+            regridmethod=ESMF_REGRIDMETHOD_CONSERVE, &
+            normType=ESMF_NORMTYPE_DSTAREA, &
+            srcTermProcessing=srcTermProcessing_Value, &
+            ignoreDegenerate=.true., &
+            unmappedaction=ESMF_UNMAPPEDACTION_IGNORE, &
+            rc=rc)
+       if (chkerr(rc,__LINE__,u_FILE_u)) return
+    else if (mapindex == mappatch) then
+       call ESMF_FieldRegridStore(fldsrc, flddst, &
+            routehandle=routehandle(n1,n2,mapindex), &
+            srcMaskValues=(/srcMaskValue/), &
+            dstMaskValues=(/dstMaskValue/), &
+            regridmethod=ESMF_REGRIDMETHOD_PATCH, &
+            polemethod=polemethod, &
+            srcTermProcessing=srcTermProcessing_Value, &
+            ignoreDegenerate=.true., &
+            unmappedaction=ESMF_UNMAPPEDACTION_IGNORE, rc=rc)
+       if (chkerr(rc,__LINE__,u_FILE_u)) return
+    else
+       call ESMF_LogWrite(trim(subname)//' mapindex '//trim(mapnames(mapindex))//&
+            ' not supported for fraction mapping', &
+            ESMF_LOGMSG_ERROR, line=__LINE__, file=u_FILE_u)
+       rc = ESMF_FAILURE
+       return
+    end if
+
+    ! consd_nstod method requires a second routehandle
+    if (mapindex == mapnstod .or. mapindex == mapnstod_consd .or. mapindex == mapnstod_consf) then
+       call ESMF_FieldRegridStore(fldsrc, flddst, &
+            routehandle=routehandle(n1,n2,mapnstod), &
+            srcMaskValues=(/srcMaskValue/), &
+            dstMaskValues=(/dstMaskValue/), &
+            regridmethod=ESMF_REGRIDMETHOD_NEAREST_STOD, &
+            srcTermProcessing=srcTermProcessing_Value, &
+            ignoreDegenerate=.true., &
+            unmappedaction=ESMF_UNMAPPEDACTION_IGNORE, &
+            rc=rc)
+       if (chkerr(rc,__LINE__,u_FILE_u)) return
+    end if
+
+    if (dbug_flag > 1) then
+      call ESMF_LogWrite(trim(subname)//": done", ESMF_LOGMSG_INFO)
+    endif
+    call t_stopf('MED:'//subname)
+
+  end subroutine med_map_routehandles_init_field
+
+!================================================================================                   
   logical function med_map_RH_is_created_RH3d(RHs,n1,n2,mapindex,rc)
 
     use ESMF  , only : ESMF_RouteHandle
@@ -413,78 +592,6 @@ contains
     if (chkerr(rc,__LINE__,u_FILE_u)) return
 
   end function med_map_RH_is_created_RH1d
-
-!================================================================================                   
-
-  subroutine med_map_fractions_init(gcomp, n1, n2, FBSrc, FBDst, RouteHandle, rc)
-
-    !---------------------------------------------
-    ! Initialize initialize additional route handles
-    ! for mapping fractions
-    !---------------------------------------------
-
-    use ESMF , only : ESMF_LogWrite, ESMF_LOGMSG_INFO, ESMF_SUCCESS, ESMF_LogFlush
-    use ESMF , only : ESMF_GridComp, ESMF_FieldBundle, ESMF_RouteHandle, ESMF_Field
-    use ESMF , only : ESMF_FieldRegridStore
-    use ESMF , only : ESMF_UNMAPPEDACTION_IGNORE
-    use ESMF , only : ESMF_REGRIDMETHOD_CONSERVE, ESMF_NORMTYPE_DSTAREA
-
-    ! input/output variables
-    type(ESMF_GridComp)                    :: gcomp
-    integer                , intent(in)    :: n1
-    integer                , intent(in)    :: n2
-    type(ESMF_FieldBundle) , intent(in)    :: FBSrc
-    type(ESMF_FieldBundle) , intent(in)    :: FBDst
-    type(ESMF_RouteHandle) , intent(inout) :: RouteHandle
-    integer                , intent(out)   :: rc
-
-    ! local variables
-    type(ESMF_Field)   :: fldsrc
-    type(ESMF_Field)   :: flddst
-    character(len=CS)  :: string
-    integer            :: SrcMaskValue
-    integer            :: DstMaskValue
-    character(len=*), parameter :: subname=' (med_map_fractions_init: ) '
-    !---------------------------------------------
-
-    call t_startf('MED:'//subname)
-    rc = ESMF_SUCCESS
-    if (dbug_flag > 1) then
-       call ESMF_LogWrite("Initializing RHs not yet created and needed for mapping fractions", &
-            ESMF_LOGMSG_INFO)
-       call ESMF_LogFlush()
-    endif
-
-    if (mastertask) then
-       string = trim(compname(n1))//"2"//trim(compname(n2))//'_weights'
-       write(logunit,'(a)') trim(subname) // trim(string) //' RH consd computed on the fly for fractions'
-    end if
-
-    dstMaskValue = ispval_mask
-    srcMaskValue = ispval_mask
-    if (n1 == compocn .or. n1 == compice) srcMaskValue = 0
-    if (n2 == compocn .or. n2 == compice) dstMaskValue = 0
-
-    call FB_getFieldN(FBsrc, 1, fldsrc, rc)
-    if (chkerr(rc,__LINE__,u_FILE_u)) return
-    call FB_getFieldN(FBDst, 1, flddst, rc)
-    if (chkerr(rc,__LINE__,u_FILE_u)) return
-    call ESMF_FieldRegridStore(fldsrc, flddst, &
-         routehandle=RouteHandle, &
-         srcMaskValues=(/srcMaskValue/), &
-         dstMaskValues=(/dstMaskValue/), &
-         regridmethod=ESMF_REGRIDMETHOD_CONSERVE, &
-         normType=ESMF_NORMTYPE_DSTAREA, &
-         srcTermProcessing=srcTermProcessing_Value, &
-         ignoreDegenerate=.true., &
-         unmappedaction=ESMF_UNMAPPEDACTION_IGNORE, rc=rc)
-
-    if (dbug_flag > 1) then
-      call ESMF_LogWrite(trim(subname)//": done", ESMF_LOGMSG_INFO)
-    endif
-    call t_stopf('MED:'//subname)
-
-  end subroutine med_map_fractions_init
 
 !================================================================================
 

--- a/mediator/med_phases_prep_lnd_mod.F90
+++ b/mediator/med_phases_prep_lnd_mod.F90
@@ -15,7 +15,7 @@ module med_phases_prep_lnd_mod
   use ESMF                  , only : ESMF_Mesh, ESMF_MeshLoc, ESMF_MESHLOC_ELEMENT
   use ESMF                  , only : ESMF_Field, ESMF_FieldGet, ESMF_FieldCreate
   use ESMF                  , only : ESMF_TYPEKIND_R8
-  use esmFlds               , only : complnd, compatm, compglc, ncomps, compname, mapconsf
+  use esmFlds               , only : complnd, compatm, compglc, ncomps, compname, mapconsd
   use esmFlds               , only : fldListFr, fldListTo
   use esmFlds               , only : med_fldlist_type
   use med_methods_mod       , only : FB_getFieldN    => med_methods_FB_getFieldN
@@ -30,7 +30,7 @@ module med_phases_prep_lnd_mod
   use med_constants_mod     , only : dbug_flag       => med_constants_dbug_flag
   use med_internalstate_mod , only : InternalState, logunit
   use med_map_mod           , only : med_map_FB_Regrid_Norm, med_map_RH_is_created
-  use med_map_mod           , only : med_map_Fractions_Init
+  use med_map_mod           , only : med_map_routehandles_init
   use med_merge_mod         , only : med_merge_auto
   use glc_elevclass_mod     , only : glc_get_num_elevation_classes
   use glc_elevclass_mod     , only : glc_mean_elevation_virtual
@@ -309,10 +309,10 @@ contains
     ! Create route handle if it has not been created
     ! -------------------------------
 
-    if (.not. med_map_RH_is_created(is_local%wrap%RH(compglc,complnd,:),mapconsf,rc=rc)) then
-       call med_map_Fractions_init( gcomp, compglc, complnd, &
+    if (.not. med_map_RH_is_created(is_local%wrap%RH(compglc,complnd,:), mapconsd,rc=rc)) then
+       call med_map_routehandles_init( compglc, complnd, &
             FBSrc=FBglc_ec, FBDst=FBlnd_ec, &
-            RouteHandle=is_local%wrap%RH(compglc,complnd,mapconsf), rc=rc)
+            mapindex=mapconsd, RouteHandle=is_local%wrap%RH, rc=rc)
        if (ChkErr(rc,__LINE__,u_FILE_u)) return
     end if
 
@@ -419,7 +419,7 @@ contains
     end if
     allocate(fldlist%flds(1))
     fldlist%flds(1)%shortname = 'field_ec'
-    fldlist%flds(1)%mapindex(complnd) = mapconsf
+    fldlist%flds(1)%mapindex(complnd) = mapconsd
     fldlist%flds(1)%mapnorm(complnd) = trim(Sg_icemask)
     call med_map_FB_Regrid_Norm( &
          fldsSrc=fldList%flds, &
@@ -465,7 +465,7 @@ contains
     end if
     allocate(fldlist%flds(1))
     fldlist%flds(1)%shortname = 'field_ec'
-    fldlist%flds(1)%mapindex(complnd) = mapconsf
+    fldlist%flds(1)%mapindex(complnd) = mapconsd
     fldlist%flds(1)%mapnorm(complnd) = 'none'
     call med_map_FB_Regrid_Norm( &
          fldsSrc=fldlist%flds, &
@@ -488,7 +488,7 @@ contains
     end if
     allocate(fldlist%flds(1))
     fldlist%flds(1)%shortname = trim(Sg_frac_x_icemask)
-    fldlist%flds(1)%mapindex(complnd) = mapconsf
+    fldlist%flds(1)%mapindex(complnd) = mapconsd
     fldlist%flds(1)%mapnorm(complnd) = 'none'
     call med_map_FB_Regrid_Norm( &
          fldsSrc=fldList%flds, &

--- a/mediator/med_phases_prep_rof_mod.F90
+++ b/mediator/med_phases_prep_rof_mod.F90
@@ -2,7 +2,7 @@ module med_phases_prep_rof_mod
 
   !-----------------------------------------------------------------------------
   ! Create rof export fields
-  ! - accumulate import lnd fields on the land grid that are sent to rof 
+  ! - accumulate import lnd fields on the land grid that are sent to rof
   !   this will be done in med_phases_prep_rof_accum
   ! - time avergage accumulated import lnd fields when necessary
   !   map the time averaged accumulated lnd fields to the rof grid
@@ -40,7 +40,7 @@ module med_phases_prep_rof_mod
   public  :: med_phases_prep_rof_accum
   public  :: med_phases_prep_rof_avg
 
-  private :: med_phases_prep_rof_irrig       
+  private :: med_phases_prep_rof_irrig
 
   type(ESMF_FieldBundle)      :: FBlndVolr          ! needed for lnd2rof irrigation
   type(ESMF_FieldBundle)      :: FBrofVolr          ! needed for lnd2rof irrigation
@@ -64,7 +64,7 @@ contains
 
     !------------------------------------
     ! Carry out fast accumulation for the river (rof) component
-    ! Accumulation and averaging is done on the land input on the land grid for the fields that will 
+    ! Accumulation and averaging is done on the land input on the land grid for the fields that will
     ! will be sent to the river component
     ! Mapping from the land to the rof grid is then done with the time averaged fields
     !------------------------------------
@@ -108,7 +108,7 @@ contains
        ncnt = 0
        call ESMF_LogWrite(trim(subname)//": FBImp(complnd,complnd) is not created", &
             ESMF_LOGMSG_INFO)
-    else 
+    else
        ! The scalar field has been removed from all mediator field bundles - so check if the fieldCount is
        ! 0 and not 1 here
        call ESMF_FieldBundleGet(is_local%wrap%FBImp(complnd,complnd), fieldCount=ncnt, rc=rc)
@@ -118,7 +118,7 @@ contains
     end if
 
     !---------------------------------------
-    ! Accumulate lnd input on lnd grid 
+    ! Accumulate lnd input on lnd grid
     !---------------------------------------
 
     ! Note that all import fields from the land are accumulated - but
@@ -155,7 +155,7 @@ contains
     !------------------------------------
 
     use NUOPC , only : NUOPC_IsConnected
-    use ESMF  , only : ESMF_GridComp, ESMF_GridCompGet 
+    use ESMF  , only : ESMF_GridComp, ESMF_GridCompGet
     use ESMF  , only : ESMF_LogWrite, ESMF_LOGMSG_INFO, ESMF_SUCCESS
     use ESMF  , only : ESMF_FieldBundleGet
 
@@ -330,7 +330,7 @@ contains
     use ESMF , only : ESMF_GridComp, ESMF_Field
     use ESMF , only : ESMF_FieldBundle, ESMF_FieldBundleGet, ESMF_FieldBundleIsCreated
     use ESMF , only : ESMF_SUCCESS, ESMF_FAILURE
-    use ESMF , only : ESMF_LOGMSG_INFO, ESMF_LogWrite
+    use ESMF , only : ESMF_LOGMSG_INFO, ESMF_LogWrite, ESMF_LOGMSG_ERROR
 
     ! input/output variables
     type(ESMF_GridComp)  :: gcomp
@@ -366,14 +366,14 @@ contains
     if (chkerr(rc,__LINE__,u_FILE_u)) return
 
     if (.not. med_map_RH_is_created(is_local%wrap%RH(complnd,comprof,:),mapconsf, rc=rc)) then
-       call ESMF_LogWrite(trim(subname)//": ERROR conservativing route handle not created for lnd->rof mapping", &
-            ESMF_LOGMSG_INFO)
+       call ESMF_LogWrite(trim(subname)//": ERROR conservative route handle not created for lnd->rof mapping", &
+            ESMF_LOGMSG_ERROR)
        rc = ESMF_FAILURE
        return
     end if
     if (.not. med_map_RH_is_created(is_local%wrap%RH(comprof,complnd,:),mapconsf, rc=rc)) then
-       call ESMF_LogWrite(trim(subname)//": ERROR conservativing route handle not created for rof->lnd mapping", &
-            ESMF_LOGMSG_INFO)
+       call ESMF_LogWrite(trim(subname)//": ERROR conservative route handle not created for rof->lnd mapping", &
+            ESMF_LOGMSG_ERROR)
        rc = ESMF_FAILURE
        return
     end if


### PR DESCRIPTION
### Description of changes
Bug fixes and cleanup of map and fractions mod 
### Specific notes
This fixes a substantial bug in that the ice/ocean mask was mapped from the ocean mesh to the atm mesh using conservative mapping with a normtype of DSTFRAC rather than a normtype of DSTAREA. The result was that the land fraction on the atm mesh was always just 0/1 and the ocean fraction in non-polar regions was 0/1 on the coasts. This PR fixes this. 

Also, as part of this PR a clean up of `med_map_mod.F90 `was done for generating the maps that were needed by `med_fraction_mod.F90.`

Contributors other than yourself, if any: mvertens

CMEPS Issues Fixed (include github issue #): #106 

Are changes expected to change answers?
 - [X] bit for bit - for most compsets other than B and X compsets 
 - [X] different at roundoff level - for some compsets other than B and X compsets
 - [X] more substantial - for B and X compsets

Any User Interface Changes (namelist or namelist defaults changes)?
 - [ ] Yes
 - [X] No

Testing performed if application target is CESM:(either UFS-S2S or CESM testing is required):
- [X] (required) CIME_DRIVER=nuopc scripts_regression_tests.py
   - machines: cheyenne
   - details (e.g. failed tests):
- [X] (required) CESM testlist_drv.xml
   - machines and compilers: cheyenne, intel
   - details (e.g. failed tests): generate oct05, compare aug19
- [ ] (optional) CESM prealpha test
   - machines and compilers
   - details (e.g. failed tests):

Testing performed if application target is UFS-S2S:
- [x] (required) UFS-S2S testing
   - description: testing was done by @DeniseWorthen to demonstrate that this bug fix was also needed in the UFS.
   - details: The tests compared results of running simulations with and without the bug fix for c384mx025

Hashes used for testing:
- [X] CESM:
  - repository to check out: https://github.com/ESCOMP/CESM.git
  - branch: nuopc_dev
  - hash: c9936d718d
     (cime is on master, hash 516f7c2755)

- [X] UFS-S2S, then umbrella repostiory to check out and associated hash:
  - repository to check out:
  - branch:
  - hash:
