### PR TITLE
addition of bilnr_cart3d mapping

### DIFF
--- a/mediator/esmFlds.F90
+++ b/mediator/esmFlds.F90
@@ -48,12 +48,13 @@ module esmflds
   integer , public, parameter :: mapnstod_consd    = 7  ! nearest source to destination followed by conservative dst
   integer , public, parameter :: mapnstod_consf    = 8  ! nearest source to destination followed by conservative frac
   integer , public, parameter :: mappatch_uv3d     = 9  ! rotate u,v to 3d cartesian space, map from src->dest, then rotate back
-  integer , public, parameter :: map_rof2ocn_ice   = 10 ! custom smoothing map to map ice from rof->ocn (cesm only)
-  integer , public, parameter :: map_rof2ocn_liq   = 11 ! custom smoothing map to map liq from rof->ocn (cesm only)
-  integer , public, parameter :: map_glc2ocn_liq   = 12 ! custom smoothing map to map liq from glc->ocn (cesm only)
-  integer , public, parameter :: map_glc2ocn_ice   = 13 ! custom smoothing map to map ice from glc->ocn (cesm only)
-  integer , public, parameter :: mapfillv_bilnr    = 14 ! fill value followed by bilinear
-  integer , public, parameter :: nmappers          = 14
+  integer , public, parameter :: mapbilnr_uv3d     = 10 ! rotate u,v to 3d cartesian space, map from src->dest, then rotate back
+  integer , public, parameter :: map_rof2ocn_ice   = 11 ! custom smoothing map to map ice from rof->ocn (cesm only)
+  integer , public, parameter :: map_rof2ocn_liq   = 12 ! custom smoothing map to map liq from rof->ocn (cesm only)
+  integer , public, parameter :: map_glc2ocn_liq   = 13 ! custom smoothing map to map liq from glc->ocn (cesm only)
+  integer , public, parameter :: map_glc2ocn_ice   = 14 ! custom smoothing map to map ice from glc->ocn (cesm only)
+  integer , public, parameter :: mapfillv_bilnr    = 15 ! fill value followed by bilinear
+  integer , public, parameter :: nmappers          = 15
 
   character(len=*) , public, parameter :: mapnames(nmappers) = &
        (/'bilnr      ',&
@@ -65,6 +66,7 @@ module esmflds
          'nstod_consd',&
          'nstod_consf',&
          'patch_uv3d ',&
+         'bilnr_uv3d ',&
          'rof2ocn_ice',&
          'rof2ocn_liq',&
          'glc2ocn_ice',&

--- a/mediator/med_map_mod.F90
+++ b/mediator/med_map_mod.F90
@@ -928,8 +928,6 @@ contains
 
              else if ( trim(packed_data(mapindex)%mapnorm) == 'one' .or. trim(packed_data(mapindex)%mapnorm) == 'none') then
 
-                write(6,*)'DEBUG: maptype = ',mapindex
-
                 ! Mapping with no normalization that is not redistribution
                 call med_map_field (&
                      field_src=packed_data(mapindex)%field_src, &


### PR DESCRIPTION
### Description of changes
addition of bilnr_cart3d mapping

### Specific notes
Addition of bilinear cart3d mapping in addition to patch cart3d. This is used to map u,v from source to destination meshes. This new addition is needed to validate GMOM cases in CESM. 

Contributors other than yourself, if any: None

CMEPS Issues Fixed: None

Are changes expected to change answers?
 - [x] bit for bit
 - [ ] different at roundoff level
 - [ ] more substantial 

Any User Interface Changes (namelist or namelist defaults changes)?
 - [ ] Yes
 - [x] No

Testing performed if application target is CESM:(either UFS-S2S or CESM testing is required):
- [ ] (recommended) CIME_DRIVER=nuopc scripts_regression_tests.py
   - machines:
   - details (e.g. failed tests):
- [ ] (recommended) CESM testlist_drv.xml
   - machines and compilers:
   - details (e.g. failed tests):
- [ ] (optional) CESM prealpha test
   - machines and compilers
   - details (e.g. failed tests):
- [ ] (other) please described in detail
   - machines and compilers
   - details (e.g. failed tests):

Testing performed if application target is UFS-coupled:
- [ ] (recommended) UFS-coupled testing
   - description:
   - details (e.g. failed tests):
Verified that ERS_Vnuopc_Ln9_N3.f19_g17_rx1.A.cheyenne_intel was still bfb with mar14 baselines. Since this was just adding a new mapping I felt that just this test would be good enough to verify that everything is still bfb. 

Testing performed if application target is UFS-HAFS:
- [ ] (recommended) UFS-HAFS testing
   - description:
   - details (e.g. failed tests):

Hashes used for testing:
- [ ] CESM:
  - repository to check out: https://github.com/ESCOMP/CESM.git
  - branch: nuopc_dev
  - hash:
- [ ] UFS-coupled, then umbrella repostiory to check out and associated hash:
  - repository to check out:
  - branch:
  - hash:
- [ ] UFS-HAFS, then umbrella repostiory to check out and associated hash:
  - repository to check out:
  - branch:
  - hash:
