### PR TITLE
remove only clause for use mpi

### DIFF
--- a/drivers/cime/esmApp.F90
+++ b/drivers/cime/esmApp.F90
@@ -12,12 +12,7 @@ program esmApp
   use ESMF,            only : ESMF_LOGKIND_MULTI_ON_ERROR, ESMF_LogKind_Flag
   use ESMF,            only : ESMF_VMGet, ESMF_VM, ESMF_InitializePreMPI
 
-#ifndef NO_MPI2
-  use mpi,             only : MPI_COMM_WORLD, MPI_COMM_NULL, MPI_Init_thread, MPI_FINALIZE, MPI_BCAST
-  use mpi,             only : MPI_COMM_RANK, MPI_THREAD_SERIALIZED, MPI_LOGICAL
-#else
   use mpi
-#endif
   use NUOPC,           only : NUOPC_FieldDictionarySetup
   use ensemble_driver, only : SetServices
   use shr_pio_mod,     only : shr_pio_init1


### PR DESCRIPTION
it turns out that the mpi module does not support functions in the only clause - this is supported in mpi_f08, but that module also changes the type of mpi variables in fortran

### Description of changes

### Specific notes

Contributors other than yourself, if any:

CMEPS Issues Fixed (include github issue #):

Are changes expected to change answers?
 - [X] bit for bit
 - [ ] different at roundoff level
 - [ ] more substantial

Any User Interface Changes (namelist or namelist defaults changes)?
 - [ ] Yes
 - [X] No

Testing performed if application target is CESM:(either UFS-S2S or CESM testing is required):
- [X] (recommended) CIME_DRIVER=nuopc scripts_regression_tests.py
   - machines:
   - details (e.g. failed tests):
- [ ] (recommended) CESM testlist_drv.xml
   - machines and compilers:
   - details (e.g. failed tests):
- [ ] (optional) CESM prealpha test
   - machines and compilers
   - details (e.g. failed tests):
- [ ] (other) please described in detail
   - machines and compilers
   - details (e.g. failed tests):

Testing performed if application target is UFS-coupled:
- [ ] (recommended) UFS-coupled testing
   - description:
   - details (e.g. failed tests):

Testing performed if application target is UFS-HAFS:
- [ ] (recommended) UFS-HAFS testing
   - description:
   - details (e.g. failed tests):

Hashes used for testing:
- [ ] CESM:
  - repository to check out: https://github.com/ESCOMP/CESM.git
  - branch:
  - hash:
- [ ] UFS-coupled, then umbrella repostiory to check out and associated hash:
  - repository to check out:
  - branch:
  - hash:
- [ ] UFS-HAFS, then umbrella repostiory to check out and associated hash:
  - repository to check out:
  - branch:
  - hash:
