### PR TITLE
Remove unused namelist variables

### DIFF
--- a/cime_config/config_component.xml
+++ b/cime_config/config_component.xml
@@ -1192,6 +1192,9 @@
     <desc>glacier (glc) grid - DO NOT EDIT (for experts only)</desc>
   </entry>
 
+  <!-- GLC_NX and GLC_NY are only needed by xglc. These variables do not
+       accommodate multiple ice sheet grids, but that's okay for now,
+       since xglc currently only runs on a single ice sheet grid.-->
   <entry id="GLC_NX">
     <type>integer</type>
     <default_value>0</default_value>
@@ -1199,7 +1202,6 @@
     <file>env_build.xml</file>
     <desc>number of glc cells in i direction - DO NOT EDIT (for experts only)</desc>
   </entry>
-
   <entry id="GLC_NY">
     <type>integer</type>
     <default_value>0</default_value>
@@ -1207,7 +1209,6 @@
     <file>env_build.xml</file>
     <desc>number of glc cells in j direction - DO NOT EDIT (for experts only)</desc>
   </entry>
-
 
   <entry id="WAV_GRID">
     <type>char</type>

--- a/cime_config/config_component.xml
+++ b/cime_config/config_component.xml
@@ -1433,22 +1433,6 @@
     <desc>lnd2atm state mapping file</desc>
   </entry>
 
-  <entry id="LND2GLC_FMAPNAME">
-    <type>char</type>
-    <default_value>idmap</default_value>
-    <group>run_domain</group>
-    <file>env_run.xml</file>
-    <desc>lnd2glc flux mapping file</desc>
-  </entry>
-
-  <entry id="LND2GLC_SMAPNAME">
-    <type>char</type>
-    <default_value>idmap</default_value>
-    <group>run_domain</group>
-    <file>env_run.xml</file>
-    <desc>lnd2glc state mapping file</desc>
-  </entry>
-
   <entry id="LND2ROF_FMAPNAME">
     <type>char</type>
     <default_value>idmap</default_value>
@@ -1487,22 +1471,6 @@
     <group>run_domain</group>
     <file>env_run.xml</file>
     <desc>rof2ocn runoff mapping file</desc>
-  </entry>
-
-  <entry id="GLC2LND_FMAPNAME">
-    <type>char</type>
-    <default_value>idmap</default_value>
-    <group>run_domain</group>
-    <file>env_run.xml</file>
-    <desc>glc2lnd flux mapping file</desc>
-  </entry>
-
-  <entry id="GLC2LND_SMAPNAME">
-    <type>char</type>
-    <default_value>idmap</default_value>
-    <group>run_domain</group>
-    <file>env_run.xml</file>
-    <desc>glc2lnd state mapping file</desc>
   </entry>
 
   <entry id="GLC2ICE_RMAPNAME">

--- a/cime_config/namelist_definition_drv.xml
+++ b/cime_config/namelist_definition_drv.xml
@@ -2005,58 +2005,6 @@
     </values>
   </entry>
 
-  <entry id="lnd2glc_fmapname"    modify_via_xml="LND2GLC_FMAPNAME">
-    <type>char</type>
-    <category>mapping</category>
-    <input_pathname>abs</input_pathname>
-    <group>MED_attributes</group>
-    <desc>
-      land to glc mapping file for fluxes
-    </desc>
-    <values>
-      <value>$LND2GLC_FMAPNAME</value>
-    </values>
-  </entry>
-
-  <entry id="lnd2glc_smapname"    modify_via_xml="LND2GLC_SMAPNAME">
-    <type>char</type>
-    <category>mapping</category>
-    <input_pathname>abs</input_pathname>
-    <group>MED_attributes</group>
-    <desc>
-      land to glc mapping file for states
-    </desc>
-    <values>
-      <value>$LND2GLC_SMAPNAME</value>
-    </values>
-  </entry>
-
-  <entry id="glc2lnd_fmapname"    modify_via_xml="GLC2LND_FMAPNAME">
-    <type>char</type>
-    <category>mapping</category>
-    <input_pathname>abs</input_pathname>
-    <group>MED_attributes</group>
-    <desc>
-      glc to land mapping file for fluxes
-    </desc>
-    <values>
-      <value>$GLC2LND_FMAPNAME</value>
-    </values>
-  </entry>
-
-  <entry id="glc2lnd_smapname"    modify_via_xml="GLC2LND_SMAPNAME">
-    <type>char</type>
-    <category>mapping</category>
-    <input_pathname>abs</input_pathname>
-    <group>MED_attributes</group>
-    <desc>
-      glc to land mapping file for states
-    </desc>
-    <values>
-      <value>$GLC2LND_SMAPNAME</value>
-    </values>
-  </entry>
-
   <entry id="atm2wav_smapname"    modify_via_xml="ATM2WAV_SMAPNAME">
     <type>char</type>
     <category>mapping</category>

--- a/cime_config/namelist_definition_drv.xml
+++ b/cime_config/namelist_definition_drv.xml
@@ -869,28 +869,6 @@
       <value>$ICE_NY</value>
     </values>
   </entry>
-  <entry id="glc_nx" modify_via_xml="GLC_NX">
-    <type>integer</type>
-    <category>control</category>
-    <group>MED_attributes</group>
-    <desc>
-      number of glc cells in i direction
-    </desc>
-    <values>
-      <value>$GLC_NX</value>
-    </values>
-  </entry>
-  <entry id="glc_ny" modify_via_xml="GLC_NY">
-    <type>integer</type>
-    <category>control</category>
-    <group>MED_attributes</group>
-    <desc>
-      number of glc cells in j direction
-    </desc>
-    <values>
-      <value>$GLC_NY</value>
-    </values>
-  </entry>
   <entry id="lnd_nx" modify_via_xml="LND_NX">
     <type>integer</type>
     <category>control</category>

--- a/mediator/esmFldsExchange_cesm_mod.F90
+++ b/mediator/esmFldsExchange_cesm_mod.F90
@@ -30,14 +30,12 @@ module esmFldsExchange_cesm_mod
   character(len=CX)   :: atm2ice_fmap='unset', atm2ice_smap='unset', atm2ice_vmap='unset'
   character(len=CX)   :: atm2ocn_fmap='unset', atm2ocn_smap='unset', atm2ocn_vmap='unset'
   character(len=CX)   :: atm2lnd_fmap='unset', atm2lnd_smap='unset'
-  character(len=CX)   :: glc2lnd_smap='unset', glc2lnd_fmap='unset'
   character(len=CX)   :: glc2ice_rmap='unset'
   character(len=CX)   :: glc2ocn_liq_rmap='unset'
   character(len=CX)   :: glc2ocn_ice_rmap='unset'
   character(len=CX)   :: ice2atm_fmap='unset', ice2atm_smap='unset'
   character(len=CX)   :: ocn2atm_fmap='unset', ocn2atm_smap='unset'
   character(len=CX)   :: lnd2atm_fmap='unset', lnd2atm_smap='unset'
-  character(len=CX)   :: lnd2glc_fmap='unset', lnd2glc_smap='unset'
   character(len=CX)   :: lnd2rof_fmap='unset'
   character(len=CX)   :: rof2lnd_fmap='unset'
   character(len=CX)   :: rof2ocn_fmap='unset', rof2ocn_ice_rmap='unset', rof2ocn_liq_rmap='unset'
@@ -140,12 +138,6 @@ contains
        call NUOPC_CompAttributeGet(gcomp, name='rof2lnd_fmapname', value=rof2lnd_fmap,  rc=rc)
        if (chkerr(rc,__LINE__,u_FILE_u)) return
        if (mastertask) write(logunit, '(a)') trim(subname)//'rof2lnd_fmapname = '// trim(rof2lnd_fmap)
-       call NUOPC_CompAttributeGet(gcomp, name='glc2lnd_fmapname', value=glc2lnd_fmap,  rc=rc)
-       if (chkerr(rc,__LINE__,u_FILE_u)) return
-       if (mastertask) write(logunit, '(a)') trim(subname)//'glc2lnd_smapname = '// trim(glc2lnd_fmap)
-       call NUOPC_CompAttributeGet(gcomp, name='glc2lnd_smapname', value=glc2lnd_smap,  rc=rc)
-       if (chkerr(rc,__LINE__,u_FILE_u)) return
-       if (mastertask) write(logunit, '(a)') trim(subname)//'glc2lnd_smapname = '// trim(glc2lnd_smap)
 
        ! mapping to ice
        call NUOPC_CompAttributeGet(gcomp, name='atm2ice_fmapname', value=atm2ice_fmap,  rc=rc)
@@ -205,14 +197,6 @@ contains
        call NUOPC_CompAttributeGet(gcomp, name='lnd2rof_fmapname', value=lnd2rof_fmap,  rc=rc)
        if (chkerr(rc,__LINE__,u_FILE_u)) return
        if (mastertask) write(logunit, '(a)') trim(subname)//'lnd2rof_fmapname = '// trim(lnd2rof_fmap)
-
-       ! mapping to glc
-       call NUOPC_CompAttributeGet(gcomp, name='lnd2glc_fmapname', value=lnd2glc_fmap,  rc=rc)
-       if (chkerr(rc,__LINE__,u_FILE_u)) return
-       if (mastertask) write(logunit, '(a)') trim(subname)//'lnd2glc_fmapname = '// trim(lnd2glc_fmap)
-       call NUOPC_CompAttributeGet(gcomp, name='lnd2glc_smapname', value=lnd2glc_smap,  rc=rc)
-       if (chkerr(rc,__LINE__,u_FILE_u)) return
-       if (mastertask) write(logunit, '(a)') trim(subname)//'lnd2glc_smapname = '// trim(lnd2glc_smap)
 
        ! mapping to wav
        call NUOPC_CompAttributeGet(gcomp, name='atm2wav_smapname', value=atm2wav_smap, rc=rc)


### PR DESCRIPTION
### Description of changes

Remove some unused namelist variables: glc_nx, glc_ny, and some glc2lnd and lnd2glc mapping file variables.

In addition to doing some general cleanup, the motivation for removing these is because they will be hard to support with the upcoming capability to have multiple GLC grids.

### Specific notes

Contributors other than yourself, if any: @mvertens provided general input

CMEPS Issues Fixed (include github issue #): none

Are changes expected to change answers?
 - [x] bit for bit
 - [ ] different at roundoff level
 - [ ] more substantial

Any User Interface Changes (namelist or namelist defaults changes)?
 - [x] Yes - just removes some namelist and xml variables
 - [ ] No

Testing performed if application target is CESM:(either UFS-S2S or CESM testing is required):
- [x] (recommended) CIME_DRIVER=nuopc scripts_regression_tests.py
   - machines: cheyenne
   - details (e.g. failed tests):
     - Testing run in the context of cesm2_3_beta03
     - Two tests failed; these also fail from out-of-the-box cesm2_3_beta03:
       - test_j_createnewcase_user_compset_vs_alias
       - ERIO_Ln11.f09_g16.X.cheyenne_intel from test_full_system
- [x] (recommended) CESM testlist_drv.xml
   - machines and compilers: cheyenne; all compilers for which tests are defined
   - details (e.g. failed tests):
     - Ran tests in xml category nuopc; did *not* perform baseline comparisons
     - Three tests failed; I'm pretty sure these are due to pre-existing issues:
       - ERR_Vnuopc_Ld5.f09_t061.B1850MOM.cheyenne_intel.allactive-nuopc_cap_io & ERS_Vnuopc_Ld5.f19_g17.B1850.cheyenne_intel.allactive-nuopc_cap_io: can't find nuopc_cap_io testmods dir
       - ERS_Vnuopc_Lm13.f10_f10_mg37.I1850Clm50SpG.cheyenne_intel: Can't do restart run with CISM & NUOPC currently
- [ ] (optional) CESM prealpha test
   - machines and compilers
   - details (e.g. failed tests):
- [x] (other) please described in detail: CISM's aux_glc test suite
   - machines and compilers: cheyenne intel & gnu
   - details (e.g. failed tests):
     - Tests run in the context of cismwrap_2_1_85
     - All tests pass and are bit-for-bit with baselines; NLCOMP failures as expected

Testing performed if application target is UFS-coupled:
- [ ] (recommended) UFS-coupled testing
   - description:
   - details (e.g. failed tests):

Testing performed if application target is UFS-HAFS:
- [ ] (recommended) UFS-HAFS testing
   - description:
   - details (e.g. failed tests):

Hashes used for testing:
- [x] CESM:
  - repository to check out: https://github.com/ESCOMP/CESM.git
  - branch:
  - hash: cesm2_3_beta03
- [ ] UFS-coupled, then umbrella repostiory to check out and associated hash:
  - repository to check out:
  - branch:
  - hash:
- [ ] UFS-HAFS, then umbrella repostiory to check out and associated hash:
  - repository to check out:
  - branch:
  - hash:
