### PR TITLE
changes to get ctsm LILAC mode to work

### DIFF
--- a/cime_config/config_component.xml
+++ b/cime_config/config_component.xml
@@ -1267,6 +1267,23 @@
   <!--  DOMAIN FILES (drv)                                          -->
   <!-- ======================================================================= -->
 
+  <!-- NOTE: the following two entries are only needed because the CTSM LILAC build still -->
+  <!-- uses fatmlndfrc and that is obtained from the following xml variables -->
+  <entry id="LND_DOMAIN_FILE">
+    <type>char</type>
+    <default_value>UNSET</default_value>
+    <group>run_domain</group>
+    <file>env_run.xml</file>
+    <desc>lnd domain file</desc>
+  </entry>
+  <entry id="LND_DOMAIN_PATH">
+    <type>char</type>
+    <default_value>$DIN_LOC_ROOT/share/domains</default_value>
+    <group>run_domain</group>
+    <file>env_run.xml</file>
+    <desc>path of lnd domain file</desc>
+  </entry>
+
   <entry id="ATM_DOMAIN_MESH">
     <type>char</type>
     <default_value>UNSET</default_value>


### PR DESCRIPTION
### Description of changes
changes to get ctsm LILAC mode to work

### Specific notes
This is a minor bugfix that only effects CESM workflow and configurations.
The LND_DOMAIN_FILE and LND_DOMAIN_PATH need to be kept in cime_config/config_component.xml 
until LILAC no longer uses the ctsm namelist variables fatmlndfrc (which is obtained from these xml variables)
Only a LILAC test was performed to verify that this bugfix worked.

Contributors other than yourself, if any:

CMEPS Issues Fixed: None

Are changes expected to change answers?
 - [x] bit for bit
 - [ ] different at roundoff level
 - [ ] more substantial 

Any User Interface Changes (namelist or namelist defaults changes)?
 - [ ] Yes
 - [x] No

Testing performed if application target is CESM:(either UFS-S2S or CESM testing is required):
- [ ] (recommended) CIME_DRIVER=nuopc scripts_regression_tests.py
   - machines:
   - details (e.g. failed tests):
- [ ] (recommended) CESM testlist_drv.xml
   - machines and compilers:
   - details (e.g. failed tests):
- [ ] (optional) CESM prealpha test
   - machines and compilers
   - details (e.g. failed tests):
- [ ] (other) please described in detail
   - machines and compilers
   - details (e.g. failed tests):

Testing performed if application target is UFS-coupled:
- [ ] (recommended) UFS-coupled testing
   - description:
   - details (e.g. failed tests):

Testing performed if application target is UFS-HAFS:
- [ ] (recommended) UFS-HAFS testing
   - description:
   - details (e.g. failed tests):

Hashes used for testing:
- [ ] CESM:
  - repository to check out: https://github.com/ESCOMP/CESM.git
  - branch: nuopc_dev
  - hash:
- [ ] UFS-coupled, then umbrella repostiory to check out and associated hash:
  - repository to check out:
  - branch:
  - hash:
- [ ] UFS-HAFS, then umbrella repostiory to check out and associated hash:
  - repository to check out:
  - branch:
  - hash:
