### PR TITLE
fix med_phases_prep_lnd problem introduced in PR#129

### DIFF
--- a/mediator/med_phases_prep_lnd_mod.F90
+++ b/mediator/med_phases_prep_lnd_mod.F90
@@ -149,31 +149,16 @@ contains
           call t_stopf('MED:'//trim(subname)//' glc2lnd init')
 
           ! The will following will map and merge Sg_frac and Sg_topo (and in the future Flgg_hflx)
-          if (cism_evolve) then
-             call t_startf('MED:'//trim(subname)//' glc2lnd ')
-             call med_map_field_packed( &
-                  FBSrc=is_local%wrap%FBImp(compglc,compglc), &
-                  FBDst=is_local%wrap%FBImp(compglc,complnd), &
-                  FBFracSrc=is_local%wrap%FBFrac(compglc), &
-                  field_normOne=is_local%wrap%field_normOne(compglc,complnd,:), &
-                  packed_data=is_local%wrap%packed_data(compglc,complnd,:), &
-                  routehandles=is_local%wrap%RH(compglc,complnd,:), rc=rc)
-             if (ChkErr(rc,__LINE__,u_FILE_u)) return
-             call map_glc2lnd(gcomp, rc=rc)
-             if (ChkErr(rc,__LINE__,u_FILE_u)) return
-             call t_stopf('MED:'//trim(subname)//' glc2lnd')
-          else if (first_call) then
-             call med_map_field_packed( &
-                  FBSrc=is_local%wrap%FBImp(compglc,compglc), &
-                  FBDst=is_local%wrap%FBImp(compglc,complnd), &
-                  FBFracSrc=is_local%wrap%FBFrac(compglc), &
-                  field_normOne=is_local%wrap%field_normOne(compglc,complnd,:), &
-                  packed_data=is_local%wrap%packed_data(compglc,complnd,:), &
-                  routehandles=is_local%wrap%RH(compglc,complnd,:), rc=rc)
-             if (ChkErr(rc,__LINE__,u_FILE_u)) return
-             call map_glc2lnd(gcomp, rc=rc)
-             if (ChkErr(rc,__LINE__,u_FILE_u)) return
-          end if
+          call t_startf('MED:'//trim(subname)//' glc2lnd ')
+          call med_map_field_packed( &
+               FBSrc=is_local%wrap%FBImp(compglc,compglc), &
+               FBDst=is_local%wrap%FBImp(compglc,complnd), &
+               FBFracSrc=is_local%wrap%FBFrac(compglc), &
+               field_normOne=is_local%wrap%field_normOne(compglc,complnd,:), &
+               packed_data=is_local%wrap%packed_data(compglc,complnd,:), &
+               routehandles=is_local%wrap%RH(compglc,complnd,:), rc=rc)
+          if (ChkErr(rc,__LINE__,u_FILE_u)) return
+          call t_stopf('MED:'//trim(subname)//' glc2lnd')
        end if
 
        !---------------------------------------
@@ -191,6 +176,21 @@ contains
             fldListTo(complnd), rc=rc)
        if (ChkErr(rc,__LINE__,u_FILE_u)) return
        call t_stopf('MED:'//trim(subname)//' merge')
+
+       !---------------------------------------
+       ! glc-lnd custom mapping and merging
+       !---------------------------------------
+
+       ! The following is only done if glc->lnd coupling is active
+       if (is_local%wrap%comp_present(compglc) .and. (is_local%wrap%med_coupling_active(compglc,complnd))) then
+          if (first_call) then
+             call map_glc2lnd_init(gcomp, rc=rc)
+             if (ChkErr(rc,__LINE__,u_FILE_u)) return
+          end if
+          ! The will following will map and merge Sg_frac and Sg_topo (and in the future Flgg_hflx)
+          call map_glc2lnd(gcomp, rc=rc)
+          if (ChkErr(rc,__LINE__,u_FILE_u)) return
+       end if
 
        !---------------------------------------
        ! update scalar data


### PR DESCRIPTION
### Description of changes
This undoes the med_phases_prep_lnd changes introduced in PR#129

### Specific notes

Contributors other than yourself, if any:

CMEPS Issues Fixed (include github issue #):

Are changes expected to change answers?
 - [x] bit for bit - with nov03 baseline - but not with nov06 baseline
 - [ ] different at roundoff level
 - [ ] more substantial 

Any User Interface Changes (namelist or namelist defaults changes)?
 - [ ] Yes
 - [x] No

Testing performed if application target is CESM:(either UFS-S2S or CESM testing is required):
- [ ] (required) CIME_DRIVER=nuopc scripts_regression_tests.py
   - machines:
   - details (e.g. failed tests):
- [x] (required) CESM testlist_drv.xml
   - machines and compilers: cheyenne, intel
   - details (e.g. failed tests):
         all of the tests are now bfb with the nov03 baseline but not with the nov06 baseline
         new nov15 baseline created
- [ ] (optional) CESM prealpha test
   - machines and compilers
   - details (e.g. failed tests):

Testing performed if application target is UFS-S2S:
- [ ] (required) UFS-S2S testing
   - description:
   - details (e.g. failed tests):

Hashes used for testing:
- [x] CESM:
  - repository to check out: https://github.com/ESCOMP/CESM.git
  - branch: nuopc_dev
  - hash: f9f8324
- [ ] UFS-S2S, then umbrella repostiory to check out and associated hash:
  - repository to check out:
  - branch:
  - hash:
