### PR TITLE
Add ozone field from atm -> lnd

### DIFF
--- a/cime_config/namelist_definition_drv_flds.xml
+++ b/cime_config/namelist_definition_drv_flds.xml
@@ -145,4 +145,21 @@
     </desc>
   </entry>
 
+  <!-- ========================================================================================  -->
+  <!-- Ozone control                                                                              -->
+  <!-- ========================================================================================  -->
+
+  <entry id="atm_ozone_frequency">
+    <type>char</type>
+    <category>ozone_coupling</category>
+    <group>ozone_coupling_nl</group>
+    <valid_values>instantaneous,monthly_interpolated</valid_values>
+    <desc>
+      Frequency of surface ozone field passed from CAM to surface components.
+      Surface ozone is passed every coupling interval, but this namelist flag
+      indicates whether the timestep-level values are interpolated from a
+      coarser temporal resolution.
+    </desc>
+  </entry>
+
 </entry_id>

--- a/cime_config/namelist_definition_drv_flds.xml
+++ b/cime_config/namelist_definition_drv_flds.xml
@@ -153,7 +153,6 @@
     <type>char</type>
     <category>ozone_coupling</category>
     <group>ozone_coupling_nl</group>
-    <valid_values>instantaneous,monthly_interpolated</valid_values>
     <desc>
       Frequency of surface ozone field passed from CAM to surface components.
       Surface ozone is passed every coupling interval, but this namelist flag

--- a/mediator/esmFldsExchange_cesm_mod.F90
+++ b/mediator/esmFldsExchange_cesm_mod.F90
@@ -358,6 +358,7 @@ contains
              'Sa_tbot     ',&
              'Sa_ptem     ',&
              'Sa_pbot     ',&
+             'Sa_o3       ',&
              'Sa_shum     ',&
              'Sa_shum_wiso'/)
 

--- a/mediator/fd_cesm.yaml
+++ b/mediator/fd_cesm.yaml
@@ -319,7 +319,7 @@
        description: atmosphere export - prognostic CO2 at the lowest model level
      #
      - standard_name: Sa_o3
-       canonical_units: 1e-9 mol/mol
+       canonical_units: mol/mol
        description: atmosphere export - O3 in the lowest model layer (prognosed or prescribed)
      #
      - standard_name: Sa_topo

--- a/mediator/fd_cesm.yaml
+++ b/mediator/fd_cesm.yaml
@@ -318,6 +318,10 @@
        canonical_units: 1e-6 mol/mol
        description: atmosphere export - prognostic CO2 at the lowest model level
      #
+     - standard_name: Sa_o3
+       canonical_units: 1e-9 mol/mol
+       description: atmosphere export - prognostic CO2 at the lowest model level
+     #
      - standard_name: Sa_topo
        alias: inst_surface_height
        canonical_units: m

--- a/mediator/fd_cesm.yaml
+++ b/mediator/fd_cesm.yaml
@@ -320,7 +320,7 @@
      #
      - standard_name: Sa_o3
        canonical_units: 1e-9 mol/mol
-       description: atmosphere export - prognostic CO2 at the lowest model level
+       description: atmosphere export - O3 in the lowest model layer (prognosed or prescribed)
      #
      - standard_name: Sa_topo
        alias: inst_surface_height


### PR DESCRIPTION
### Description of changes

Add ozone field from atm -> lnd, and namelist definition for the atm_ozone_frequency variable which will appear in drv_flds_in.

This will work together with changes in CAM (to send ozone and set atm_ozone_frequency), CESM_share (to facilitate reading atm_ozone_frequency) and CTSM (to receive ozone and read atm_ozone_frequency), but the changes here can be brought in independently of those changes.

### Specific notes

Contributors other than yourself, if any: @mvertens 

CMEPS Issues Fixed (include github issue #):

Are changes expected to change answers?
 - [x] bit for bit
 - [ ] different at roundoff level
 - [ ] more substantial

Any User Interface Changes (namelist or namelist defaults changes)?
 - [ ] Yes
 - [x] No

Testing performed if application target is CESM:(either UFS-S2S or CESM testing is required):
- [ ] (recommended) CIME_DRIVER=nuopc scripts_regression_tests.py
   - machines:
   - details (e.g. failed tests):
- [ ] (recommended) CESM testlist_drv.xml
   - machines and compilers:
   - details (e.g. failed tests):
- [ ] (optional) CESM prealpha test
   - machines and compilers
   - details (e.g. failed tests):
- [x] (other) please described in detail
   - SMS_D_Ln1_Vnuopc.f10_f10_mg37.I2000Clm50BgcCropQianRs.cheyenne_intel
   - SMS_D_Ln1_Vnuopc.f10_f10_mg37.F2000climo.cheyenne_intel

Testing performed if application target is UFS-coupled:
- [ ] (recommended) UFS-coupled testing
   - description:
   - details (e.g. failed tests):

Testing performed if application target is UFS-HAFS:
- [ ] (recommended) UFS-HAFS testing
   - description:
   - details (e.g. failed tests):

Hashes used for testing:
- [x] CESM:
  - repository to check out: https://github.com/ESCOMP/CESM.git
  - hash: `997657f`
    - In addition to this CMEPS branch, used:
      - CAM at `8f93d2a`
      - CESM_share at `82006bf`
      - diffs in CLM to call `shr_ozone_coupling_readnl` and print the returned value
- [ ] UFS-coupled, then umbrella repostiory to check out and associated hash:
  - repository to check out:
  - branch:
  - hash:
- [ ] UFS-HAFS, then umbrella repostiory to check out and associated hash:
  - repository to check out:
  - branch:
  - hash:
