### PR TITLE
Diags optional in configfile

### DIFF
--- a/mediator/Makefile
+++ b/mediator/Makefile
@@ -58,5 +58,5 @@ med_phases_prep_wav_mod.o : med_kind_mod.o med_utils_mod.o med_internalstate_mod
 med_phases_profile_mod.o : med_kind_mod.o med_utils_mod.o med_constants_mod.o med_internalstate_mod.o med_time_mod.o
 med_phases_restart_mod.o : med_kind_mod.o med_utils_mod.o med_constants_mod.o med_internalstate_mod.o esmFlds.o med_io_mod.o
 med_time_mod.o : med_kind_mod.o med_utils_mod.o med_constants_mod.o
-med_utils_mod.o : med_kind_mod.o med_utils_mod.F90
-med_diag_mod.o : med_kind_mod.o med_time_mod.o med_utils_mod.o med_methods_mod.o med_internalstate_mod.o med_diag_mod.F90
+med_utils_mod.o : med_kind_mod.o
+med_diag_mod.o : med_kind_mod.o med_time_mod.o med_utils_mod.o med_methods_mod.o med_internalstate_mod.o

--- a/mediator/med_diag_mod.F90
+++ b/mediator/med_diag_mod.F90
@@ -15,7 +15,7 @@ module med_diag_mod
   !    salt  flux    ~ (kg/s)/m^2
   !----------------------------------------------------------------------------
 
-  use NUOPC                 , only : NUOPC_CompAttributeGet, NUOPC_CompAttributeSet
+  use NUOPC                 , only : NUOPC_CompAttributeGet, NUOPC_CompAttributeSet, NUOPC_CompAttributeAdd
   use NUOPC_Mediator        , only : NUOPC_MediatorGet
   use ESMF                  , only : ESMF_LogWrite, ESMF_LOGMSG_INFO, ESMF_SUCCESS
   use ESMF                  , only : ESMF_FAILURE,  ESMF_LOGMSG_ERROR

--- a/mediator/med_diag_mod.F90
+++ b/mediator/med_diag_mod.F90
@@ -15,7 +15,7 @@ module med_diag_mod
   !    salt  flux    ~ (kg/s)/m^2
   !----------------------------------------------------------------------------
 
-  use NUOPC                 , only : NUOPC_CompAttributeGet
+  use NUOPC                 , only : NUOPC_CompAttributeGet, NUOPC_CompAttributeSet
   use NUOPC_Mediator        , only : NUOPC_MediatorGet
   use ESMF                  , only : ESMF_LogWrite, ESMF_LOGMSG_INFO, ESMF_SUCCESS
   use ESMF                  , only : ESMF_FAILURE,  ESMF_LOGMSG_ERROR
@@ -247,6 +247,7 @@ contains
     integer           :: stop_n   ! Number until restart interval
     integer           :: stop_ymd ! Restart date (YYYYMMDD)
     type(ESMF_ALARM)  :: stop_alarm
+    character(CS)     :: cvalue
     ! ------------------------------------------------------------------
 
     rc = ESMF_SUCCESS
@@ -351,12 +352,18 @@ contains
     ! Get config variables
     !-------------------------------------------------------------------------------
 
-    budget_print_inst = get_diag_attribute(gcomp, 'budget_inst')
-    budget_print_daily = get_diag_attribute(gcomp, 'budget_daily')
-    budget_print_month = get_diag_attribute(gcomp, 'budget_month')
-    budget_print_ann  = get_diag_attribute(gcomp, 'budget_ann')
-    budget_print_ltann  = get_diag_attribute(gcomp, 'budget_ltann')
-    budget_print_ltend  = get_diag_attribute(gcomp, 'budget_ltend')
+    budget_print_inst = get_diag_attribute(gcomp, 'budget_inst', rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+    budget_print_daily = get_diag_attribute(gcomp, 'budget_daily', rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+    budget_print_month = get_diag_attribute(gcomp, 'budget_month', rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+    budget_print_ann  = get_diag_attribute(gcomp, 'budget_ann', rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+    budget_print_ltann  = get_diag_attribute(gcomp, 'budget_ltann', rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+    budget_print_ltend  = get_diag_attribute(gcomp, 'budget_ltend', rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
 
     ! Set stop alarm (needed for budgets)
     call NUOPC_CompAttributeGet(gcomp, name="stop_option", value=stop_option, rc=rc)
@@ -379,6 +386,7 @@ contains
       integer, intent(out) :: rc
 
       character(CS)     :: cvalue
+      logical :: isPresent
 
       rc = ESMF_SUCCESS
       get_diag_attribute = 0
@@ -391,7 +399,6 @@ contains
       else
          call NUOPC_CompAttributeSet(gcomp, name=name, value='0', rc=rc)
       endif
-
     end function get_diag_attribute
 
    end subroutine med_diag_init

--- a/mediator/med_diag_mod.F90
+++ b/mediator/med_diag_mod.F90
@@ -238,7 +238,7 @@ contains
     integer             , intent(out)   :: rc
 
     ! local variables
-    character(CS)     :: cvalue
+
     integer           :: c_size   ! number of component send/recvs
     integer           :: f_size   ! number of fields
     integer           :: p_size   ! number of period types
@@ -351,29 +351,12 @@ contains
     ! Get config variables
     !-------------------------------------------------------------------------------
 
-    call NUOPC_CompAttributeGet(gcomp, name='budget_inst', value=cvalue, rc=rc)
-    if (chkerr(rc,__LINE__,u_FILE_u)) return
-    read(cvalue,*) budget_print_inst
-
-    call NUOPC_CompAttributeGet(gcomp, name='budget_daily', value=cvalue, rc=rc)
-    if (chkerr(rc,__LINE__,u_FILE_u)) return
-    read(cvalue,*) budget_print_daily
-
-    call NUOPC_CompAttributeGet(gcomp, name='budget_month', value=cvalue, rc=rc)
-    if (chkerr(rc,__LINE__,u_FILE_u)) return
-    read(cvalue,*) budget_print_month
-
-    call NUOPC_CompAttributeGet(gcomp, name='budget_ann', value=cvalue, rc=rc)
-    if (chkerr(rc,__LINE__,u_FILE_u)) return
-    read(cvalue,*) budget_print_ann
-
-    call NUOPC_CompAttributeGet(gcomp, name='budget_ltann', value=cvalue, rc=rc)
-    if (chkerr(rc,__LINE__,u_FILE_u)) return
-    read(cvalue,*) budget_print_ltann
-
-    call NUOPC_CompAttributeGet(gcomp, name='budget_ltend', value=cvalue, rc=rc)
-    if (chkerr(rc,__LINE__,u_FILE_u)) return
-    read(cvalue,*) budget_print_ltend
+    budget_print_inst = get_diag_attribute(gcomp, 'budget_inst')
+    budget_print_daily = get_diag_attribute(gcomp, 'budget_daily')
+    budget_print_month = get_diag_attribute(gcomp, 'budget_month')
+    budget_print_ann  = get_diag_attribute(gcomp, 'budget_ann')
+    budget_print_ltann  = get_diag_attribute(gcomp, 'budget_ltann')
+    budget_print_ltend  = get_diag_attribute(gcomp, 'budget_ltend')
 
     ! Set stop alarm (needed for budgets)
     call NUOPC_CompAttributeGet(gcomp, name="stop_option", value=stop_option, rc=rc)
@@ -389,6 +372,27 @@ contains
     call alarmInit(mediatorclock, stop_alarm, stop_option, opt_n=stop_n, opt_ymd=stop_ymd, &
          alarmname='alarm_stop', rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
+  contains
+    integer function get_diag_attribute(gcomp, name, rc)
+      type(ESMF_GridComp) , intent(inout) :: gcomp
+      character(len=*), intent(in) :: name
+      integer, intent(out) :: rc
+
+      character(CS)     :: cvalue
+
+      rc = ESMF_SUCCESS
+      get_diag_attribute = 0
+      call NUOPC_CompAttributeGet(gcomp, name=name, isPresent=isPresent, rc=rc)
+      if (chkerr(rc,__LINE__,u_FILE_u)) return
+      if (isPresent) then
+         call NUOPC_CompAttributeGet(gcomp, name=name, value=cvalue, rc=rc)
+         if (chkerr(rc,__LINE__,u_FILE_u)) return
+         read(cvalue,*) get_diag_attribute
+      else
+         call NUOPC_CompAttributeSet(gcomp, name=name, value='0', rc=rc)
+      endif
+
+    end function get_diag_attribute
 
    end subroutine med_diag_init
 

--- a/mediator/med_diag_mod.F90
+++ b/mediator/med_diag_mod.F90
@@ -396,8 +396,10 @@ contains
          call NUOPC_CompAttributeGet(gcomp, name=name, value=cvalue, rc=rc)
          if (chkerr(rc,__LINE__,u_FILE_u)) return
          read(cvalue,*) get_diag_attribute
-      else
-         call NUOPC_CompAttributeSet(gcomp, name=name, value='0', rc=rc)
+       ! the following gave an error in esmf 8.1.0b: Operation not yet supported
+!      else
+!         call NUOPC_CompAttributeSet(gcomp, name=name, value='0', rc=rc)
+!         if (ChkErr(rc,__LINE__,u_FILE_u)) return
       endif
     end function get_diag_attribute
 

--- a/mediator/med_diag_mod.F90
+++ b/mediator/med_diag_mod.F90
@@ -397,10 +397,11 @@ contains
          call NUOPC_CompAttributeGet(gcomp, name=name, value=cvalue, rc=rc)
          if (chkerr(rc,__LINE__,u_FILE_u)) return
          read(cvalue,*) get_diag_attribute
-       ! the following gave an error in esmf 8.1.0b: Operation not yet supported
-!      else
-!         call NUOPC_CompAttributeSet(gcomp, name=name, value='0', rc=rc)
-!         if (ChkErr(rc,__LINE__,u_FILE_u)) return
+      else
+         call NUOPC_CompAttributeAdd(gcomp, (/name/), rc=rc)
+         if (ChkErr(rc,__LINE__,u_FILE_u)) return
+         call NUOPC_CompAttributeSet(gcomp, name=name, value='0', rc=rc)
+         if (ChkErr(rc,__LINE__,u_FILE_u)) return
       endif
     end function get_diag_attribute
 

--- a/mediator/med_diag_mod.F90
+++ b/mediator/med_diag_mod.F90
@@ -364,21 +364,22 @@ contains
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
     budget_print_ltend  = get_diag_attribute(gcomp, 'budget_ltend', rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
-
-    ! Set stop alarm (needed for budgets)
-    call NUOPC_CompAttributeGet(gcomp, name="stop_option", value=stop_option, rc=rc)
-    if (ChkErr(rc,__LINE__,u_FILE_u)) return
-    call NUOPC_CompAttributeGet(gcomp, name="stop_n", value=cvalue, rc=rc)
-    if (ChkErr(rc,__LINE__,u_FILE_u)) return
-    read(cvalue,*) stop_n
-    call NUOPC_CompAttributeGet(gcomp, name="stop_ymd", value=cvalue, rc=rc)
-    if (ChkErr(rc,__LINE__,u_FILE_u)) return
-    read(cvalue,*) stop_ymd
-    call NUOPC_MediatorGet(gcomp, mediatorClock=mediatorClock, rc=rc)
-    if (ChkErr(rc,__LINE__,u_FILE_u)) return
-    call alarmInit(mediatorclock, stop_alarm, stop_option, opt_n=stop_n, opt_ymd=stop_ymd, &
-         alarmname='alarm_stop', rc=rc)
-    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+    if (budget_print_inst + budget_print_daily + budget_print_month + budget_print_ann + budget_print_ltann + budget_print_ltend > 0) then
+       ! Set stop alarm (needed for budgets)
+       call NUOPC_CompAttributeGet(gcomp, name="stop_option", value=stop_option, rc=rc)
+       if (ChkErr(rc,__LINE__,u_FILE_u)) return
+       call NUOPC_CompAttributeGet(gcomp, name="stop_n", value=cvalue, rc=rc)
+       if (ChkErr(rc,__LINE__,u_FILE_u)) return
+       read(cvalue,*) stop_n
+       call NUOPC_CompAttributeGet(gcomp, name="stop_ymd", value=cvalue, rc=rc)
+       if (ChkErr(rc,__LINE__,u_FILE_u)) return
+       read(cvalue,*) stop_ymd
+       call NUOPC_MediatorGet(gcomp, mediatorClock=mediatorClock, rc=rc)
+       if (ChkErr(rc,__LINE__,u_FILE_u)) return
+       call alarmInit(mediatorclock, stop_alarm, stop_option, opt_n=stop_n, opt_ymd=stop_ymd, &
+            alarmname='alarm_stop', rc=rc)
+       if (ChkErr(rc,__LINE__,u_FILE_u)) return
+    endif
   contains
     integer function get_diag_attribute(gcomp, name, rc)
       type(ESMF_GridComp) , intent(inout) :: gcomp


### PR DESCRIPTION
### Description of changes
If budget variables are not in config file set them to 0 and continue

### Specific notes

Contributors other than yourself, if any:

CMEPS Issues Fixed (include github issue #): #116 

Are changes expected to change answers?
 - [X] bit for bit
 - [ ] different at roundoff level
 - [ ] more substantial 

Any User Interface Changes (namelist or namelist defaults changes)?
 - [ ] Yes
 - [X] No

Testing performed if application target is CESM:(either UFS-S2S or CESM testing is required):
- [X] (required) CIME_DRIVER=nuopc scripts_regression_tests.py
   - machines: cheyenne
   - details (e.g. failed tests):  
- [X] (required) CESM testlist_drv.xml
   - machines and compilers: cheyenne intel 
   - details (e.g. failed tests): All pass  oct22 baselines generated
- [ ] (optional) CESM prealpha test
   - machines and compilers
   - details (e.g. failed tests):

Testing performed if application target is UFS-S2S:
- [ ] (required) UFS-S2S testing
   - description:
   - details (e.g. failed tests):

Hashes used for testing:
- [X] CESM:
  - repository to check out: https://github.com/ESCOMP/CESM.git
  - branch: nuopc_dev
  - hash:9118a884f
- [ ] UFS-S2S, then umbrella repostiory to check out and associated hash:
  - repository to check out:
  - branch:
  - hash:
