### PR TITLE
cesm: bug fix for C1850ECO co2 and additional cesm tests

### DIFF
--- a/cime_config/config_component_cesm.xml
+++ b/cime_config/config_component_cesm.xml
@@ -499,7 +499,8 @@
     <default_value>284.7</default_value>
     <values match="last">
       <value compset="^2000">367.0</value>
-      <value compset="DATM.*POP2%ECO">284.7</value>
+      <value compset="DATM.*_POP2%[^_]*ECO">284.317</value>
+      <value compset="DATM.*_POP2%[^_]*ECOCESM20">284.7</value>
     </values>
     <group>run_co2</group>
     <file>env_run.xml</file>

--- a/cime_config/testdefs/testlist_drv.xml
+++ b/cime_config/testdefs/testlist_drv.xml
@@ -376,7 +376,7 @@
       <option name="wallclock"> 00:20:00 </option>
     </options>
   </test>
-  <test compset="I1850Clm50SpG" grid="T31_g37_gl20" name="ERS_Vnuopc_Ld5" testmods="cism-test_coupling">
+  <test compset="I1850Clm50SpG" grid="f10_f10_mg37" name="ERS_Vnuopc_Lm13">
     <machines>
       <machine name="cheyenne" compiler="intel" category="nuopc"/>
       <machine name="theia" compiler="intel" category="nuopc"/>
@@ -391,7 +391,7 @@
   <!-- TG compsets -->
   <!-- ======================================= -->
 
-  <test name="SMS_D_Ly1_Vnuopc" grid="f09_g17_gl4" compset="T1850G">
+  <test name="SMS_D_Ly1_Vnuopc" grid="f09_g17_gl4" compset="T1850Gg">
     <machines>
       <machine name="cheyenne" compiler="intel" category="nuopc">
         <options>
@@ -400,7 +400,7 @@
       </machine>
     </machines>
   </test>
-  <test name="ERS_Ly3_Vnuopc" grid="f09_g17_gl4" compset="T1850G">
+  <test name="ERS_Ly3_Vnuopc" grid="f09_g17_gl4" compset="T1850Gg">
     <machines>
       <machine name="cheyenne" compiler="intel" category="nuopc">
         <options>


### PR DESCRIPTION
### Description of changes
bug fix for co2 in config_components_cesm.xml and addition of tests to testlist_drv.xml for cesm testing

### Specific notes
This PR only effects the CESM cime_config directory. 

Contributors other than yourself, if any:

CMEPS Issues Fixed: None

Are changes expected to change answers?
 - [x] bit for bit - except for C1850ECO
 - [ ] different at roundoff level
 - [ ] more substantial 

Any User Interface Changes (namelist or namelist defaults changes)?
 - [ ] Yes
 - [x] No

Testing performed if application target is CESM:(either UFS-S2S or CESM testing is required):
No testing was done - since these are just additions to the automated test suite for cesm

