### PR TITLE
original code failed with rc2 error using gnu compiler

### DIFF
--- a/mediator/med_map_mod.F90
+++ b/mediator/med_map_mod.F90
@@ -576,21 +576,27 @@ contains
     if      (mapindex == mapnstod_consd .and. &
              ESMF_RouteHandleIsCreated(RHs(mapnstod), rc=rc1) .and. &
              ESMF_RouteHandleIsCreated(RHs(mapconsd), rc=rc2)) then
+       rc = rc1
+       if (chkerr(rc,__LINE__,u_FILE_u)) return
+       rc = rc2
+       if (chkerr(rc,__LINE__,u_FILE_u)) return
        mapexists = .true.
     else if (mapindex == mapnstod_consf .and. &
              ESMF_RouteHandleIsCreated(RHs(mapnstod), rc=rc1) .and. &
              ESMF_RouteHandleIsCreated(RHs(mapconsf), rc=rc2)) then
+       rc = rc1
+       if (chkerr(rc,__LINE__,u_FILE_u)) return
+       rc = rc2
+       if (chkerr(rc,__LINE__,u_FILE_u)) return
        mapexists = .true.
     else if (ESMF_RouteHandleIsCreated(RHs(mapindex), rc=rc1)) then
+       rc = rc1
+       if (chkerr(rc,__LINE__,u_FILE_u)) return
        mapexists = .true.
     end if
 
     med_map_RH_is_created_RH1d = mapexists
 
-    rc = rc1
-    if (chkerr(rc,__LINE__,u_FILE_u)) return
-    rc = rc2
-    if (chkerr(rc,__LINE__,u_FILE_u)) return
 
   end function med_map_RH_is_created_RH1d
 


### PR DESCRIPTION
### Description of changes

### Specific notes
Appears to be an optimization issue with the gnu/10.1.0 compiler

Contributors other than yourself, if any:

CMEPS Issues Fixed (include github issue #):

Are changes expected to change answers?
 - [X] bit for bit
 - [ ] different at roundoff level
 - [ ] more substantial 

Any User Interface Changes (namelist or namelist defaults changes)?
 - [ ] Yes
 - [X] No

Testing performed if application target is CESM:(either UFS-S2S or CESM testing is required):
- [X] (required) CIME_DRIVER=nuopc scripts_regression_tests.py 
   - machines: cheyenne gnu mpilib mpt
   - details (e.g. failed tests): 
- [ ] (required) CESM testlist_drv.xml
   - machines and compilers:
   - details (e.g. failed tests):
- [ ] (optional) CESM prealpha test
   - machines and compilers
   - details (e.g. failed tests):

Testing performed if application target is UFS-S2S:
- [ ] (required) UFS-S2S testing
   - description:
   - details (e.g. failed tests):

Hashes used for testing:
- [ ] CESM:
  - repository to check out: https://github.com/ESCOMP/CESM.git
  - branch: nuopc_dev
  - hash:
- [ ] UFS-S2S, then umbrella repostiory to check out and associated hash:
  - repository to check out:
  - branch:
  - hash:
