### PR TITLE
remove the version ifdef and add the CASE_HASH variable

### DIFF
--- a/cime_config/config_component.xml
+++ b/cime_config/config_component.xml
@@ -186,6 +186,13 @@
     <desc>username of user who created case</desc>
   </entry>
 
+  <entry id="CASE_HASH">
+    <type>char</type>
+    <group>case_desc</group>
+    <file>env_case.xml</file>
+    <desc>Unique identifier for case</desc>
+  </entry>
+
   <!-- ===================================================================== -->
   <!-- definitions runtimes -->
   <!-- ===================================================================== -->

--- a/mediator/esmFlds.F90
+++ b/mediator/esmFlds.F90
@@ -363,12 +363,8 @@ contains
     use ESMF              , only : ESMF_StateGet, ESMF_LogFoundError
     use ESMF              , only : ESMF_LogWrite, ESMF_LOGMSG_ERROR, ESMF_FAILURE, ESMF_LOGERR_PASSTHRU
     use ESMF              , only : ESMF_LOGMSG_INFO, ESMF_StateRemove, ESMF_SUCCESS
-#if ESMF_VERSION_MAJOR >= 8
-#if ESMF_VERSION_MINOR >  0
     use ESMF              , only : ESMF_STATEINTENT_IMPORT, ESMF_STATEINTENT_EXPORT, ESMF_StateIntent_Flag
     use ESMF              , only : ESMF_RC_ARG_BAD, ESMF_LogSetError, operator(==)
-#endif
-#endif
     ! input/output variables
     type(ESMF_State)            , intent(inout)            :: state
     type(med_fldlist_type), intent(in)               :: fldList
@@ -386,11 +382,7 @@ contains
     character(CS)                   :: shortname
     character(CS)                   :: stdname
     character(ESMF_MAXSTR)          :: transferActionAttr
-#if ESMF_VERSION_MAJOR >= 8
-#if ESMF_VERSION_MINOR >  0
     type(ESMF_StateIntent_Flag)     :: stateIntent
-#endif
-#endif
     character(ESMF_MAXSTR)          :: transferAction
     character(ESMF_MAXSTR), pointer :: StandardNameList(:) => null()
     character(ESMF_MAXSTR), pointer :: ConnectedList(:) => null()
@@ -454,9 +446,6 @@ contains
 #endif
 
     nflds = size(fldList%flds)
-    transferActionAttr="TransferActionGeomObject"
-#if ESMF_VERSION_MAJOR >= 8
-#if ESMF_VERSION_MINOR >  0
     call ESMF_StateGet(state, stateIntent=stateIntent, rc=rc)
     if (stateIntent==ESMF_STATEINTENT_EXPORT) then
        transferActionAttr="ProducerTransferAction"
@@ -470,8 +459,6 @@ contains
             rcToReturn=rc)
        return  ! bail out
     endif
-#endif
-#endif
 
     do n = 1, nflds
        shortname = fldList%flds(n)%shortname

--- a/mediator/esmFldsExchange_hafs_mod.F90
+++ b/mediator/esmFldsExchange_hafs_mod.F90
@@ -930,28 +930,9 @@ contains
     rc = ESMF_SUCCESS
 
     ! Query component for name, verbosity, and diagnostic values
-#if ESMF_VERSION_MAJOR >= 8
     call NUOPC_CompGet(gcomp, name=cname, verbosity=verbosity, &
       diagnostic=diagnostic, rc=rc)
     if (chkerr(rc,__LINE__,u_FILE_u)) return
-#else
-    call ESMF_GridCompGet(gcomp, name=cname, rc=rc)
-    if (chkerr(rc,__LINE__,u_FILE_u)) return
-    call ESMF_AttributeGet(gcomp, name="Verbosity", value=cvalue, &
-      defaultValue="0", convention="NUOPC", purpose="Instance", rc=rc)
-    if (chkerr(rc,__LINE__,u_FILE_u)) return
-    verbosity = ESMF_UtilString2Int(cvalue, &
-      specialStringList=(/"off ","low ","high","max "/), &
-      specialValueList=(/0,9985,32513,131071/), rc=rc)
-    if (chkerr(rc,__LINE__,u_FILE_u)) return
-    call ESMF_AttributeGet(gcomp, name="Diagnostic", value=cvalue, &
-      defaultValue="0", convention="NUOPC", purpose="Instance", rc=rc)
-    if (chkerr(rc,__LINE__,u_FILE_u)) return
-    diagnostic = ESMF_UtilString2Int(cvalue, &
-      specialStringList=(/"off ","max "/), &
-      specialValueList=(/0,131071/), rc=rc)
-    if (chkerr(rc,__LINE__,u_FILE_u)) return
-#endif
 
     !----------------------------------------------------------
     ! Initialize system type

--- a/mediator/med.F90
+++ b/mediator/med.F90
@@ -990,12 +990,9 @@ contains
     use ESMF , only : ESMF_GridComp, ESMF_State, ESMF_Clock, ESMF_VM, ESMF_SUCCESS
     use ESMF , only : ESMF_LogWrite, ESMF_LOGMSG_INFO, ESMF_TimeInterval
     use ESMF , only : ESMF_VMGet, ESMF_StateIsCreated, ESMF_GridCompGet
-#if ESMF_VERSION_MAJOR >= 8
-#if ESMF_VERSION_MINOR >  0
     use ESMF , only : ESMF_StateSet, ESMF_StateIntent_Import, ESMF_StateIntent_Export
     use ESMF , only : ESMF_StateIntent_Flag
-#endif
-#endif
+
     ! Input/output variables
     type(ESMF_GridComp)  :: gcomp
     type(ESMF_State)     :: importState, exportState
@@ -1026,24 +1023,16 @@ contains
     ! Realize States
     do n = 1,ncomps
       if (ESMF_StateIsCreated(is_local%wrap%NStateImp(n), rc=rc)) then
-#if ESMF_VERSION_MAJOR >= 8
-#if ESMF_VERSION_MINOR >  0
          call ESMF_StateSet(is_local%wrap%NStateImp(n), stateIntent=ESMF_StateIntent_Import, rc=rc)
          if (ChkErr(rc,__LINE__,u_FILE_u)) return
-#endif
-#endif
          call med_fldList_Realize(is_local%wrap%NStateImp(n), fldListFr(n), &
               is_local%wrap%flds_scalar_name, is_local%wrap%flds_scalar_num, &
               tag=subname//':Fr_'//trim(compname(n)), rc=rc)
          if (ChkErr(rc,__LINE__,u_FILE_u)) return
       endif
       if (ESMF_StateIsCreated(is_local%wrap%NStateExp(n), rc=rc)) then
-#if ESMF_VERSION_MAJOR >= 8
-#if ESMF_VERSION_MINOR >  0
           call ESMF_StateSet(is_local%wrap%NStateExp(n), stateIntent=ESMF_StateIntent_Export, rc=rc)
           if (ChkErr(rc,__LINE__,u_FILE_u)) return
-#endif
-#endif
           call med_fldList_Realize(is_local%wrap%NStateExp(n), fldListTo(n), &
               is_local%wrap%flds_scalar_name, is_local%wrap%flds_scalar_num, &
               tag=subname//':To_'//trim(compname(n)), rc=rc)


### PR DESCRIPTION
### Description of changes
Remove the ifdef which assured that the version of ESMF was 8 or greater.   Version 8 or greater is always required so this is just a cleanup.   Also added the CASE_HASH variable which is used by cime to establish provenance. 

### Specific notes

Contributors other than yourself, if any:

CMEPS Issues Fixed (include github issue #):

Are changes expected to change answers?
 - [X] bit for bit
 - [ ] different at roundoff level
 - [ ] more substantial

Any User Interface Changes (namelist or namelist defaults changes)?
 - [ ] Yes
 - [X] No

Testing performed if application target is CESM:(either UFS-S2S or CESM testing is required):
- [X] (recommended) CIME_DRIVER=nuopc scripts_regression_tests.py
   - machines: cheyenne intel
   - details (e.g. failed tests):
- [ ] (recommended) CESM testlist_drv.xml
   - machines and compilers:
   - details (e.g. failed tests):
- [ ] (optional) CESM prealpha test
   - machines and compilers
   - details (e.g. failed tests):
- [ ] (other) please described in detail
   - machines and compilers
   - details (e.g. failed tests):

Testing performed if application target is UFS-coupled:
- [ ] (recommended) UFS-coupled testing
   - description:
   - details (e.g. failed tests):

Testing performed if application target is UFS-HAFS:
- [ ] (recommended) UFS-HAFS testing
   - description:
   - details (e.g. failed tests):

Hashes used for testing:
- [ ] CESM:
  - repository to check out: https://github.com/ESCOMP/CESM.git
  - branch:
  - hash:
- [ ] UFS-coupled, then umbrella repostiory to check out and associated hash:
  - repository to check out:
  - branch:
  - hash:
- [ ] UFS-HAFS, then umbrella repostiory to check out and associated hash:
  - repository to check out:
  - branch:
  - hash:
