### PR TITLE
remove albedo from the X compset

### DIFF
--- a/cime_config/config_component.xml
+++ b/cime_config/config_component.xml
@@ -987,9 +987,9 @@
     <file>env_run.xml</file>
     <desc>
       Determines what ESMF log files (if any) are generated when
-          USE_ESMF_LIB is TRUE.
+	  USE_ESMF_LIB is TRUE.
       ESMF_LOGKIND_SINGLE: Use a single log file, combining messages from
-          all of the PETs. Not supported on some platforms.
+	  all of the PETs. Not supported on some platforms.
       ESMF_LOGKIND_MULTI: Use multiple log files -- one per PET.
       ESMF_LOGKIND_NONE: Do not issue messages to a log file.
       By default, no ESMF log files are generated.
@@ -2018,7 +2018,7 @@
     <desc>pio rearranger communication max pending requests (io2comp) :
        -2 implies that CIME internally calculates the value ( = 64),
        -1 implies no bound on max pending requests
-        0 implies that MPI_ALLTOALL will be used
+	0 implies that MPI_ALLTOALL will be used
     </desc>
   </entry>
 
@@ -2600,7 +2600,7 @@
  </entry>
 
   <!-- ===================================================================== -->
-  <!-- write ESMF PET log files even without an error -->
+  <!-- Include the AOFLUX calculation for this compset -->
   <!-- ===================================================================== -->
 
  <entry id="ADD_AOFLUX_TO_RUNSEQ">

--- a/cime_config/runseq/runseq_general.py
+++ b/cime_config/runseq/runseq_general.py
@@ -18,9 +18,10 @@ def gen_runseq(case, coupling_times):
     rundir         = case.get_value("RUNDIR")
     caseroot       = case.get_value("CASEROOT")
     cpl_seq_option = case.get_value('CPL_SEQ_OPTION')
-    cpl_add_aoflux = case.get_value('ADD_AOFLUX_TO_RUNSEQ')
     coupling_mode  = case.get_value('COUPLING_MODE')
     diag_mode      = case.get_value('BUDGETS')
+    xcompset = case.get_value("COMP_ATM") == 'xatm'
+    cpl_add_aoflux = not xcompset and case.get_value('ADD_AOFLUX_TO_RUNSEQ')
 
     # It is assumed that if a component will be run it will send information to the mediator
     # so the flags run_xxx and xxx_to_med are redundant
@@ -33,6 +34,7 @@ def gen_runseq(case, coupling_times):
     run_ocn, med_to_ocn, ocn_cpl_time = driver_config['ocn']
     run_rof, med_to_rof, rof_cpl_time = driver_config['rof']
     run_wav, med_to_wav, wav_cpl_time = driver_config['wav']
+
 
     # Note: assume that atm_cpl_dt, lnd_cpl_dt, ice_cpl_dt and wav_cpl_dt are the same
 
@@ -89,7 +91,7 @@ def gen_runseq(case, coupling_times):
                 runseq.add_action("MED med_phases_aofluxes_run"        , run_ocn and run_atm and (med_to_ocn or med_to_atm))
             runseq.add_action("MED med_phases_prep_ocn_merge"      , med_to_ocn)
             runseq.add_action("MED med_phases_prep_ocn_accum_fast" , med_to_ocn)
-            runseq.add_action("MED med_phases_ocnalb_run"          , run_ocn and run_atm and (med_to_ocn or med_to_atm))
+            runseq.add_action("MED med_phases_ocnalb_run"          , (run_ocn and run_atm and (med_to_ocn or med_to_atm)) and not xcompset)
         runseq.add_action("MED med_phases_prep_lnd"                , med_to_lnd)
         runseq.add_action("MED -> LND :remapMethod=redist"         , med_to_lnd)
         runseq.add_action("MED med_phases_prep_ice"                , med_to_ice)
@@ -116,7 +118,7 @@ def gen_runseq(case, coupling_times):
                 runseq.add_action("MED med_phases_aofluxes_run"        , run_ocn and run_atm)
             runseq.add_action("MED med_phases_prep_ocn_merge"      , med_to_ocn)
             runseq.add_action("MED med_phases_prep_ocn_accum_fast" , med_to_ocn)
-            runseq.add_action("MED med_phases_ocnalb_run"          , run_ocn and run_atm)
+            runseq.add_action("MED med_phases_ocnalb_run"          , (run_ocn and run_atm) and not xcompset)
         runseq.add_action("MED med_phases_diag_ocn"                , run_ocn and diag_mode and not ocn_outer_loop)
         runseq.add_action("LND -> MED :remapMethod=redist"         , run_lnd)
         runseq.add_action("ICE -> MED :remapMethod=redist"         , run_ice)


### PR DESCRIPTION
### Description of changes
Fixes test ERI_Ln9_Vnuopc.f09_g16.X by removing aofluxes and ocnalb calculations

### Specific notes

Contributors other than yourself, if any:

CMEPS Issues Fixed (include github issue #):

Are changes expected to change answers?
 - [X] bit for bit
 - [ ] different at roundoff level
 - [ ] more substantial 

Any User Interface Changes (namelist or namelist defaults changes)?
 - [ ] Yes
 - [X] No

Testing performed if application target is CESM:(either UFS-S2S or CESM testing is required):
- [X] (required) CIME_DRIVER=nuopc scripts_regression_tests.py
   - machines: cheyenne intel 
   - details (e.g. failed tests):  All PASS
- [X] (required) CESM testlist_drv.xml
   - machines and compilers: cheyenne intel
   - details (e.g. failed tests):generate oct27  SMS_Vnuopc.f19_g17.X.cheyenne_intel  failed BASELINE (expected)
- [ ] (optional) CESM prealpha test
   - machines and compilers
   - details (e.g. failed tests):

Testing performed if application target is UFS-S2S:
- [ ] (required) UFS-S2S testing
   - description:
   - details (e.g. failed tests):

Hashes used for testing:
- [ ] CESM:
  - repository to check out: https://github.com/ESCOMP/CESM.git
  - branch: nuopc_dev
  - hash:
- [ ] UFS-S2S, then umbrella repostiory to check out and associated hash:
  - repository to check out:
  - branch:
  - hash:
