### PR TITLE
changes to get nag 6.2 compiler working

### DIFF
--- a/cime_config/testdefs/testlist_drv.xml
+++ b/cime_config/testdefs/testlist_drv.xml
@@ -155,7 +155,7 @@
       <option name="wallclock"> 00:40:00 </option>
     </options>
   </test>
-  <test compset="B1850" grid="f09_t061" name="ERR_Vmct_Ld5" testmods="allactive/nuopc_cap_io">
+  <test compset="B1850" grid="f09_g17" name="ERR_Vmct_Ld5" testmods="allactive/nuopc_cap_io">
     <machines>
       <machine name="cheyenne" compiler="intel" category="mctcheck"/>
       <machine name="theia" compiler="intel" category="mctcheck"/>
@@ -394,18 +394,18 @@
   <test name="SMS_D_Ly1_Vnuopc" grid="f09_g17_gl4" compset="T1850G">
     <machines>
       <machine name="cheyenne" compiler="intel" category="nuopc">
-	<options>
-	  <option name="wallclock">0:20</option>
-	</options>
+        <options>
+          <option name="wallclock">0:20</option>
+        </options>
       </machine>
     </machines>
   </test>
   <test name="ERS_Ly3_Vnuopc" grid="f09_g17_gl4" compset="T1850G">
     <machines>
       <machine name="cheyenne" compiler="intel" category="nuopc">
-	<options>
-	  <option name="wallclock">0:20</option>
-	</options>
+        <options>
+          <option name="wallclock">0:20</option>
+        </options>
       </machine>
     </machines>
   </test>

--- a/drivers/cime/esm.F90
+++ b/drivers/cime/esm.F90
@@ -976,8 +976,10 @@ contains
           return
        endif
 
-       if (allocated(petlist) .and. size(petlist) .ne. ntasks) then
-          deallocate(petlist)
+       if (allocated(petlist)) then
+          if(size(petlist) .ne. ntasks) then
+             deallocate(petlist)
+          endif
        endif
        if(.not. allocated(petlist)) then
           allocate(petlist(ntasks))

--- a/drivers/cime/esm_time_mod.F90
+++ b/drivers/cime/esm_time_mod.F90
@@ -643,6 +643,7 @@ contains
    !----------------------------------------------------------------
 
    ! use netcdf here since it's serial
