### PR TITLE
fixes to land ice runoff in budget table

### DIFF
--- a/mediator/med_phases_prep_ice_mod.F90
+++ b/mediator/med_phases_prep_ice_mod.F90
@@ -58,7 +58,6 @@ contains
     real(r8)                       :: nextsw_cday
     integer                        :: scalar_id
     real(r8)                       :: tmp(1)
-    logical                        :: first_call = .true.
     logical                        :: first_precip_fact_call = .true.
     character(len=*),parameter     :: subname='(med_phases_prep_ice)'
     !---------------------------------------
@@ -104,10 +103,6 @@ contains
           if (chkerr(rc,__LINE__,u_FILE_u)) return
           scalar_id=is_local%wrap%flds_scalar_index_precip_factor
           precip_fact(1) = dataptr_scalar_ocn(scalar_id,1)
-          if (first_call) then
-             write(logunit,'(a)')'(merge_to_ice): Scaling rain, snow, liquid and ice runoff by precip_fact from ocn'
-             first_call = .false.
-          end if
           if (precip_fact(1) /= 1._r8) then
              write(logunit,'(a,f21.13)')&
                   '(merge_to_ice): Scaling rain, snow, liquid and ice runoff by non-unity precip_fact ',&
@@ -155,9 +150,6 @@ contains
        call FB_diagnose(is_local%wrap%FBExp(compice), string=trim(subname)//' FBexp(compice) ', rc=rc)
        if (chkerr(rc,__LINE__,u_FILE_u)) return
     end if
-
-    ! Set first call logical to false
-    first_call = .false.
 
     if (dbug_flag > 5) then
        call ESMF_LogWrite(trim(subname)//": done", ESMF_LOGMSG_INFO)

--- a/mediator/med_phases_prep_ocn_mod.F90
+++ b/mediator/med_phases_prep_ocn_mod.F90
@@ -243,7 +243,6 @@ contains
     integer             :: n
     integer             :: lsize
     real(R8)            :: c1,c2,c3,c4
-    logical             :: first_call = .true.
     character(len=64), allocatable :: fldnames(:)
     character(len=*), parameter    :: subname='(med_phases_prep_ocn_custom_cesm)'
     !---------------------------------------
@@ -451,10 +450,6 @@ contains
           if (chkerr(rc,__LINE__,u_FILE_u)) return
           scalar_id=is_local%wrap%flds_scalar_index_precip_factor
           precip_fact(1) = dataptr_scalar_ocn(scalar_id,1)
-          if (first_call) then
-             write(logunit,'(a)')'(merge_to_ocn): Scaling rain, snow, liquid and ice runoff by precip_fact from ocn'
-             first_call = .false.
-          end if
           if (precip_fact(1) /= 1._r8) then
              write(logunit,'(a,f21.13)')&
                   '(merge_to_ocn): Scaling rain, snow, liquid and ice runoff by non-unity precip_fact ',&


### PR DESCRIPTION
### Description of changes
This fixes the budget table to have the correct land ice runoff value and balance the runoff sent to the ocean.

### Specific notes
This PR does not affect any UFS configuration, since the UFS does not use the budget tables at this point.

Contributors other than yourself, if any:

CMEPS Issues Fixed:
Fixes #179 

Are changes expected to change answers?
 - [x] bit for bit
 - [ ] different at roundoff level
 - [ ] more substantial 

Any User Interface Changes (namelist or namelist defaults changes)?
 - [ ] Yes
 - [x] No

Testing performed if application target is CESM:(either UFS-S2S or CESM testing is required):
Ran a B1850 f19_g17 case for 3 months and verified that the budget table looked correct with this term

Testing performed if application target is UFS-coupled:
- [ ] (recommended) UFS-coupled testing
   - description:
   - details (e.g. failed tests):

Hashes used for testing:
- [x] CESM:
  - repository to check out: https://github.com/ESCOMP/CESM.git
  - branch: master
  - tag: cesm2_3_beta02

