### PR TITLE
fix avgdt variable and add nthreads value to gcomp

### DIFF
--- a/.github/workflows/extbuild.yml
+++ b/.github/workflows/extbuild.yml
@@ -35,7 +35,9 @@ jobs:
           path: ~/ESMF
           key: ${{ runner.os }}-${{ env.ESMF_VERSION }}-ESMF
       - id: load-env
-        run: sudo apt-get install gfortran wget openmpi-bin netcdf-bin libopenmpi-dev libnetcdf-dev
+        run: |
+          sudo apt-get update
+          sudo apt-get install gfortran wget openmpi-bin netcdf-bin libopenmpi-dev libnetcdf-dev
       - id: build-ESMF
         if: steps.cache-esmf.outputs.cache-hit != 'true'
         run: |

--- a/cime_config/buildexe
+++ b/cime_config/buildexe
@@ -39,6 +39,7 @@ def _main_func():
         ocn_model = case.get_value("COMP_OCN")
         atm_model = case.get_value("COMP_ATM")
         gmake_args = get_standard_makefile_args(case)
+        esmf_aware_threading = case.get_value("ESMF_AWARE_THREADING")
 
     # Determine valid components
     valid_comps = []
@@ -73,6 +74,8 @@ def _main_func():
             gmake_args += " {}_PRESENT=FALSE".format(comp)
     if skip_mediator:
         gmake_args += " MED_PRESENT=FALSE"
+    if esmf_aware_threading:
+        gmake_args += " USER_CPPDEFS=-DESMF_AWARE_THREADING"
 
     gmake_args += " IAC_PRESENT=FALSE"
     expect((num_esp is None) or (int(num_esp) == 1), "ESP component restricted to one instance")
@@ -92,6 +95,11 @@ def _main_func():
     # build model executable
     makefile = os.path.join(casetools, "Makefile")
     exename = os.path.join(exeroot, cime_model + ".exe")
+
+    # always rebuild file esm.F90 this is because cpp macros in that file may have changed
+    esm = os.path.join(bld_root,"esm.o")
+    if os.path.isfile(esm):
+        os.remove(esm)
 
     # always relink
     if os.path.isfile(exename):

--- a/cime_config/config_component.xml
+++ b/cime_config/config_component.xml
@@ -798,6 +798,15 @@
     <desc>TRUE implies that at least one of the components is built threaded (DO NOT EDIT)</desc>
   </entry>
 
+  <entry id="ESMF_AWARE_THREADING">
+    <type>logical</type>
+    <valid_values>TRUE,FALSE</valid_values>
+    <default_value>FALSE</default_value>
+    <group>mach_pes</group>
+    <file>env_mach_pes.xml</file>
+    <desc>TRUE indicates that the ESMF Aware threading method is used</desc>
+  </entry>
+
   <entry id="USE_PETSC">
     <type>logical</type>
     <valid_values>TRUE,FALSE</valid_values>

--- a/cime_config/config_component_cesm.xml
+++ b/cime_config/config_component_cesm.xml
@@ -35,16 +35,6 @@
     <desc>run DOI</desc>
   </entry>
 
-  <entry id="DRV_THREADING">
-    <type>logical</type>
-    <valid_values>TRUE,FALSE</valid_values>
-    <default_value>FALSE</default_value>
-    <group>run_flags</group>
-    <file>env_run.xml</file>
-    <desc>Turns on component varying thread control in the driver.
-    Used to set the driver namelist variable "drv_threading".</desc>
-  </entry>
-
   <entry id="SAVE_TIMING">
     <type>logical</type>
     <valid_values>TRUE,FALSE</valid_values>
@@ -541,7 +531,7 @@
     <values match="last">
       <value compset="_CLM.+CISM\d">TRUE</value>
       <!-- Turn on two-way coupling for TG compsets - even though there are no
-	   feedbacks for a TG compset, this will give us additional diagnostics -->
+           feedbacks for a TG compset, this will give us additional diagnostics -->
       <value compset="_DLND.+CISM\d">TRUE</value>
     </values>
     <group>run_glc</group>

--- a/cime_config/config_component_ufs.xml
+++ b/cime_config/config_component_ufs.xml
@@ -35,16 +35,6 @@
     <desc>run DOI</desc>
   </entry>
 
-  <entry id="DRV_THREADING">
-    <type>logical</type>
-    <valid_values>TRUE,FALSE</valid_values>
-    <default_value>FALSE</default_value>
-    <group>run_flags</group>
-    <file>env_run.xml</file>
-    <desc>Turns on component varying thread control in the driver.
-    Used to set the driver namelist variable "drv_threading".</desc>
-  </entry>
-
   <entry id="SAVE_TIMING">
     <type>logical</type>
     <valid_values>TRUE,FALSE</valid_values>

--- a/cime_config/namelist_definition_drv.xml
+++ b/cime_config/namelist_definition_drv.xml
@@ -178,31 +178,6 @@
     </values>
   </entry>
 
-  <!-- <entry id="cpl_cdf64"> -->
-  <!--   <type>logical</type> -->
-  <!--   <category>expdef</category> -->
-  <!--   <group>DRIVER_attributes</group> -->
-  <!--   <desc> -->
-  <!--     default: true -->
-  <!--   </desc> -->
-  <!--   <values> -->
-  <!--     <value>.true.</value> -->
-  <!--   </values> -->
-  <!-- </entry> -->
-
-  <entry id="drv_threading" modify_via_xml="DRV_THREADING">
-    <type>logical</type>
-    <category>performance</category>
-    <group>DRIVER_attributes</group>
-    <desc>
-      turn on run time control of threading per pe per component by the driver
-      default: false
-    </desc>
-    <values>
-      <value>$DRV_THREADING</value>
-    </values>
-  </entry>
-
   <entry id="run_barriers" modify_via_xml="COMP_RUN_BARRIERS">
     <type>logical</type>
     <category>performance</category>
@@ -732,7 +707,7 @@
     <category>single_column</category>
     <group>ALLCOMP_attributes</group>
     <desc>
-      DOMAIN file needed for single column model IF and only if 
+      DOMAIN file needed for single column model IF and only if
       a nearest neighbor search is done to match the PTS_LAT and PTS_LON
       to the closest point in the domain file. This file is ONLY used in
       single column mode.
@@ -1072,7 +1047,7 @@
     </desc>
     <values>
       <value>$MASK_MESH</value>
-      <value single_column='true'>null</value> 
+      <value single_column='true'>null</value>
     </values>
   </entry>
 
@@ -1085,7 +1060,7 @@
     </desc>
     <values>
       <value>$ATM_DOMAIN_MESH</value>
-      <value single_column='true'>null</value> 
+      <value single_column='true'>null</value>
     </values>
   </entry>
 
@@ -1098,7 +1073,7 @@
     </desc>
     <values>
       <value>$LND_DOMAIN_MESH</value>
-      <value single_column='true'>null</value> 
+      <value single_column='true'>null</value>
     </values>
   </entry>
 
@@ -1111,7 +1086,7 @@
     </desc>
     <values>
       <value>$OCN_DOMAIN_MESH</value>
-      <value single_column='true'>null</value> 
+      <value single_column='true'>null</value>
     </values>
   </entry>
 
@@ -1124,7 +1099,7 @@
     </desc>
     <values>
       <value>$ICE_DOMAIN_MESH</value>
-      <value single_column='true'>null</value> 
+      <value single_column='true'>null</value>
     </values>
   </entry>
 
@@ -1137,7 +1112,7 @@
     </desc>
     <values>
       <value>$ROF_DOMAIN_MESH</value>
-      <value single_column='true'>null</value> 
+      <value single_column='true'>null</value>
     </values>
   </entry>
 
@@ -1150,7 +1125,7 @@
     </desc>
     <values>
       <value>$GLC_DOMAIN_MESH</value>
-      <value single_column='true'>null</value> 
+      <value single_column='true'>null</value>
     </values>
   </entry>
 
@@ -1163,7 +1138,7 @@
     </desc>
     <values>
       <value>$WAV_DOMAIN_MESH</value>
-      <value single_column='true'>null</value> 
+      <value single_column='true'>null</value>
     </values>
   </entry>
 

--- a/cime_config/testdefs/testlist_drv.xml
+++ b/cime_config/testdefs/testlist_drv.xml
@@ -397,6 +397,15 @@
       <option name="wallclock"> 00:20:00 </option>
     </options>
   </test>
+  <test compset="I2000Clm50BgcCropRtm" grid="f10_f10_mg37" name="SMS_D_Ld5_Vnuopc" testmods="rtm/default">
+    <machines>
+      <machine name="cheyenne" compiler="intel" category="nuopc"/>
+      <machine name="izumi" compiler="nag" category="nuopc"/>
+    </machines>
+    <options>
+      <option name="wallclock"> 00:20:00 </option>
+    </options>
+  </test>
 
   <!-- ======================================= -->
   <!-- TG compsets -->

--- a/cime_config/testdefs/testlist_drv.xml
+++ b/cime_config/testdefs/testlist_drv.xml
@@ -166,6 +166,17 @@
     </options>
   </test>
 
+  <test compset="B1850" grid="f19_g17" name="ERS_Vnuopc_Ld5" testmods="allactive/nuopc_cap_io">
+    <machines>
+      <machine name="cheyenne" compiler="intel" category="nuopc"/>
+      <machine name="theia" compiler="intel" category="nuopc"/>
+      <machine name="izumi" compiler="intel" category="nuopc"/>
+    </machines>
+    <options>
+      <option name="wallclock"> 00:40:00 </option>
+    </options>
+  </test>
+
   <!-- ======================================= -->
   <!-- C compsets -->
   <!-- ======================================= -->

--- a/drivers/cime/esm.F90
+++ b/drivers/cime/esm.F90
@@ -978,6 +978,9 @@ contains
        info = ESMF_InfoCreate(rc=rc)
        if (chkerr(rc,__LINE__,u_FILE_u)) return
 
+!       call ESMF_InfoSet(info, key="/NUOPC/Hint/PePerPet/MinStackSize",value=400000000, rc=rc)
+!       if (chkerr(rc,__LINE__,u_FILE_u)) return
+
        call ESMF_InfoSet(info, key="/NUOPC/Hint/PePerPet/MaxCount", value=nthrds, rc=rc)
        if (chkerr(rc,__LINE__,u_FILE_u)) return
 
@@ -1044,7 +1047,6 @@ contains
 
        comps(i+1) = i+1
        found_comp = .false.
-! If maxthreads == 1 then no threading is used and we do not need the SetVM in calls to NUOPC_DriverAddComp
 #ifdef MED_PRESENT
        if (trim(compLabels(i)) == 'MED') then
           med_id = i + 1

--- a/drivers/cime/esm.F90
+++ b/drivers/cime/esm.F90
@@ -988,6 +988,7 @@ contains
           call ESMF_InfoSet(info, key="/NUOPC/Hint/PePerPet/OpenMpHandling", value='none', rc=rc)
           if (chkerr(rc,__LINE__,u_FILE_u)) return
        endif
+
        call NUOPC_CompAttributeGet(driver, name=trim(namestr)//'_rootpe', value=cvalue, rc=rc)
        if (chkerr(rc,__LINE__,u_FILE_u)) return
        read(cvalue,*) rootpe
@@ -1029,9 +1030,17 @@ contains
 #endif
        endif
 
+#ifdef ESMF_AWARE_THREADING
+       cnt = 1
+       do ntask = rootpe, rootpe+nthrds*ntasks*stride-1, stride
+          petlist(cnt) = ntask
+          cnt = cnt + 1
+       enddo
+#else
        do ntask = 1, size(petlist)
           petlist(ntask) = rootpe + (ntask-1)*stride
        enddo
+#endif
 
        comps(i+1) = i+1
        found_comp = .false.

--- a/drivers/cime/esm.F90
+++ b/drivers/cime/esm.F90
@@ -989,7 +989,7 @@ contains
 #ifdef MED_PRESENT
        if (trim(compLabels(i)) == 'MED') then
           med_id = i + 1
-          if(maxthreads > 1) then
+          if(nthrds > 1) then
              call NUOPC_DriverAddComp(driver, trim(compLabels(i)), MEDSetServices, MEDSetVM, &
                   petList=petlist, comp=child, info=info, rc=rc)
           else
@@ -1002,7 +1002,7 @@ contains
 #endif
 #ifdef ATM_PRESENT
        if (trim(compLabels(i)) .eq. 'ATM') then
-          if(maxthreads > 1) then
+          if(nthrds > 1) then
              call NUOPC_DriverAddComp(driver, trim(compLabels(i)), ATMSetServices, ATMSetVM, &
                   petList=petlist, comp=child, info=info, rc=rc)
           else
@@ -1015,7 +1015,7 @@ contains
 #endif
 #ifdef LND_PRESENT
        if (trim(compLabels(i)) .eq. 'LND') then
-          if(maxthreads > 1) then
+          if(nthrds > 1) then
              call NUOPC_DriverAddComp(driver, trim(compLabels(i)), LNDSetServices, LNDSetVM, &
                   PetList=petlist, comp=child, info=info, rc=rc)
           else
@@ -1028,7 +1028,7 @@ contains
 #endif
 #ifdef OCN_PRESENT
        if (trim(compLabels(i)) .eq. 'OCN') then
-          if(maxthreads > 1) then
+          if(nthrds > 1) then
              call NUOPC_DriverAddComp(driver, trim(compLabels(i)), OCNSetServices, OCNSetVM, &
                   PetList=petlist, comp=child, info=info, rc=rc)
           else
@@ -1041,7 +1041,7 @@ contains
 #endif
 #ifdef ICE_PRESENT
        if (trim(compLabels(i)) .eq. 'ICE') then
-          if(maxthreads > 1) then
+          if(nthrds > 1) then
              call NUOPC_DriverAddComp(driver, trim(compLabels(i)), ICESetServices, ICESetVM, &
                   PetList=petlist, comp=child, info=info, rc=rc)
           else
@@ -1054,7 +1054,7 @@ contains
 #endif
 #ifdef GLC_PRESENT
        if (trim(compLabels(i)) .eq. 'GLC') then
-          if(maxthreads > 1) then
+          if(nthrds > 1) then
              call NUOPC_DriverAddComp(driver, trim(compLabels(i)), GLCSetServices, GLCSetVM, &
                   PetList=petlist, comp=child, info=info, rc=rc)
           else
@@ -1067,7 +1067,7 @@ contains
 #endif
 #ifdef ROF_PRESENT
        if (trim(compLabels(i)) .eq. 'ROF') then
-          if(maxthreads > 1) then
+          if(nthrds > 1) then
              call NUOPC_DriverAddComp(driver, trim(compLabels(i)), ROFSetServices, ROFSetVM, &
                   PetList=petlist, comp=child, info=info, rc=rc)
           else
@@ -1080,7 +1080,7 @@ contains
 #endif
 #ifdef WAV_PRESENT
        if (trim(compLabels(i)) .eq. 'WAV') then
-          if(maxthreads > 1) then
+          if(nthrds > 1) then
              call NUOPC_DriverAddComp(driver, trim(compLabels(i)), WAVSetServices, WAVSetVM, &
                   PetList=petlist, comp=child, info=info, rc=rc)
           else

--- a/drivers/cime/esm.F90
+++ b/drivers/cime/esm.F90
@@ -807,7 +807,9 @@ contains
     use ESMF         , only : ESMF_InfoCreate, ESMF_InfoDestroy
     use NUOPC        , only : NUOPC_CompAttributeGet
     use NUOPC_Driver , only : NUOPC_DriverAddComp
+#ifndef NO_MPI2
     use mpi          , only : MPI_COMM_NULL, mpi_comm_size
+#endif
     use mct_mod      , only : mct_world_init
     use shr_pio_mod  , only : shr_pio_init2
 
@@ -836,7 +838,9 @@ contains
 #ifdef GLC_PRESENT
     use glc_comp_nuopc        , only : GLCSetServices => SetServices, GLCSetVM => SetVM
 #endif
-
+#ifdef NO_MPI2
+    include 'mpif.h'
+#endif
     ! input/output variables
     type(ESMF_GridComp)            :: driver
     integer, intent(out)           :: maxthreads ! maximum number of threads any component

--- a/drivers/cime/esm.F90
+++ b/drivers/cime/esm.F90
@@ -1044,6 +1044,7 @@ contains
 
        comps(i+1) = i+1
        found_comp = .false.
+! If maxthreads == 1 then no threading is used and we do not need the SetVM in calls to NUOPC_DriverAddComp
 #ifdef MED_PRESENT
        if (trim(compLabels(i)) == 'MED') then
           med_id = i + 1

--- a/drivers/cime/esm.F90
+++ b/drivers/cime/esm.F90
@@ -978,9 +978,6 @@ contains
        info = ESMF_InfoCreate(rc=rc)
        if (chkerr(rc,__LINE__,u_FILE_u)) return
 
-!       call ESMF_InfoSet(info, key="/NUOPC/Hint/PePerPet/MinStackSize",value=400000000, rc=rc)
-!       if (chkerr(rc,__LINE__,u_FILE_u)) return
-
        call ESMF_InfoSet(info, key="/NUOPC/Hint/PePerPet/MaxCount", value=nthrds, rc=rc)
        if (chkerr(rc,__LINE__,u_FILE_u)) return
 

--- a/drivers/cime/esm.F90
+++ b/drivers/cime/esm.F90
@@ -1441,7 +1441,6 @@ contains
     call t_prf(trim(timing_dir)//'/model_timing'//trim(inst_suffix), mpicom=mpicomm)
 
     call t_finalizef()
-    print *,__FILE__,__LINE__
   end subroutine esm_finalize
 
 

--- a/drivers/cime/esm.F90
+++ b/drivers/cime/esm.F90
@@ -993,7 +993,7 @@ contains
 #ifdef MED_PRESENT
        if (trim(compLabels(i)) == 'MED') then
           med_id = i + 1
-          if(nthrds > 1) then
+          if(maxthreads > 1) then
              call NUOPC_DriverAddComp(driver, trim(compLabels(i)), MEDSetServices, MEDSetVM, &
                   petList=petlist, comp=child, info=info, rc=rc)
           else
@@ -1006,7 +1006,7 @@ contains
 #endif
 #ifdef ATM_PRESENT
        if (trim(compLabels(i)) .eq. 'ATM') then
-          if(nthrds > 1) then
+          if(maxthreads > 1) then
              call NUOPC_DriverAddComp(driver, trim(compLabels(i)), ATMSetServices, ATMSetVM, &
                   petList=petlist, comp=child, info=info, rc=rc)
           else
@@ -1019,7 +1019,7 @@ contains
 #endif
 #ifdef LND_PRESENT
        if (trim(compLabels(i)) .eq. 'LND') then
-          if(nthrds > 1) then
+          if(maxthreads > 1) then
              call NUOPC_DriverAddComp(driver, trim(compLabels(i)), LNDSetServices, LNDSetVM, &
                   PetList=petlist, comp=child, info=info, rc=rc)
           else
@@ -1032,7 +1032,7 @@ contains
 #endif
 #ifdef OCN_PRESENT
        if (trim(compLabels(i)) .eq. 'OCN') then
-          if(nthrds > 1) then
+          if(maxthreads > 1) then
              call NUOPC_DriverAddComp(driver, trim(compLabels(i)), OCNSetServices, OCNSetVM, &
                   PetList=petlist, comp=child, info=info, rc=rc)
           else
@@ -1045,7 +1045,7 @@ contains
 #endif
 #ifdef ICE_PRESENT
        if (trim(compLabels(i)) .eq. 'ICE') then
-          if(nthrds > 1) then
+          if(maxthreads > 1) then
              call NUOPC_DriverAddComp(driver, trim(compLabels(i)), ICESetServices, ICESetVM, &
                   PetList=petlist, comp=child, info=info, rc=rc)
           else
@@ -1058,7 +1058,7 @@ contains
 #endif
 #ifdef GLC_PRESENT
        if (trim(compLabels(i)) .eq. 'GLC') then
-          if(nthrds > 1) then
+          if(maxthreads > 1) then
              call NUOPC_DriverAddComp(driver, trim(compLabels(i)), GLCSetServices, GLCSetVM, &
                   PetList=petlist, comp=child, info=info, rc=rc)
           else
@@ -1071,7 +1071,7 @@ contains
 #endif
 #ifdef ROF_PRESENT
        if (trim(compLabels(i)) .eq. 'ROF') then
-          if(nthrds > 1) then
+          if(maxthreads > 1) then
              call NUOPC_DriverAddComp(driver, trim(compLabels(i)), ROFSetServices, ROFSetVM, &
                   PetList=petlist, comp=child, info=info, rc=rc)
           else
@@ -1084,7 +1084,7 @@ contains
 #endif
 #ifdef WAV_PRESENT
        if (trim(compLabels(i)) .eq. 'WAV') then
-          if(nthrds > 1) then
+          if(maxthreads > 1) then
              call NUOPC_DriverAddComp(driver, trim(compLabels(i)), WAVSetServices, WAVSetVM, &
                   PetList=petlist, comp=child, info=info, rc=rc)
           else

--- a/drivers/cime/esm.F90
+++ b/drivers/cime/esm.F90
@@ -954,6 +954,9 @@ contains
        info = ESMF_InfoCreate(rc=rc)
        if (chkerr(rc,__LINE__,u_FILE_u)) return
 
+!       call ESMF_InfoSet(info, key="/NUOPC/Hint/PePerPet/MinStackSize",value=400000000, rc=rc)
+!       if (chkerr(rc,__LINE__,u_FILE_u)) return
+
        call ESMF_InfoSet(info, key="/NUOPC/Hint/PePerPet/MaxCount", value=nthrds, rc=rc)
        if (chkerr(rc,__LINE__,u_FILE_u)) return
 
@@ -978,9 +981,9 @@ contains
        call NUOPC_CompAttributeGet(driver, name=trim(namestr)//'_pestride', value=cvalue, rc=rc)
        if (chkerr(rc,__LINE__,u_FILE_u)) return
        read(cvalue,*) stride
-       if (stride < 1 .or. rootpe+ntasks*stride > PetCount) then
+       if (stride < 1 .or. rootpe+(ntasks-1)*stride > PetCount) then
           write (msgstr, *) "Invalid pestride value specified for component: ",namestr,&
-               ' rootpe: ',rootpe, ' pestride: ', stride
+               ' rootpe: ',rootpe, ' pestride: ', stride, ' ntasks: ',ntasks, ' PetCount: ', PetCount
           call ESMF_LogSetError(ESMF_RC_NOT_VALID, msg=msgstr, line=__LINE__, file=__FILE__, rcToReturn=rc)
           return
        endif
@@ -1000,108 +1003,67 @@ contains
 
        comps(i+1) = i+1
        found_comp = .false.
-! If maxthreads == 1 then no threading is used and we do not need the SetVM in calls to NUOPC_DriverAddComp
 #ifdef MED_PRESENT
        if (trim(compLabels(i)) == 'MED') then
           med_id = i + 1
-          if(maxthreads > 1) then
-             call NUOPC_DriverAddComp(driver, trim(compLabels(i)), MEDSetServices, MEDSetVM, &
-                  petList=petlist, comp=child, info=info, rc=rc)
-          else
-             call NUOPC_DriverAddComp(driver, trim(compLabels(i)), MEDSetServices, &
-                  petList=petlist, comp=child, rc=rc)
-          endif
+          call NUOPC_DriverAddComp(driver, trim(compLabels(i)), MEDSetServices, MEDSetVM, &
+               petList=petlist, comp=child, info=info, rc=rc)
           if (chkerr(rc,__LINE__,u_FILE_u)) return
           found_comp = .true.
        end if
 #endif
 #ifdef ATM_PRESENT
        if (trim(compLabels(i)) .eq. 'ATM') then
-          if(maxthreads > 1) then
-             call NUOPC_DriverAddComp(driver, trim(compLabels(i)), ATMSetServices, ATMSetVM, &
-                  petList=petlist, comp=child, info=info, rc=rc)
-          else
-             call NUOPC_DriverAddComp(driver, trim(compLabels(i)), ATMSetServices, &
-                  petList=petlist, comp=child, rc=rc)
-          endif
+          call NUOPC_DriverAddComp(driver, trim(compLabels(i)), ATMSetServices, ATMSetVM, &
+               petList=petlist, comp=child, info=info, rc=rc)
           if (chkerr(rc,__LINE__,u_FILE_u)) return
           found_comp = .true.
        end if
 #endif
 #ifdef LND_PRESENT
        if (trim(compLabels(i)) .eq. 'LND') then
-          if(maxthreads > 1) then
-             call NUOPC_DriverAddComp(driver, trim(compLabels(i)), LNDSetServices, LNDSetVM, &
-                  PetList=petlist, comp=child, info=info, rc=rc)
-          else
-             call NUOPC_DriverAddComp(driver, trim(compLabels(i)), LNDSetServices,  &
-                  PetList=petlist, comp=child, rc=rc)
-          endif
+          call NUOPC_DriverAddComp(driver, trim(compLabels(i)), LNDSetServices, LNDSetVM, &
+               PetList=petlist, comp=child, info=info, rc=rc)
           if (chkerr(rc,__LINE__,u_FILE_u)) return
           found_comp = .true.
        end if
 #endif
 #ifdef OCN_PRESENT
        if (trim(compLabels(i)) .eq. 'OCN') then
-          if(maxthreads > 1) then
-             call NUOPC_DriverAddComp(driver, trim(compLabels(i)), OCNSetServices, OCNSetVM, &
-                  PetList=petlist, comp=child, info=info, rc=rc)
-          else
-             call NUOPC_DriverAddComp(driver, trim(compLabels(i)), OCNSetServices, &
-                  PetList=petlist, comp=child, rc=rc)
-          endif
+          call NUOPC_DriverAddComp(driver, trim(compLabels(i)), OCNSetServices, OCNSetVM, &
+               PetList=petlist, comp=child, info=info, rc=rc)
           if (chkerr(rc,__LINE__,u_FILE_u)) return
           found_comp = .true.
        end if
 #endif
 #ifdef ICE_PRESENT
        if (trim(compLabels(i)) .eq. 'ICE') then
-          if(maxthreads > 1) then
-             call NUOPC_DriverAddComp(driver, trim(compLabels(i)), ICESetServices, ICESetVM, &
-                  PetList=petlist, comp=child, info=info, rc=rc)
-          else
-             call NUOPC_DriverAddComp(driver, trim(compLabels(i)), ICESetServices,  &
-                  PetList=petlist, comp=child, rc=rc)
-          endif
+          call NUOPC_DriverAddComp(driver, trim(compLabels(i)), ICESetServices, ICESetVM, &
+               PetList=petlist, comp=child, info=info, rc=rc)
           if (chkerr(rc,__LINE__,u_FILE_u)) return
           found_comp = .true.
        end if
 #endif
 #ifdef GLC_PRESENT
        if (trim(compLabels(i)) .eq. 'GLC') then
-          if(maxthreads > 1) then
-             call NUOPC_DriverAddComp(driver, trim(compLabels(i)), GLCSetServices, GLCSetVM, &
-                  PetList=petlist, comp=child, info=info, rc=rc)
-          else
-             call NUOPC_DriverAddComp(driver, trim(compLabels(i)), GLCSetServices, &
-                  PetList=petlist, comp=child, rc=rc)
-          endif
+          call NUOPC_DriverAddComp(driver, trim(compLabels(i)), GLCSetServices, GLCSetVM, &
+               PetList=petlist, comp=child, info=info, rc=rc)
           if (chkerr(rc,__LINE__,u_FILE_u)) return
           found_comp = .true.
        end if
 #endif
 #ifdef ROF_PRESENT
        if (trim(compLabels(i)) .eq. 'ROF') then
-          if(maxthreads > 1) then
-             call NUOPC_DriverAddComp(driver, trim(compLabels(i)), ROFSetServices, ROFSetVM, &
-                  PetList=petlist, comp=child, info=info, rc=rc)
-          else
-             call NUOPC_DriverAddComp(driver, trim(compLabels(i)), ROFSetServices, &
-                  PetList=petlist, comp=child, rc=rc)
-          endif
+          call NUOPC_DriverAddComp(driver, trim(compLabels(i)), ROFSetServices, ROFSetVM, &
+               PetList=petlist, comp=child, info=info, rc=rc)
           if (chkerr(rc,__LINE__,u_FILE_u)) return
           found_comp = .true.
        end if
 #endif
 #ifdef WAV_PRESENT
        if (trim(compLabels(i)) .eq. 'WAV') then
-          if(maxthreads > 1) then
-             call NUOPC_DriverAddComp(driver, trim(compLabels(i)), WAVSetServices, WAVSetVM, &
-                  PetList=petlist, comp=child, info=info, rc=rc)
-          else
-             call NUOPC_DriverAddComp(driver, trim(compLabels(i)), WAVSetServices,  &
-                  PetList=petlist, comp=child, rc=rc)
-          endif
+          call NUOPC_DriverAddComp(driver, trim(compLabels(i)), WAVSetServices, WAVSetVM, &
+               PetList=petlist, comp=child, info=info, rc=rc)
           if (chkerr(rc,__LINE__,u_FILE_u)) return
           found_comp = .true.
        end if

--- a/drivers/cime/esmApp.F90
+++ b/drivers/cime/esmApp.F90
@@ -12,8 +12,9 @@ program esmApp
   use ESMF,            only : ESMF_LOGKIND_MULTI_ON_ERROR, ESMF_LogKind_Flag
   use ESMF,            only : ESMF_VMGet, ESMF_VM, ESMF_InitializePreMPI
 
-#ifdef USE_MPI2
-  use mpi,             only : MPI_COMM_WORLD, MPI_COMM_NULL, MPI_Init, MPI_FINALIZE, MPI_BCAST, MPI_COMM_RANK
+#ifndef NO_MPI2
+  use mpi,             only : MPI_COMM_WORLD, MPI_COMM_NULL, MPI_Init_thread, MPI_FINALIZE, MPI_BCAST
+  use mpi,             only : MPI_COMM_RANK, MPI_THREAD_SERIALIZED, MPI_LOGICAL
 #else
   use mpi
 #endif
@@ -40,9 +41,12 @@ program esmApp
   !-----------------------------------------------------------------------------
   ! Initiallize MPI
   !-----------------------------------------------------------------------------
-
+#ifndef NO_MPI2
   call ESMF_InitializePreMPI()
   call MPI_init_thread(MPI_THREAD_SERIALIZED, provided, rc)
+#else
+  call MPI_init(rc)
+#endif
   COMP_COMM = MPI_COMM_WORLD
 
   !-----------------------------------------------------------------------------

--- a/drivers/cime/esmApp.F90
+++ b/drivers/cime/esmApp.F90
@@ -175,7 +175,6 @@ program esmApp
        line=__LINE__, &
        file=__FILE__)) &
        call ESMF_Finalize(endflag=ESMF_END_ABORT)
-  print *,__FILE__,__LINE__
   if (ESMF_LogFoundError(rcToCheck=urc, msg=ESMF_LOGERR_PASSTHRU, &
        line=__LINE__, &
        file=__FILE__)) &

--- a/drivers/cime/esmApp.F90
+++ b/drivers/cime/esmApp.F90
@@ -169,11 +169,13 @@ program esmApp
   ! Call Finalize for the ensemble driver
   ! Destroy the ensemble driver
   !-----------------------------------------------------------------------------
+
   call ESMF_GridCompFinalize(ensemble_driver_comp, userRc=urc, rc=rc)
   if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
        line=__LINE__, &
        file=__FILE__)) &
        call ESMF_Finalize(endflag=ESMF_END_ABORT)
+  print *,__FILE__,__LINE__
   if (ESMF_LogFoundError(rcToCheck=urc, msg=ESMF_LOGERR_PASSTHRU, &
        line=__LINE__, &
        file=__FILE__)) &

--- a/drivers/cime/esmApp.F90
+++ b/drivers/cime/esmApp.F90
@@ -169,13 +169,11 @@ program esmApp
   ! Call Finalize for the ensemble driver
   ! Destroy the ensemble driver
   !-----------------------------------------------------------------------------
-  print *,__FILE__,__LINE__
   call ESMF_GridCompFinalize(ensemble_driver_comp, userRc=urc, rc=rc)
   if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
        line=__LINE__, &
        file=__FILE__)) &
        call ESMF_Finalize(endflag=ESMF_END_ABORT)
-  print *,__FILE__,__LINE__
   if (ESMF_LogFoundError(rcToCheck=urc, msg=ESMF_LOGERR_PASSTHRU, &
        line=__LINE__, &
        file=__FILE__)) &
@@ -200,7 +198,6 @@ program esmApp
        line=__LINE__, &
        file=__FILE__)) &
        call ESMF_Finalize(endflag=ESMF_END_ABORT)
-  print *,__FILE__,__LINE__
   call ESMF_Finalize()
 
 end program

--- a/drivers/cime/esmApp.F90
+++ b/drivers/cime/esmApp.F90
@@ -169,12 +169,13 @@ program esmApp
   ! Call Finalize for the ensemble driver
   ! Destroy the ensemble driver
   !-----------------------------------------------------------------------------
-
+  print *,__FILE__,__LINE__
   call ESMF_GridCompFinalize(ensemble_driver_comp, userRc=urc, rc=rc)
   if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
        line=__LINE__, &
        file=__FILE__)) &
        call ESMF_Finalize(endflag=ESMF_END_ABORT)
+  print *,__FILE__,__LINE__
   if (ESMF_LogFoundError(rcToCheck=urc, msg=ESMF_LOGERR_PASSTHRU, &
        line=__LINE__, &
        file=__FILE__)) &
@@ -199,7 +200,7 @@ program esmApp
        line=__LINE__, &
        file=__FILE__)) &
        call ESMF_Finalize(endflag=ESMF_END_ABORT)
-
+  print *,__FILE__,__LINE__
   call ESMF_Finalize()
 
 end program

--- a/drivers/cime/esm_utils_mod.F90
+++ b/drivers/cime/esm_utils_mod.F90
@@ -15,7 +15,7 @@ contains
 !===============================================================================
 
   logical function ChkErr(rc, line, file, mpierr)
-#ifdef USE_MPI2
+#ifndef NO_MPI2
     use mpi, only : MPI_ERROR_STRING, MPI_MAX_ERROR_STRING, MPI_SUCCESS
 #else
     use mpi, only : MPI_SUCCESS
@@ -28,7 +28,7 @@ contains
 
     character(len=*), intent(in) :: file
     logical, optional, intent(in) :: mpierr
-#ifndef USE_MPI2
+#ifdef NO_MPI2
     integer, parameter :: MPI_MAX_ERROR_STRING=80
 #endif
     character(MPI_MAX_ERROR_STRING) :: lstring

--- a/mediator/med.F90
+++ b/mediator/med.F90
@@ -3,8 +3,8 @@ module MED
   !-----------------------------------------------------------------------------
   ! Mediator Component.
   !-----------------------------------------------------------------------------
-
   use ESMF                     , only : ESMF_VMLogMemInfo
+  use NUOPC_Model              , only : SetVM
   use med_kind_mod             , only : CX=>SHR_KIND_CX, CS=>SHR_KIND_CS, CL=>SHR_KIND_CL, R8=>SHR_KIND_R8
   use med_constants_mod        , only : dbug_flag          => med_constants_dbug_flag
   use med_constants_mod        , only : spval_init         => med_constants_spval_init
@@ -48,7 +48,7 @@ module MED
   private
 
   public  SetServices
-
+  public  SetVM
   private InitializeP0
   private InitializeIPDv03p1 ! advertise fields
   private InitializeIPDv03p3 ! realize connected Fields with transfer action "provide"
@@ -279,7 +279,7 @@ contains
     call NUOPC_CompSpecialize(gcomp, specLabel=mediator_label_TimestampExport, &
          specPhaselabel="med_phases_post_ocn", specRoutine=NUOPC_NoOp, rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
- 
+
     !------------------
     ! prep and post routines for ice
     !------------------

--- a/mediator/med_utils_mod.F90
+++ b/mediator/med_utils_mod.F90
@@ -33,7 +33,7 @@ contains
 !===============================================================================
 
   logical function med_utils_ChkErr(rc, line, file, mpierr)
-#ifdef USE_MPI2
+#ifndef NO_MPI2
     use mpi , only : MPI_ERROR_STRING, MPI_MAX_ERROR_STRING, MPI_SUCCESS
 #else
     use mpi, only : MPI_SUCCESS
@@ -46,7 +46,7 @@ contains
 
     character(len=*), intent(in) :: file
     logical, optional, intent(in) :: mpierr
-#ifndef USE_MPI2
+#ifdef NO_MPI2
     integer, parameter :: MPI_MAX_ERROR_STRING=80
 #endif
     character(MPI_MAX_ERROR_STRING) :: lstring


### PR DESCRIPTION
### Description of changes
Fixes the avgdt variable to output in correct units of wallclock seconds per simulation day.

In the CESM driver only, add the nthreads value from nuopc.runconfig to each components attributes. Since the CESM driver is include with CMEPS - this is in fact a CMEPS change but only relevant to the driver.

### Specific notes

Contributors other than yourself, if any:

CMEPS Issues Fixed (include github issue #):

Are changes expected to change answers?
 - [X] bit for bit
 - [ ] different at roundoff level
 - [ ] more substantial 

Any User Interface Changes (namelist or namelist defaults changes)?
 - [ ] Yes
 - [X] No

Testing performed if application target is CESM:(either UFS-S2S or CESM testing is required):
- [X] (required) CIME_DRIVER=nuopc scripts_regression_tests.py
   - machines:
   - details (e.g. failed tests):
- [X] (required) CESM testlist_drv.xml
   - machines and compilers: cheyenne intel, baseline is apr05
   - details (e.g. failed tests):
- [ ] (optional) CESM prealpha test
   - machines and compilers
   - details (e.g. failed tests):

Testing performed if application target is UFS-S2S:
- [ ] (required) UFS-S2S testing
   - description:
   - details (e.g. failed tests):

Hashes used for testing:
- [ ] CESM:
  - repository to check out: https://github.com/ESCOMP/CESM.git
  - branch: nuopc_dev
  - hash:
- [ ] UFS-S2S, then umbrella repository to check out and associated hash:
  - repository to check out:
  - branch:
  - hash:
