### PR TITLE
add functionality for ocean precip scaling for CESM

### DIFF
--- a/cime_config/namelist_definition_drv.xml
+++ b/cime_config/namelist_definition_drv.xml
@@ -1076,35 +1076,6 @@
     </values>
   </entry>
 
-  <entry id="single_column_domainfile" modify_via_xml="ATM_DOMAIN_FILE">
-    <type>char</type>
-    <category>mapping</category>
-    <group>ALLCOMP_attributes</group>
-    <desc>
-      DOMAIN file needed for single column model
-      A nearest neighbor search is done to match the PTS_LAT and PTS_LON
-      to the closest point in the domain file. This file is ONLY used in
-      single column mode. The mask in this file is the land mask that will be used.
-      The ocean mask is just 1 minus the land mask.
-    </desc>
-    <values>
-      <value>$ATM_DOMAIN_PATH/$ATM_DOMAIN_FILE</value>
-    </values>
-  </entry>
-
-  <entry id="domain_lnd" modify_via_xml="LND_DOMAIN_FILE">
-    <type>char</type>
-    <category>mapping</category>
-    <group>LND_attributes</group>
-    <desc>
-      DOMAIN description of lnd grid - this will be depracated 
-      only here for backwards compatibility
-    </desc>
-    <values>
-      <value>$LND_DOMAIN_PATH/$LND_DOMAIN_FILE</value>
-    </values>
-  </entry>
-
   <entry id="mesh_atm" modify_via_xml="ATM_DOMAIN_MESH">
     <type>char</type>
     <category>mapping</category>

--- a/cime_config/namelist_definition_drv.xml
+++ b/cime_config/namelist_definition_drv.xml
@@ -1666,7 +1666,7 @@
       total number of scalars in the scalar coupling field
     </desc>
     <values>
-      <value>5</value>
+      <value>4</value>
     </values>
   </entry>
 
@@ -1714,8 +1714,8 @@
       index of scalar containing epbal precipitation factor from ocn (only for POP)
     </desc>
     <values>
-      <value flux_epbal='off'>0</value>
-      <value flux_epbal="ocn">5</value>
+      <value COMP_OCN="pop">4</value>
+      <value>0</value>
     </values>
   </entry>
 

--- a/cime_config/namelist_definition_drv.xml
+++ b/cime_config/namelist_definition_drv.xml
@@ -1076,6 +1076,35 @@
     </values>
   </entry>
 
+  <entry id="single_column_domainfile" modify_via_xml="ATM_DOMAIN_FILE">
+    <type>char</type>
+    <category>mapping</category>
+    <group>ALLCOMP_attributes</group>
+    <desc>
+      DOMAIN file needed for single column model
+      A nearest neighbor search is done to match the PTS_LAT and PTS_LON
+      to the closest point in the domain file. This file is ONLY used in
+      single column mode. The mask in this file is the land mask that will be used.
+      The ocean mask is just 1 minus the land mask.
+    </desc>
+    <values>
+      <value>$ATM_DOMAIN_PATH/$ATM_DOMAIN_FILE</value>
+    </values>
+  </entry>
+
+  <entry id="domain_lnd" modify_via_xml="LND_DOMAIN_FILE">
+    <type>char</type>
+    <category>mapping</category>
+    <group>LND_attributes</group>
+    <desc>
+      DOMAIN description of lnd grid - this will be depracated 
+      only here for backwards compatibility
+    </desc>
+    <values>
+      <value>$LND_DOMAIN_PATH/$LND_DOMAIN_FILE</value>
+    </values>
+  </entry>
+
   <entry id="mesh_atm" modify_via_xml="ATM_DOMAIN_MESH">
     <type>char</type>
     <category>mapping</category>

--- a/cime_config/namelist_definition_drv.xml
+++ b/cime_config/namelist_definition_drv.xml
@@ -1643,7 +1643,7 @@
   <!-- </entry> -->
 
   <!-- =========================== -->
-  <!-- MED attributes              -->
+  <!-- ALLCOMP attributes          -->
   <!-- =========================== -->
 
   <entry id="ScalarFieldName">

--- a/mediator/med.F90
+++ b/mediator/med.F90
@@ -905,7 +905,7 @@ contains
     if (isPresent .and. isSet) then
        read(cvalue,*) is_local%wrap%flds_scalar_index_precip_factor
     else
-       is_local%wrap%flds_scalar_index_precip_factor = spval
+       is_local%wrap%flds_scalar_index_precip_factor = 0
     end if
 
     !------------------

--- a/mediator/med_constants_mod.F90
+++ b/mediator/med_constants_mod.F90
@@ -11,6 +11,6 @@ module med_constants_mod
   real(R8), parameter :: med_constants_czero           = 0.0_R8  ! spval
   integer,  parameter :: med_constants_ispval_mask     = -987987 ! spval for RH mask values
   integer,  parameter :: med_constants_SecPerDay       = 86400   ! Seconds per day
-  integer             :: med_constants_dbug_flag       = 15
+  integer             :: med_constants_dbug_flag       = 0
 
 end module med_constants_mod

--- a/mediator/med_constants_mod.F90
+++ b/mediator/med_constants_mod.F90
@@ -11,6 +11,6 @@ module med_constants_mod
   real(R8), parameter :: med_constants_czero           = 0.0_R8  ! spval
   integer,  parameter :: med_constants_ispval_mask     = -987987 ! spval for RH mask values
   integer,  parameter :: med_constants_SecPerDay       = 86400   ! Seconds per day
-  integer             :: med_constants_dbug_flag       = 0
+  integer             :: med_constants_dbug_flag       = 15
 
 end module med_constants_mod

--- a/mediator/med_internalstate_mod.F90
+++ b/mediator/med_internalstate_mod.F90
@@ -62,6 +62,7 @@ module med_internalstate_mod
     integer                :: flds_scalar_index_ny = 0
     integer                :: flds_scalar_index_nextsw_cday = 0
     integer                :: flds_scalar_index_precip_factor = 0
+    real(r8)               :: flds_scalar_precip_factor = 1._r8  ! actual value of precip factor from ocn
 
     ! Import/export States and field bundles (the field bundles have the scalar fields removed)
     type(ESMF_State)       :: NStateImp(ncomps)                  ! Import data from various component, on their grid

--- a/mediator/med_io_mod.F90
+++ b/mediator/med_io_mod.F90
@@ -1053,7 +1053,6 @@ contains
        do k = 1,nf
           call FB_getNameN(FB, k, itemc, rc=rc)
           if (chkerr(rc,__LINE__,u_FILE_u)) return
-          write(6,*)'DEBUG: k,itemc= ',k,trim(itemc)
  
           call FB_getFldPtr(FB, itemc, &
                fldptr1=fldptr1, fldptr2=fldptr2, rank=rank, rc=rc)

--- a/mediator/med_io_mod.F90
+++ b/mediator/med_io_mod.F90
@@ -1053,7 +1053,8 @@ contains
        do k = 1,nf
           call FB_getNameN(FB, k, itemc, rc=rc)
           if (chkerr(rc,__LINE__,u_FILE_u)) return
-
+          write(6,*)'DEBUG: k,itemc= ',k,trim(itemc)
+ 
           call FB_getFldPtr(FB, itemc, &
                fldptr1=fldptr1, fldptr2=fldptr2, rank=rank, rc=rc)
           if (chkerr(rc,__LINE__,u_FILE_u)) return

--- a/mediator/med_phases_prep_ice_mod.F90
+++ b/mediator/med_phases_prep_ice_mod.F90
@@ -29,6 +29,7 @@ contains
     use ESMF                  , only : ESMF_FieldBundleGet, ESMF_FieldGet, ESMF_Field
     use ESMF                  , only : ESMF_LOGMSG_ERROR, ESMF_FAILURE
     use ESMF                  , only : ESMF_StateItem_Flag, ESMF_STATEITEM_NOTFOUND
+    use ESMF                  , only : ESMF_VMBroadCast 
     use med_utils_mod         , only : chkerr       => med_utils_ChkErr
     use med_methods_mod       , only : FB_fldchk    => med_methods_FB_FldChk
     use med_methods_mod       , only : FB_diagnose  => med_methods_FB_diagnose
@@ -46,12 +47,12 @@ contains
     integer, intent(out) :: rc
 
     ! local variables
-    type(ESMF_StateItem_Flag)      :: itemType
     type(InternalState)            :: is_local
     type(ESMF_Field)               :: lfield
     integer                        :: i,n
-    real(R8), pointer              :: dataptr1d(:) => null()
-    real(R8)                       :: precip_fact
+    real(R8), pointer              :: dataptr(:) => null()
+    real(R8), pointer              :: dataptr_scalar_ocn(:,:) => null()
+    real(R8)                       :: precip_fact(1)
     character(len=CS)              :: cvalue
     character(len=64), allocatable :: fldnames(:)
     real(r8)                       :: nextsw_cday
@@ -88,14 +89,47 @@ contains
          fldListTo(compice), rc=rc)
     if (chkerr(rc,__LINE__,u_FILE_u)) return
 
-    ! apply precipitation factor from ocean if appropriate
+    ! Apply precipitation factor from ocean (that scales atm rain and snow to ice) if appropriate
     if (trim(coupling_mode) == 'cesm' .and. is_local%wrap%flds_scalar_index_precip_factor /= 0) then
+
+       ! Note that in med_internal_mod.F90 all is_local%wrap%flds_scalar_index_precip_factor 
+       ! is initialized to 0.
+       ! In addition, in med.F90, if this attribute is not present as a mediator component attribute, 
+       ! it is set to 0. 
+       if (mastertask) then
+          call ESMF_StateGet(is_local%wrap%NstateImp(compocn), & 
+               itemName=trim(is_local%wrap%flds_scalar_name), field=lfield, rc=rc)
+          if (chkerr(rc,__LINE__,u_FILE_u)) return
+          call ESMF_FieldGet(lfield, farrayPtr=dataptr_scalar_ocn, rc=rc)
+          if (chkerr(rc,__LINE__,u_FILE_u)) return
+          scalar_id=is_local%wrap%flds_scalar_index_precip_factor
+          precip_fact(1) = dataptr_scalar_ocn(scalar_id,1)
+          if (first_call) then
+             write(logunit,'(a)')'(merge_to_ice): Scaling rain, snow, liquid and ice runoff by precip_fact from ocn'
+             first_call = .false.
+          end if
+          if (precip_fact(1) /= 1._r8) then
+             write(logunit,'(a,f21.13)')&
+                  '(merge_to_ice): Scaling rain, snow, liquid and ice runoff by non-unity precip_fact ',&
+                  precip_fact(1)
+          end if
+       end if
+       call ESMF_VMBroadCast(is_local%wrap%vm, precip_fact, 1, 0, rc=rc)
+       if (chkerr(rc,__LINE__,u_FILE_u)) return
+       is_local%wrap%flds_scalar_precip_factor = precip_fact(1)      
+       if (dbug_flag > 5) then
+          write(cvalue,*) precip_fact(1)
+          call ESMF_LogWrite(trim(subname)//" precip_fact is "//trim(cvalue), ESMF_LOGMSG_INFO)
+       end if
+
+       ! Scale rain and snow to ice from atm by the precipitation factor received from the ocean
+       allocate(fldnames(3))
        fldnames = (/'Faxa_rain', 'Faxa_snow', 'Fixx_rofi'/)
        do n = 1,size(fldnames)
           if (FB_fldchk(is_local%wrap%FBExp(compice), trim(fldnames(n)), rc=rc)) then
-             call FB_GetFldPtr(is_local%wrap%FBExp(compocn), trim(fldnames(n)), dataptr1d, rc=rc)
+             call FB_GetFldPtr(is_local%wrap%FBExp(compice), trim(fldnames(n)), dataptr, rc=rc)
              if (ChkErr(rc,__LINE__,u_FILE_u)) return
-             dataptr1d(:) = dataptr1d(:) * is_local%wrap%flds_scalar_precip_factor
+             dataptr(:) = dataptr(:) * is_local%wrap%flds_scalar_precip_factor
           end if
        end do
        deallocate(fldnames)

--- a/mediator/med_phases_prep_ocn_mod.F90
+++ b/mediator/med_phases_prep_ocn_mod.F90
@@ -440,6 +440,10 @@ contains
     ! application of precipitation factor from ocean
     !---------------------------------------
     if (is_local%wrap%flds_scalar_index_precip_factor /= 0) then
+       ! Note that in med_internal_mod.F90 all is_local%wrap%flds_scalar_index_precip_factor 
+       ! is initialized to 0.
+       ! In addition, in med.F90, if this attribute is not present as a mediator component attribute, 
+       ! it is set to 0. 
        if (mastertask) then
           call ESMF_StateGet(is_local%wrap%NstateImp(compocn), & 
                itemName=trim(is_local%wrap%flds_scalar_name), field=lfield, rc=rc)
@@ -462,6 +466,8 @@ contains
           write(cvalue,*) precip_fact(1)
           call ESMF_LogWrite(trim(subname)//" precip_fact is "//trim(cvalue), ESMF_LOGMSG_INFO)
        end if
+
+       ! Scale rain and snow from atm by the precipitation factor received from the ocean
        allocate(fldnames(4))
        fldnames = (/'Faxa_rain', 'Faxa_snow', 'Foxx_rofl', 'Foxx_rofi'/)
        do n = 1,size(fldnames)


### PR DESCRIPTION
### Description of changes
This change only effects CESM compsets

### Specific notes
This adds the capability currently only activated by CESM C and G compsets (with POP not MOM) to have a precip factor sent by POP to the mediator that is then applied to scale atmosphere rain and snow going back to the ocean and sea-ice (in this case POP and CICE/DICE). In the current testing, the precip factor was only set to 1 by POP - as a result, this PR does not change any baselines.

Contributors other than yourself, if any:

CMEPS Issues Fixed: None

Are changes expected to change answers?
 - [x] bit for bit
 - [ ] different at roundoff level
 - [ ] more substantial 

Any User Interface Changes (namelist or namelist defaults changes)?
 - [ ] Yes
 - [x] No

Testing performed if application target is CESM:(either UFS-S2S or CESM testing is required):
- Verified manually that for SMS_Ld1_Vnuopc.T62_g17.G.cheyenne_intel.pop-default, the scaling factor to the mediator and that was set correctly in med_phases_prep_ocn_mod.F90 and that the results were bfb
- Verified that SMS_Vnuopc_Ld5.T62_t061.GMOM.cheyenne_intel was bfb before and after this change.

