### PR TITLE
Bug fixes for CESM 1850 mct/nuopc validation

### DIFF
--- a/cime_config/runseq/runseq_general.py
+++ b/cime_config/runseq/runseq_general.py
@@ -100,7 +100,6 @@ def gen_runseq(case, coupling_times):
 
         runseq.add_action("MED med_phases_prep_ice"         , med_to_ice)
         runseq.add_action("MED -> ICE :remapMethod=redist"  , med_to_ice)
-        runseq.add_action("MED med_phases_diag_ice_med2ice" , run_ice and diag_mode)
 
         runseq.add_action("MED med_phases_prep_wav"        , med_to_wav)
         runseq.add_action("MED -> WAV :remapMethod=redist" , med_to_wav)
@@ -132,9 +131,12 @@ def gen_runseq(case, coupling_times):
 
         runseq.add_action("LND -> MED :remapMethod=redist"  , run_lnd)
         runseq.add_action("MED med_phases_post_lnd"         , run_lnd)
+        runseq.add_action("MED med_phases_diag_lnd"         , run_lnd and diag_mode)
+        runseq.add_action("MED med_phases_diag_rof"         , run_rof and diag_mode)
+        runseq.add_action("MED med_phases_diag_ice_ice2med" , run_ice and diag_mode)
+        runseq.add_action("MED med_phases_diag_glc"         , run_glc and diag_mode)
 
         runseq.add_action("ICE -> MED :remapMethod=redist"  , run_ice)
-        runseq.add_action("MED med_phases_diag_ice_ice2med" , run_ice and diag_mode)
         runseq.add_action("MED med_phases_post_ice"         , run_ice)
 
         runseq.add_action("MED med_phases_prep_atm"         , med_to_atm)
@@ -142,6 +144,8 @@ def gen_runseq(case, coupling_times):
         runseq.add_action("ATM"                             , run_atm)
         runseq.add_action("ATM -> MED :remapMethod=redist"  , run_atm)
         runseq.add_action("MED med_phases_post_atm"         , run_atm)
+        runseq.add_action("MED med_phases_diag_atm"         , run_atm and diag_mode)
+        runseq.add_action("MED med_phases_diag_ice_med2ice" , run_ice and diag_mode)
 
         runseq.add_action("WAV -> MED :remapMethod=redist", run_wav)
         runseq.add_action("MED med_phases_post_wav"       , run_wav)
@@ -149,10 +153,6 @@ def gen_runseq(case, coupling_times):
         runseq.add_action("ROF -> MED :remapMethod=redist", run_rof and not rof_outer_loop)
         runseq.add_action("MED med_phases_post_rof"       , run_rof and not rof_outer_loop)
 
-        runseq.add_action("MED med_phases_diag_atm"   , run_atm and diag_mode)
-        runseq.add_action("MED med_phases_diag_lnd"   , run_lnd and diag_mode)
-        runseq.add_action("MED med_phases_diag_rof"   , run_rof and diag_mode)
-        runseq.add_action("MED med_phases_diag_glc"   , run_glc and diag_mode)
         runseq.add_action("MED med_phases_diag_accum" , diag_mode)
         runseq.add_action("MED med_phases_diag_print" , diag_mode)
 

--- a/mediator/med_diag_mod.F90
+++ b/mediator/med_diag_mod.F90
@@ -2325,8 +2325,6 @@ contains
     ice_area_sh = data(f_area,c_ish_recv,ip)
     sum_area    = atm_area + lnd_area + ocn_area + ice_area_nh + ice_area_sh
     write(diagunit,FA1) budget_diags%fields(f_area)%name, atm_area, lnd_area, ocn_area, ice_area_nh, ice_area_sh, sum_area
-    write(diagUnit,*) 'counter: ',budget_counter(f_area, c_atm_recv, ip)
-
     ! write out net heat budgets
 
     write(diagunit,*) ' '


### PR DESCRIPTION
### Description of changes

Bug fixes for CESM 1850 mct/nuopc validation - including memory leak in med_diag_mod.F90.

### Specific notes
These are changes needed to the budgets and run sequence needed that were needed to fix problems in the B1850 mct/nuopc validation.

Contributors other than yourself, if any: @jedwards4b 

CMEPS Issues Fixed: #190 #197 

Are changes expected to change answers?
 - [x] bit for bit

Any User Interface Changes (namelist or namelist defaults changes)?
 - [x] No

Testing performed if application target is CESM:(either UFS-S2S or CESM testing is required):
5 year B1850 1 year simulation was run

Hashes used for testing:
- [x] CESM: 
  - repository to check out: https://github.com/ESCOMP/CESM.git
  - tag: cesm2_3_alpha03a

