### PR TITLE
Feature/multiple icesheet update

### DIFF
--- a/cime_config/namelist_definition_drv.xml
+++ b/cime_config/namelist_definition_drv.xml
@@ -1694,6 +1694,18 @@
     </values>
   </entry>
 
+  <entry id="num_icesheets">
+    <type>integer</type>
+    <category>expdef</category>
+    <group>ALLCOMP_attributes</group>
+    <desc>
+      number of glc ice sheets
+    </desc>
+    <values>
+      <value>1</value>
+    </values>
+  </entry>
+
   <entry id="mapuv_with_cart3d">
     <type>logical</type>
     <category>mapping</category>

--- a/mediator/esmFlds.F90
+++ b/mediator/esmFlds.F90
@@ -17,7 +17,8 @@ module esmflds
   integer, public, parameter  :: comprof  = 6
   integer, public, parameter  :: compwav  = 7
   integer, public, parameter  :: compglc1 = 8
-  integer, public, parameter  :: ncomps   = 8
+  integer, public, parameter  :: compglc2 = 9
+  integer, public, parameter  :: ncomps   = 9
 
   character(len=*), public, parameter :: compname(ncomps) = &
        (/'med ',&
@@ -27,11 +28,12 @@ module esmflds
          'ice ',&
          'rof ',&
          'wav ',&
-         'glc '/)
+         'glc1',&
+         'glc2'/)
 
-  integer, public, parameter :: max_icesheets = 1
-  integer, public :: compglc(max_icesheets) = (/compglc1/)
-  integer, public :: num_icesheets = 1
+  integer, public, parameter :: max_icesheets = 2
+  integer, public :: compglc(max_icesheets) = (/compglc1,compglc2/)
+  integer, public :: num_icesheets     ! obtained from attribute
   logical, public :: ocn2glc_coupling  ! obtained from attribute
 
   logical, public :: dststatus_print = .false.

--- a/mediator/med.F90
+++ b/mediator/med.F90
@@ -651,6 +651,7 @@ contains
     ! TransferOfferGeomObject Attribute.
 
     use ESMF  , only : ESMF_GridComp, ESMF_State, ESMF_Clock, ESMF_SUCCESS, ESMF_LogFoundAllocError
+    use ESMF  , only : ESMF_StateIsCreated 
     use ESMF  , only : ESMF_LogMsg_Info, ESMF_LogWrite
     use ESMF  , only : ESMF_END_ABORT, ESMF_Finalize
     use NUOPC , only : NUOPC_AddNamespace, NUOPC_Advertise, NUOPC_AddNestedState
@@ -959,7 +960,8 @@ contains
                 call ESMF_LogWrite(subname//':To_'//trim(compname(ncomp))//': '//trim(shortname), ESMF_LOGMSG_INFO)
              end do
           end if
-       end do ! end of ncomps loop
+       end if
+    end do ! end of ncomps loop
 
     if (profile_memory) call ESMF_VMLogMemInfo("Leaving "//trim(subname))
     call ESMF_LogWrite(trim(subname)//": done", ESMF_LOGMSG_INFO)

--- a/mediator/med.F90
+++ b/mediator/med.F90
@@ -731,6 +731,14 @@ contains
          nestedState=is_local%wrap%NStateExp(compwav), rc=rc)
 
     ! Only create nested states for active ice sheets
+    call NUOPC_CompAttributeGet(gcomp, name='num_icesheets', value=cvalue, &
+         isPresent=isPresent, isSet=isSet, rc=rc)
+    if (chkerr(rc,__LINE__,u_FILE_u)) return
+    if (isPresent .and. isSet) then
+       read(cvalue,*) num_icesheets
+    else
+       num_icesheets = 0
+    end if
     do ns = 1,num_icesheets
        write(cnum,'(i0)') ns
        call NUOPC_AddNestedState(importState, CplSet="GLC"//trim(cnum), &
@@ -915,41 +923,43 @@ contains
     do ncomp = 1,ncomps
        if (ncomp /= compmed) then
           if (mastertask) write(logunit,*)
-          nflds = med_fldList_GetNumFlds(fldListFr(ncomp))
-          do n = 1,nflds
-             call med_fldList_GetFldInfo(fldListFr(ncomp), n, stdname, shortname)
-             if (mastertask) then
-                write(logunit,'(a)') trim(subname)//':Fr_'//trim(compname(ncomp))//': '//trim(shortname)
-             end if
-             if (trim(shortname) == is_local%wrap%flds_scalar_name) then
-                transferOffer = 'will provide'
-             else
-                transferOffer = 'cannot provide'
-             end if
-             call NUOPC_Advertise(is_local%wrap%NStateImp(ncomp), standardName=stdname, shortname=shortname, name=shortname, &
-                  TransferOfferGeomObject=transferOffer, rc=rc)
-             if (ChkErr(rc,__LINE__,u_FILE_u)) return
-             call ESMF_LogWrite(subname//':Fr_'//trim(compname(ncomp))//': '//trim(shortname), ESMF_LOGMSG_INFO)
-          end do
-
-          nflds = med_fldList_GetNumFlds(fldListTo(ncomp))
-          do n = 1,nflds
-             call med_fldList_GetFldInfo(fldListTo(ncomp), n, stdname, shortname)
-             if (mastertask) then
-                write(logunit,'(a)') trim(subname)//':To_'//trim(compname(ncomp))//': '//trim(shortname)
-             end if
-             if (trim(shortname) == is_local%wrap%flds_scalar_name) then
-                transferOffer = 'will provide'
-             else
-                transferOffer = 'cannot provide'
-             end if
-             call NUOPC_Advertise(is_local%wrap%NStateExp(ncomp), standardName=stdname, shortname=shortname, name=shortname, &
-                  TransferOfferGeomObject=transferOffer, rc=rc)
-             if (ChkErr(rc,__LINE__,u_FILE_u)) return
-             call ESMF_LogWrite(subname//':To_'//trim(compname(ncomp))//': '//trim(shortname), ESMF_LOGMSG_INFO)
-          end do
-       end if
-    end do ! end of ncomps loop
+          if (ESMF_StateIsCreated(is_local%wrap%NStateImp(ncomp))) then
+             nflds = med_fldList_GetNumFlds(fldListFr(ncomp))
+             do n = 1,nflds
+                call med_fldList_GetFldInfo(fldListFr(ncomp), n, stdname, shortname)
+                if (mastertask) then
+                   write(logunit,'(a)') trim(subname)//':Fr_'//trim(compname(ncomp))//': '//trim(shortname)
+                end if
+                if (trim(shortname) == is_local%wrap%flds_scalar_name) then
+                   transferOffer = 'will provide'
+                else
+                   transferOffer = 'cannot provide'
+                end if
+                call NUOPC_Advertise(is_local%wrap%NStateImp(ncomp), standardName=stdname, shortname=shortname, name=shortname, &
+                     TransferOfferGeomObject=transferOffer, rc=rc)
+                if (ChkErr(rc,__LINE__,u_FILE_u)) return
+                call ESMF_LogWrite(subname//':Fr_'//trim(compname(ncomp))//': '//trim(shortname), ESMF_LOGMSG_INFO)
+             end do
+          end if
+          if (ESMF_StateIsCreated(is_local%wrap%NStateExp(ncomp))) then
+             nflds = med_fldList_GetNumFlds(fldListTo(ncomp))
+             do n = 1,nflds
+                call med_fldList_GetFldInfo(fldListTo(ncomp), n, stdname, shortname)
+                if (mastertask) then
+                   write(logunit,'(a)') trim(subname)//':To_'//trim(compname(ncomp))//': '//trim(shortname)
+                end if
+                if (trim(shortname) == is_local%wrap%flds_scalar_name) then
+                   transferOffer = 'will provide'
+                else
+                   transferOffer = 'cannot provide'
+                end if
+                call NUOPC_Advertise(is_local%wrap%NStateExp(ncomp), standardName=stdname, shortname=shortname, name=shortname, &
+                     TransferOfferGeomObject=transferOffer, rc=rc)
+                if (ChkErr(rc,__LINE__,u_FILE_u)) return
+                call ESMF_LogWrite(subname//':To_'//trim(compname(ncomp))//': '//trim(shortname), ESMF_LOGMSG_INFO)
+             end do
+          end if
+       end do ! end of ncomps loop
 
     if (profile_memory) call ESMF_VMLogMemInfo("Leaving "//trim(subname))
     call ESMF_LogWrite(trim(subname)//": done", ESMF_LOGMSG_INFO)


### PR DESCRIPTION
### Description of changes
Changes to actually send 2 ice sheets from CISM

### Specific notes
Verified that sending two identical ice sheets from CISM to the mediator had the mediator recognize them as separate but identical. This was with a TG compset.

Contributors other than yourself, if any:

CMEPS Issues Fixed: None

Are changes expected to change answers?
 - [x] bit for bit
 - [ ] different at roundoff level
 - [ ] more substantial

Any User Interface Changes (namelist or namelist defaults changes)?
 - [ ] Yes
 - [x] No

Testing performed if application target is CESM:(either UFS-S2S or CESM testing is required):
aux_cism  test suite was run with nuopc with this change and was successful. 

Hashes used for testing:
- [x] CISM checkout using externals
  - repository to check out: https://github.com/escomp/cism-wrapper
  - tag:  cismwrap_2_1_81
  

