### PR TITLE
Call GLC at the end of the day rather than the start

### DIFF
--- a/cime_config/runseq/runseq_general.py
+++ b/cime_config/runseq/runseq_general.py
@@ -61,11 +61,6 @@ def gen_runseq(case, coupling_times):
         runseq.enter_time_loop(glc_cpl_time, newtime=run_glc, active=med_to_glc)
         #------------------
 
-        runseq.add_action("MED med_phases_prep_glc_avg"    , med_to_glc)
-        runseq.add_action("MED -> GLC :remapMethod=redist" , med_to_glc)
-        runseq.add_action("GLC"                            , run_glc and med_to_glc)
-        runseq.add_action("GLC -> MED :remapMethod=redist" , run_glc)
-
         #------------------
         runseq.enter_time_loop(rof_cpl_time, newtime=rof_outer_loop)
         #------------------
@@ -165,5 +160,10 @@ def gen_runseq(case, coupling_times):
         #------------------
         runseq.leave_time_loop(rof_outer_loop)
         #------------------
+
+        runseq.add_action("MED med_phases_prep_glc_avg"    , med_to_glc)
+        runseq.add_action("MED -> GLC :remapMethod=redist" , med_to_glc)
+        runseq.add_action("GLC"                            , run_glc and med_to_glc)
+        runseq.add_action("GLC -> MED :remapMethod=redist" , run_glc)
 
     shutil.copy(os.path.join(caseroot, "CaseDocs", "nuopc.runseq"), rundir)


### PR DESCRIPTION
### Description of changes

Previously, CISM was being called at the start of December 31, with data
from December 31 of the previous year through December 30 of the current
year. The desired behavior is for CISM to be called at the end of
December 31, with data from January 1 of the current year through
December 31 of the current year. This commit fixes that behavior.

### Specific notes

Contributors other than yourself, if any: @mvertens 

CMEPS Issues Fixed (include github issue #): none

Are changes expected to change answers?
 - [ ] bit for bit
 - [ ] different at roundoff level
 - [x] more substantial 

Any User Interface Changes (namelist or namelist defaults changes)?
 - [ ] Yes
 - [x] No

Testing performed if application target is CESM:(either UFS-S2S or CESM testing is required):
- [ ] (required) CIME_DRIVER=nuopc scripts_regression_tests.py
   - machines:
   - details (e.g. failed tests):
- [ ] (required) CESM testlist_drv.xml
   - machines and compilers:
   - details (e.g. failed tests):
- [ ] (optional) CESM prealpha test
   - machines and compilers
   - details (e.g. failed tests):

Testing performed if application target is UFS-S2S:
- [ ] (required) UFS-S2S testing
   - description:
   - details (e.g. failed tests):

Hashes used for testing:
- [ ] CESM:
  - repository to check out: https://github.com/ESCOMP/CESM.git
  - branch: nuopc_dev
  - hash:
- [ ] UFS-S2S, then umbrella repostiory to check out and associated hash:
  - repository to check out:
  - branch:
  - hash:
