### PR TITLE
use pts_lat and pts_lon for single point cases

### DIFF
--- a/cime_config/buildnml
+++ b/cime_config/buildnml
@@ -43,7 +43,8 @@ def _create_drv_namelists(case, infile, confdir, nmlgen, files):
     config['MPILIB'] = case.get_value('MPILIB')
     config['OS'] = case.get_value('OS')
     config['glc_nec'] = 0 if case.get_value('GLC_NEC') == 0 else case.get_value('GLC_NEC')
-    config['single_column'] = 'true' if case.get_value('PTS_MODE') else 'false'
+    if case.get_value("ATM_NX") == 1 and case.get_value("ATM_NY") == 1 and case.get_value("ATM_DOMAIN_FILE") != "UNSET":
+        config['single_column'] = 'true'
     config['timer_level'] = 'pos' if case.get_value('TIMER_LEVEL') >= 1 else 'neg'
     config['bfbflag'] = 'on' if case.get_value('BFBFLAG') else 'off'
     config['continue_run'] = '.true.' if case.get_value('CONTINUE_RUN') else '.false.'

--- a/cime_config/config_component.xml
+++ b/cime_config/config_component.xml
@@ -1233,21 +1233,13 @@
     <desc>grid mask - DO NOT EDIT (for experts only)</desc>
   </entry>
 
-  <entry id="PTS_MODE">
-    <type>logical</type>
-    <valid_values>TRUE,FALSE</valid_values>
-    <default_value>FALSE</default_value>
-    <group>run_domain</group>
-    <file>env_run.xml</file>
-    <desc>Operate on only a single point of the global grid  - DO NOT EDIT (for experts only)</desc>
-  </entry>
-
   <entry id="PTS_LAT">
     <type>real</type>
     <default_value>-999.99</default_value>
     <group>run_domain</group>
     <file>env_run.xml</file>
-    <desc>Latitude to find nearest points for points mode (only used if PTS_MODE is TRUE)</desc>
+    <desc>Latitude of grid location, in single column mode interpolate datasets to this location
+          in single point mode assume all datasets are at this location</desc>
   </entry>
 
   <entry id="PTS_LON">
@@ -1255,7 +1247,8 @@
     <default_value>-999.99</default_value>
     <group>run_domain</group>
     <file>env_run.xml</file>
-    <desc>Longitude to find nearest points for points mode (only used if PTS_MODE is TRUE)</desc>
+    <desc>Longitude of grid location, in single column mode interpolate datasets to this location
+          in single point mode assume all datasets are at this location</desc>
   </entry>
 
   <!-- ======================================================================= -->

--- a/cime_config/namelist_definition_drv.xml
+++ b/cime_config/namelist_definition_drv.xml
@@ -720,11 +720,10 @@
     <group>ALLCOMP_attributes</group>
     <desc>
       grid point latitude associated with single column mode.
-      if set to -999, ignore this value
+      used for single column and single point grids
     </desc>
     <values>
-      <value>-999.</value>
-      <value single_column="true">$PTS_LAT</value>
+      <value>$PTS_LAT</value>
     </values>
   </entry>
 
@@ -737,8 +736,7 @@
       set by PTS_LON in env_run.xml.
     </desc>
     <values>
-      <value>-999.</value>
-      <value single_column="true">$PTS_LON</value>
+      <value>$PTS_LON</value>
     </values>
   </entry>
 
@@ -1095,7 +1093,7 @@
     <category>mapping</category>
     <group>LND_attributes</group>
     <desc>
-      DOMAIN description of lnd grid - this will be depracated 
+      DOMAIN description of lnd grid - this will be depracated
       only here for backwards compatibility
     </desc>
     <values>

--- a/cime_config/namelist_definition_drv.xml
+++ b/cime_config/namelist_definition_drv.xml
@@ -701,12 +701,12 @@
     </values>
   </entry>
 
-  <entry id="single_column" modify_via_xml="PTS_MODE">
+  <entry id="single_column">
     <type>logical</type>
     <category>single_column</category>
     <group>ALLCOMP_attributes</group>
     <desc>
-      turns on single column mode. set by PTS_MODE in env_case.xml, default: false
+      Turns on single column mode.
     </desc>
     <values>
       <value>.false.</value>
@@ -719,8 +719,8 @@
     <category>single_column</category>
     <group>ALLCOMP_attributes</group>
     <desc>
-      grid point latitude associated with single column mode.
-      used for single column and single point grids
+      Latitude in degrees corresponding to the grid location
+      in single column and single point modes.
     </desc>
     <values>
       <value>$PTS_LAT</value>
@@ -732,8 +732,8 @@
     <category>single_column</category>
     <group>ALLCOMP_attributes</group>
     <desc>
-      grid point longitude associated with single column mode.
-      set by PTS_LON in env_run.xml.
+      Longitude in degrees corresponding to the grid location
+      in single column and single point modes.
     </desc>
     <values>
       <value>$PTS_LON</value>


### PR DESCRIPTION
### Description of changes
Instead of defining a domain file with a single lat lon point we use the PTS_LAT and PTS_LON variables to input
the location to be used to create a mesh.   This requires the cime changes in https://github.com/ESMCI/cime/pull/3868

### Specific notes

Contributors other than yourself, if any: 

CMEPS Issues Fixed (include github issue #):

Are changes expected to change answers?
 - [X] bit for bit
 - [ ] different at roundoff level
 - [ ] more substantial 

Any User Interface Changes (namelist or namelist defaults changes)?
 - [ ] Yes
 - [ ] No

Testing performed if application target is CESM:(either UFS-S2S or CESM testing is required):
- [ ] (recommended) CIME_DRIVER=nuopc scripts_regression_tests.py
   - machines:
   - details (e.g. failed tests):
- [ ] (recommended) CESM testlist_drv.xml
   - machines and compilers:
   - details (e.g. failed tests):
- [ ] (optional) CESM prealpha test
   - machines and compilers
   - details (e.g. failed tests):
- [ ] (other) please described in detail
   - machines and compilers
   - details (e.g. failed tests):

Testing performed if application target is UFS-coupled:
- [ ] (recommended) UFS-coupled testing
   - description:
   - details (e.g. failed tests):

Testing performed if application target is UFS-HAFS:
- [ ] (recommended) UFS-HAFS testing
   - description:
   - details (e.g. failed tests):

Hashes used for testing:
- [ ] CESM:
  - repository to check out: https://github.com/ESCOMP/CESM.git
  - branch: nuopc_dev
  - hash:
- [ ] UFS-coupled, then umbrella repostiory to check out and associated hash:
  - repository to check out:
  - branch:
  - hash:
- [ ] UFS-HAFS, then umbrella repostiory to check out and associated hash:
  - repository to check out:
  - branch:
  - hash:
