### PR TITLE
fix setting of scol_spval for single column functionality 

### DIFF
--- a/drivers/cime/esm.F90
+++ b/drivers/cime/esm.F90
@@ -1266,6 +1266,8 @@ contains
     read(cvalue,*) scol_lat
     call NUOPC_CompAttributeGet(gcomp, name='single_column_lnd_domainfile', value=single_column_lnd_domainfile, rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
+    call NUOPC_CompAttributeAdd(gcomp, attrList=(/'scol_spval'/), rc=rc)
+    if (chkerr(rc,__LINE__,u_FILE_u)) return
 
     if ( (scol_lon < scol_spval .and. scol_lat > scol_spval) .or. &
          (scol_lon > scol_spval .and. scol_lat < scol_spval)) then
@@ -1307,8 +1309,7 @@ contains
                        'scol_lndmask', &
                        'scol_lndfrac', &
                        'scol_ocnmask', &
-                       'scol_ocnfrac', &
-                       'scol_spval  '/), rc=rc)
+                       'scol_ocnfrac'/), rc=rc)
        if (chkerr(rc,__LINE__,u_FILE_u)) return
 
        if (trim(single_column_lnd_domainfile) /= 'UNSET') then


### PR DESCRIPTION
### Description of changes
Fix setting of scol_spval for single column functionality 

### Specific notes
This is a simple fix for CESM single column functionality. This ONLY effects the CESM NUOPC driver code.

Contributors other than yourself, if any:

CMEPS Issues Fixed: None

Are changes expected to change answers?
 - [x] bit for bit
 - [ ] different at roundoff level
 - [ ] more substantial 

Any User Interface Changes (namelist or namelist defaults changes)?
 - [ ] Yes
 - [x] No

Testing performed if application target is CESM:(either UFS-S2S or CESM testing is required):
    validated that SMS_D_Ln9_Vnuopc.T42_T42.FSCAM.cheyenne_intel.cam-scam_mpace_outfrq9s now works using cesm2_3_alpah02d hash

Hashes used for testing:
- [ ] CESM:
  - repository to check out: https://github.com/ESCOMP/CESM.git
  - hash: tag for cesm2_3_alpah02d

