### PR TITLE
update for getting the glc present flag set correctly with nag compiler

### DIFF
--- a/mediator/med.F90
+++ b/mediator/med.F90
@@ -842,9 +842,9 @@ contains
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
     call NUOPC_CompAttributeSet(gcomp, name="rof_present", value=rof_present, rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
-    call NUOPC_CompAttributeSet(gcomp, name="wav_present", value=wav_present, rc=rc)
+    call NUOPC_CompAttributeSet(gcomp, name="wav_present", value=trim(wav_present), rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
-    call NUOPC_CompAttributeSet(gcomp, name="glc_present", value=glc_present, rc=rc)
+    call NUOPC_CompAttributeSet(gcomp, name="glc_present", value=trim(glc_present), rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
     call NUOPC_CompAttributeSet(gcomp, name="med_present", value=med_present, rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
@@ -1790,15 +1790,15 @@ contains
             call ESMF_AttributeGet(gcomp, name="glc_present", value=cvalue, &
                  convention="NUOPC", purpose="Instance", rc=rc)
             if (ChkErr(rc,__LINE__,u_FILE_u)) return
-            if (trim(cvalue) == 'true') then
-               do ns = 1,max_icesheets
-                  if (ns <= num_icesheets) then
+            do ns = 1,max_icesheets
+               if (ns <= num_icesheets) then
+                  if (trim(cvalue) == 'true') then
                      is_local%wrap%comp_present(compglc(ns)) = .true.
                   else
                      is_local%wrap%comp_present(compglc(ns)) = .false.
                   end if
-               end do
-            end if
+               end if
+            end do
          else
             call ESMF_AttributeGet(gcomp, name=trim(compname(n1))//"_present", value=cvalue, &
                  convention="NUOPC", purpose="Instance", rc=rc)


### PR DESCRIPTION
### Description of changes
update for getting the glc present flag set correctly with nag compiler

### Specific notes
The following ctsm test - SMS_D_Ld5_Vnuopc.f10_f10_mg37.I2000Clm50BgcCrop.izumi_nag.clm-irrig_alternate passed on cheyenne with intel but failed on izumi with nag. This bugfix corrects the if-present logic for GLC and permits the test to successfully pass now on izumi.

Contributors other than yourself, if any:

CMEPS Issues Fixed: None

Are changes expected to change answers?
 - [x] bit for bit
 - [ ] different at roundoff level
 - [ ] more substantial 

Any User Interface Changes (namelist or namelist defaults changes)?
 - [ ] Yes
 - [x] No

Testing performed if application target is CESM:(either UFS-S2S or CESM testing is required):
ran SMS_D_Ld5_Vnuopc.f10_f10_mg37.I2000Clm50BgcCrop.izumi_nag.clm-irrig_alternate successfully on izumi.