+   rc = ESMF_SUCCESS
    status = nf90_open(restart_file, NF90_NOWRITE, ncid)
    if (status /= nf90_NoErr) then
       call ESMF_LogWrite(trim(subname)//' ERROR: nf90_open: '//trim(restart_file), ESMF_LOGMSG_INFO)

--- a/drivers/cime/esm_utils_mod.F90
+++ b/drivers/cime/esm_utils_mod.F90
@@ -36,15 +36,17 @@ contains
 
     ChkErr = .false.
     lrc = rc
-    if (present(mpierr) .and. mpierr) then
-       if (rc == MPI_SUCCESS) return
+    if (present(mpierr)) then
+       if(mpierr) then
+          if (rc == MPI_SUCCESS) return
 #ifdef USE_MPI2
-       call MPI_ERROR_STRING(rc, lstring, len, ierr)
+          call MPI_ERROR_STRING(rc, lstring, len, ierr)
 #else
-       write(lstring,*) "ERROR in mct mpi-serial library rc=",rc
+          write(lstring,*) "ERROR in mct mpi-serial library rc=",rc
 #endif
-       call ESMF_LogWrite("ERROR: "//trim(lstring), ESMF_LOGMSG_INFO, line=line, file=file, rc=dbrc)
-       lrc = ESMF_FAILURE
+          call ESMF_LogWrite("ERROR: "//trim(lstring), ESMF_LOGMSG_INFO, line=line, file=file, rc=dbrc)
+          lrc = ESMF_FAILURE
+       endif
     endif
 
     if (ESMF_LogFoundError(rcToCheck=lrc, msg=ESMF_LOGERR_PASSTHRU, line=line, file=file)) then

--- a/mediator/med_phases_post_glc_mod.F90
+++ b/mediator/med_phases_post_glc_mod.F90
@@ -135,9 +135,9 @@ contains
           end if
        end do
        if (mastertask) then
-          write(logunit,'(a,l)') trim(subname) // 'glc2lnd_coupling is ',glc2lnd_coupling
-          write(logunit,'(a,l)') trim(subname) // 'glc2ocn_coupling is ',glc2ocn_coupling
-          write(logunit,'(a,l)') trim(subname) // 'glc2ice_coupling is ',glc2ice_coupling
+          write(logunit,'(a,L1)') trim(subname) // 'glc2lnd_coupling is ',glc2lnd_coupling
+          write(logunit,'(a,L1)') trim(subname) // 'glc2ocn_coupling is ',glc2ocn_coupling
+          write(logunit,'(a,L1)') trim(subname) // 'glc2ice_coupling is ',glc2ice_coupling
        end if
 
        ! determine if coupling to CISM is 2-way

--- a/mediator/med_utils_mod.F90
+++ b/mediator/med_utils_mod.F90
@@ -54,15 +54,17 @@ contains
 
     med_utils_ChkErr = .false.
     lrc = rc
-    if (present(mpierr) .and. mpierr) then
-       if (rc == MPI_SUCCESS) return
+    if (present(mpierr)) then
+       if(mpierr) then
+          if (rc == MPI_SUCCESS) return
 #ifdef USE_MPI2
-       call MPI_ERROR_STRING(rc, lstring, len, ierr)
+          call MPI_ERROR_STRING(rc, lstring, len, ierr)
 #else
-       write(lstring,*) "ERROR in mct mpi-serial library rc=",rc
+          write(lstring,*) "ERROR in mct mpi-serial library rc=",rc
 #endif
-       call ESMF_LogWrite("ERROR: "//trim(lstring), ESMF_LOGMSG_INFO, line=line, file=file)
-       lrc = ESMF_FAILURE
+          call ESMF_LogWrite("ERROR: "//trim(lstring), ESMF_LOGMSG_INFO, line=line, file=file)
+          lrc = ESMF_FAILURE
+       endif
     endif
 
     if (ESMF_LogFoundError(rcToCheck=lrc, msg=ESMF_LOGERR_PASSTHRU, line=line, file=file)) then


### PR DESCRIPTION
### Description of changes
Port to the nag fortran compiler.   

### Specific notes

Contributors other than yourself, if any: mvertens

CMEPS Issues Fixed (include github issue #):

Are changes expected to change answers?
 - [X] bit for bit
 - [X] different at roundoff level   for I cases
 - [X] more substantial for MOM 

Any User Interface Changes (namelist or namelist defaults changes)?
 - [ ] Yes
 - [X] No

Testing performed if application target is CESM:(either UFS-S2S or CESM testing is required):
- [X] (recommended) CIME_DRIVER=nuopc scripts_regression_tests.py
   - machines: izumi, nag compiler
   - details (e.g. failed tests): 
- [X] (recommended) CESM testlist_drv.xml
   - machines and compilers: izumi, nag
   - details (e.g. failed tests): All tests using FMS fail
- [ ] (optional) CESM prealpha test
   - machines and compilers
   - details (e.g. failed tests):
- [ ] (other) please described in detail
   - machines and compilers
   - details (e.g. failed tests):

Testing performed if application target is UFS-coupled:
- [ ] (recommended) UFS-coupled testing
   - description:
   - details (e.g. failed tests):

Testing performed if application target is UFS-HAFS:
- [ ] (recommended) UFS-HAFS testing
   - description:
   - details (e.g. failed tests):

Hashes used for testing:
- [ ] CESM:
  - repository to check out: https://github.com/ESCOMP/CESM.git
  - branch: nuopc_dev
  - hash:
- [ ] UFS-coupled, then umbrella repostiory to check out and associated hash:
  - repository to check out:
  - branch:
  - hash:
- [ ] UFS-HAFS, then umbrella repostiory to check out and associated hash:
  - repository to check out:
  - branch:
  - hash:
