### PR TITLE
Fix namelist variables that weren't being set

### DIFF
--- a/cime_config/namelist_definition_drv.xml
+++ b/cime_config/namelist_definition_drv.xml
@@ -571,7 +571,7 @@
     </values>
   </entry>
 
-  <entry id="mediator_read_restart" modify_via_xml="MEDIATOR_READ_RESTART">
+  <entry id="mediator_read_restart" skip_default_entry="true" modify_via_xml="MEDIATOR_READ_RESTART">
     <type>logical</type>
     <category>expdef</category>
     <group>DRIVER_attributes</group>

--- a/cime_config/namelist_definition_modelio.xml
+++ b/cime_config/namelist_definition_modelio.xml
@@ -166,6 +166,7 @@
     <value component="rof">$ROF_PIO_NETCDF_FORMAT</value>
     <value component="glc">$GLC_PIO_NETCDF_FORMAT</value>
     <value component="wav">$WAV_PIO_NETCDF_FORMAT</value>
+    <value component="esp">$ESP_PIO_NETCDF_FORMAT</value>
     </values>
   </entry>
 


### PR DESCRIPTION
### Description of changes

With my upcoming fix for https://github.com/ESMCI/cime/issues/3984, I
was getting some failures due to namelist variables that weren't
properly defined.

(1) mediator_read_restart: since this is set in the code rather than via
    the normal mechanism, I think it's appropriate to have
    skip_default_entry="true" here.

(2) ESP's pio_netcdf_format: I'm not positive that the way I've set it
    is correct, but it seems more correct than before.

### Specific notes

Contributors other than yourself, if any: none

CMEPS Issues Fixed (include github issue #): none

Are changes expected to change answers?
 - [x] bit for bit
 - [ ] different at roundoff level
 - [ ] more substantial

Any User Interface Changes (namelist or namelist defaults changes)?
 - [ ] Yes
 - [x] No

Testing performed if application target is CESM:(either UFS-S2S or CESM testing is required):
- [ ] (recommended) CIME_DRIVER=nuopc scripts_regression_tests.py
   - machines:
   - details (e.g. failed tests):
- [ ] (recommended) CESM testlist_drv.xml
   - machines and compilers:
   - details (e.g. failed tests):
- [x] (optional) CESM prealpha test
   - cheyenne & izumi (all compilers)
   - details (e.g. failed tests): only test failures are ones that seem to have failed in the baseline, except for a couple of tests that looked like system issues. NLCOMPs identical except for the expected change in pio_netcdf_format for ESP
- [x] (other) please described in detail: CESM's aux_cime_baselines
   - cheyenne (all compilers for which tests are defined)
   - details (e.g. failed tests): all pass; NLCOMPs identical except for the expected change in pio_netcdf_format for ESP

Testing performed if application target is UFS-coupled:
- [ ] (recommended) UFS-coupled testing
   - description:
   - details (e.g. failed tests):

Testing performed if application target is UFS-HAFS:
- [ ] (recommended) UFS-HAFS testing
   - description:
   - details (e.g. failed tests):

Hashes used for testing:
- [x] CESM:
  - repository to check out: https://github.com/ESCOMP/CESM.git
  - cesm2_3_alpha03a, with the cime branch in https://github.com/ESMCI/cime/pull/3988
- [ ] UFS-coupled, then umbrella repostiory to check out and associated hash:
  - repository to check out:
  - branch:
  - hash:
- [ ] UFS-HAFS, then umbrella repostiory to check out and associated hash:
  - repository to check out:
  - branch:
  - hash:
