### PR TITLE
esmf aware threading now works with esmf 8.2.0b10 or newer

### DIFF
--- a/cime_config/buildexe
+++ b/cime_config/buildexe
@@ -76,21 +76,6 @@ def _main_func():
         gmake_args += " MED_PRESENT=FALSE"
     if esmf_aware_threading:
         gmake_args += " USER_CPPDEFS=-DESMF_AWARE_THREADING"
-    esmfmkfile = os.getenv("ESMFMKFILE")
-    expect(esmfmkfile and os.path.isfile(esmfmkfile),"ESMFMKFILE not found {}".format(esmfmkfile))
-    with open(esmfmkfile, 'r') as f:
-        major = None
-        minor = None
-        for line in f.readlines():
-            if 'ESMF_VERSION' in line:
-                major = line[-2] if 'MAJOR' in line else major
-                minor = line[-2] if 'MINOR' in line else minor
-        logger.debug("ESMF version major {} minor {}".format(major,minor))
-        expect(int(major) >=8,"ESMF version should be 8.1 or newer")
-        if esmf_aware_threading:
-            expect(int(minor) >= 2, "ESMF version should be 8.2.0 or newer when using ESMF_AWARE_THREADING")
-        else:
-            expect(int(minor) >= 1, "ESMF version should be 8.1.0 or newer")
 
     gmake_args += " IAC_PRESENT=FALSE"
     expect((num_esp is None) or (int(num_esp) == 1), "ESP component restricted to one instance")

--- a/cime_config/buildexe
+++ b/cime_config/buildexe
@@ -76,6 +76,21 @@ def _main_func():
         gmake_args += " MED_PRESENT=FALSE"
     if esmf_aware_threading:
         gmake_args += " USER_CPPDEFS=-DESMF_AWARE_THREADING"
+    esmfmkfile = os.getenv("ESMFMKFILE")
+    expect(esmfmkfile and os.path.isfile(esmfmkfile),"ESMFMKFILE not found {}".format(esmfmkfile))
+    with open(esmfmkfile, 'r') as f:
+        major = None
+        minor = None
+        for line in f.readlines():
+            if 'ESMF_VERSION' in line:
+                major = line[-2] if 'MAJOR' in line else major
+                minor = line[-2] if 'MINOR' in line else minor
+        logger.debug("ESMF version major {} minor {}".format(major,minor))
+        expect(int(major) >=8,"ESMF version should be 8.1 or newer")
+        if esmf_aware_threading:
+            expect(int(minor) >= 2, "ESMF version should be 8.2.0 or newer when using ESMF_AWARE_THREADING")
+        else:
+            expect(int(minor) >= 1, "ESMF version should be 8.1.0 or newer")
 
     gmake_args += " IAC_PRESENT=FALSE"
     expect((num_esp is None) or (int(num_esp) == 1), "ESP component restricted to one instance")

--- a/cime_config/buildnml
+++ b/cime_config/buildnml
@@ -516,6 +516,24 @@ def buildnml(case, caseroot, component):
     if component != "drv":
         raise AttributeError
 
+#   Do a check here of ESMF VERSION, requires 8.1.0 or newer (8.2.0 or newer for esmf_aware_threading)
+    esmf_aware_threading = case.get_value("ESMF_AWARE_THREADING")
+    esmfmkfile = os.getenv("ESMFMKFILE")
+    expect(esmfmkfile and os.path.isfile(esmfmkfile),"ESMFMKFILE not found {}".format(esmfmkfile))
+    with open(esmfmkfile, 'r') as f:
+        major = None
+        minor = None
+        for line in f.readlines():
+            if 'ESMF_VERSION' in line:
+                major = line[-2] if 'MAJOR' in line else major
+                minor = line[-2] if 'MINOR' in line else minor
+        logger.debug("ESMF version major {} minor {}".format(major,minor))
+        expect(int(major) >=8,"ESMF version should be 8.1 or newer")
+        if esmf_aware_threading:
+            expect(int(minor) >= 2, "ESMF version should be 8.2.0 or newer when using ESMF_AWARE_THREADING")
+        else:
+            expect(int(minor) >= 1, "ESMF version should be 8.1.0 or newer")
+
     confdir = os.path.join(case.get_value("CASEBUILD"), "cplconf")
     if not os.path.isdir(confdir):
         os.makedirs(confdir)

--- a/drivers/cime/esm.F90
+++ b/drivers/cime/esm.F90
@@ -981,14 +981,6 @@ contains
        call ESMF_InfoSet(info, key="/NUOPC/Hint/PePerPet/MaxCount", value=nthrds, rc=rc)
        if (chkerr(rc,__LINE__,u_FILE_u)) return
 
-!       call ESMF_InfoSet(info, key="/NUOPC/Hint/PePerPet/MinStackSize", value='40MiB', rc=rc)
-!       if (chkerr(rc,__LINE__,u_FILE_u)) return
-
-       if (nthrds == 1) then
-          call ESMF_InfoSet(info, key="/NUOPC/Hint/PePerPet/OpenMpHandling", value='none', rc=rc)
-          if (chkerr(rc,__LINE__,u_FILE_u)) return
-       endif
-
        call NUOPC_CompAttributeGet(driver, name=trim(namestr)//'_rootpe', value=cvalue, rc=rc)
        if (chkerr(rc,__LINE__,u_FILE_u)) return
        read(cvalue,*) rootpe


### PR DESCRIPTION
### Description of changes
Add code to buildexe script to check that ESMF VERSION is new enough.  ESMF 8.1 is required unless ESMF_AWARE_THREADING is enabled which requires 8.2.0

### Specific notes

Contributors other than yourself, if any:

CMEPS Issues Fixed (include github issue #):

Are changes expected to change answers?
 - [X] bit for bit
 - [ ] different at roundoff level
 - [ ] more substantial

Any User Interface Changes (namelist or namelist defaults changes)?
 - [ ] Yes
 - [X] No

Testing performed if application target is CESM:(either UFS-S2S or CESM testing is required):
- [X] (recommended) CIME_DRIVER=nuopc scripts_regression_tests.py
   - machines: cheyenne intel (all pass)
   - details (e.g. failed tests):
- [ ] (recommended) CESM testlist_drv.xml
   - machines and compilers:
   - details (e.g. failed tests):
- [ ] (optional) CESM prealpha test
   - machines and compilers
   - details (e.g. failed tests):
- [ ] (other) please described in detail
   - machines and compilers
   - details (e.g. failed tests):

Testing performed if application target is UFS-coupled:
- [ ] (recommended) UFS-coupled testing
   - description:
   - details (e.g. failed tests):

Testing performed if application target is UFS-HAFS:
- [ ] (recommended) UFS-HAFS testing
   - description:
   - details (e.g. failed tests):

Hashes used for testing:
- [ ] CESM:
  - repository to check out: https://github.com/ESCOMP/CESM.git
  - branch:
  - hash:
- [ ] UFS-coupled, then umbrella repostiory to check out and associated hash:
  - repository to check out:
  - branch:
  - hash:
- [ ] UFS-HAFS, then umbrella repostiory to check out and associated hash:
  - repository to check out:
  - branch:
  - hash:
