### PR TITLE
code to use HPE SMARTREDIS

### DIFF
--- a/cime_config/buildexe
+++ b/cime_config/buildexe
@@ -40,6 +40,7 @@ def _main_func():
         atm_model = case.get_value("COMP_ATM")
         gmake_args = get_standard_makefile_args(case)
         esmf_aware_threading = case.get_value("ESMF_AWARE_THREADING")
+        use_smartsim = case.get_value("USE_SMARTSIM")
 
     # Determine valid components
     valid_comps = []
@@ -77,6 +78,10 @@ def _main_func():
     if esmf_aware_threading:
         gmake_args += " USER_CPPDEFS=-DESMF_AWARE_THREADING"
 
+    if use_smartsim:
+        gmake_args += " USE_SMARTSIM=TRUE"
+
+
     gmake_args += " IAC_PRESENT=FALSE"
     expect((num_esp is None) or (int(num_esp) == 1), "ESP component restricted to one instance")
 
@@ -109,7 +114,7 @@ def _main_func():
         .format(gmake, gmake_j, exename, gmake_args, makefile)
 
 
-    rc, out, err = run_cmd(cmd,from_dir=bld_root)
+    rc, out, err = run_cmd(cmd,from_dir=bld_root, verbose=True)
     expect(rc==0,"Command {} failed rc={}\nout={}\nerr={}".format(cmd,rc,out,err))
     logger.info(out)
 

--- a/cime_config/config_component.xml
+++ b/cime_config/config_component.xml
@@ -2528,6 +2528,15 @@
    <desc>if true, create ESMF PET log files even if there is no error encountered </desc>
  </entry>
 
+ <entry id="USE_SMARTSIM">
+   <type>logical</type>
+   <valid_values>TRUE,FALSE</valid_values>
+   <default_value>FALSE</default_value>
+   <group>run_debug</group>
+   <file>env_build.xml</file>
+   <desc>if true, link with the HPE SmartRedis library  </desc>
+ </entry>
+
   <!-- ===================================================================== -->
   <!-- Include the AOFLUX calculation for this compset -->
   <!-- ===================================================================== -->

--- a/cime_config/testdefs/testmods_dirs/drv/smartsim/shell_commands
+++ b/cime_config/testdefs/testmods_dirs/drv/smartsim/shell_commands
@@ -1,0 +1,1 @@
+./xmlchange USE_SMARTSIM=TRUE

--- a/drivers/cime/ensemble_driver.F90
+++ b/drivers/cime/ensemble_driver.F90
@@ -134,7 +134,7 @@ contains
     call ReadAttributes(ensemble_driver, config, "CLOCK_attributes::", rc=rc)
     if (chkerr(rc,__LINE__,u_FILE_u)) return
 
-    call NUOPC_CompAttributeGet(ensemble_driver, 'calendar', calendar, rc=rc) 
+    call NUOPC_CompAttributeGet(ensemble_driver, 'calendar', calendar, rc=rc)
     if (chkerr(rc,__LINE__,u_FILE_u)) return
     if (calendar == 'NO_LEAP') then
        call ESMF_CalendarSetDefault(ESMF_CALKIND_NOLEAP, rc=rc)
@@ -247,7 +247,7 @@ contains
           call ReadAttributes(driver, config, "DRV_modelio"//trim(inst_suffix)//"::", rc=rc)
           if (chkerr(rc,__LINE__,u_FILE_u)) return
 
-          ! Set the driver log to the driver task 0 
+          ! Set the driver log to the driver task 0
           if (mod(localPet, ntasks_per_member) == 0) then
              call NUOPC_CompAttributeGet(driver, name="diro", value=diro, rc=rc)
              if (chkerr(rc,__LINE__,u_FILE_u)) return

--- a/drivers/cime/esmApp.F90
+++ b/drivers/cime/esmApp.F90
@@ -18,7 +18,7 @@ program esmApp
   use shr_pio_mod,     only : shr_pio_init1
   use shr_sys_mod,     only : shr_sys_abort
 #ifdef SMARTREDIS
-  use esm_utils_mod , only : sr_client
+  use nuopc_shr_methods, only : sr_client
 #endif
 
   implicit none
@@ -47,7 +47,7 @@ program esmApp
 #endif
   COMP_COMM = MPI_COMM_WORLD
 #ifdef SMARTREDIS
-  call sr_client%initialize(.true.)
+  call sr_client%initialize(.false.)
 #endif
   !-----------------------------------------------------------------------------
   ! Initialize PIO

--- a/drivers/cime/esmApp.F90
+++ b/drivers/cime/esmApp.F90
@@ -17,6 +17,9 @@ program esmApp
   use ensemble_driver, only : SetServices
   use shr_pio_mod,     only : shr_pio_init1
   use shr_sys_mod,     only : shr_sys_abort
+#ifdef SMARTREDIS
+  use esm_utils_mod , only : sr_client
+#endif
 
   implicit none
 
@@ -43,7 +46,9 @@ program esmApp
   call MPI_init(rc)
 #endif
   COMP_COMM = MPI_COMM_WORLD
-
+#ifdef SMARTREDIS
+  call sr_client%initialize(.true.)
+#endif
   !-----------------------------------------------------------------------------
   ! Initialize PIO
   !-----------------------------------------------------------------------------

--- a/drivers/cime/esm_utils_mod.F90
+++ b/drivers/cime/esm_utils_mod.F90
@@ -1,16 +1,10 @@
 module esm_utils_mod
-#ifdef SMARTREDIS
-    use smartredis_client, only : client_type
-#endif
   implicit none
   public
 
   logical :: mastertask
   integer :: logunit
   integer :: dbug_flag = 0
-#ifdef SMARTREDIS
-  type(client_type) :: sr_client
-#endif
   character(*), parameter :: u_FILE_u = &
        __FILE__
 

--- a/drivers/cime/esm_utils_mod.F90
+++ b/drivers/cime/esm_utils_mod.F90
@@ -1,12 +1,16 @@
 module esm_utils_mod
-
+#ifdef SMARTREDIS
+    use smartredis_client, only : client_type
+#endif
   implicit none
   public
 
   logical :: mastertask
   integer :: logunit
   integer :: dbug_flag = 0
-
+#ifdef SMARTREDIS
+  type(client_type) :: sr_client
+#endif
   character(*), parameter :: u_FILE_u = &
        __FILE__
 

--- a/nuopc_cap_share/nuopc_shr_methods.F90
+++ b/nuopc_cap_share/nuopc_shr_methods.F90
@@ -1,5 +1,7 @@
 module nuopc_shr_methods
-
+#ifdef SMARTREDIS
+    use smartredis_client, only : client_type
+#endif
   use ESMF         , only : operator(<), operator(/=), operator(+)
   use ESMF         , only : operator(-), operator(*) , operator(>=)
   use ESMF         , only : operator(<=), operator(>), operator(==)
@@ -68,6 +70,9 @@ module nuopc_shr_methods
   character(len=1024)                   :: msgString
   character(len=*), parameter :: u_FILE_u = &
        __FILE__
+#ifdef SMARTREDIS
+  type(client_type), public :: sr_client
+#endif
 
 !===============================================================================
 contains
@@ -222,7 +227,6 @@ contains
 
     call ESMF_VMGet(vm, localPet=mytask, rc=rc)
     if (chkerr(rc,__LINE__,u_FILE_u)) return
-
     call ESMF_StateGet(State, itemName=trim(flds_scalar_name), field=field, rc=rc)
     if (chkerr(rc,__LINE__,u_FILE_u)) return
 


### PR DESCRIPTION
### Description of changes
Adds an interface to the HPE SmartSim database.  Currently only tested on casper with gnu compiler. 
Adds a test mod for testing with smartsim.  
Requires CESM_share https://github.com/ESCOMP/CESM_share/pull/5

### Specific notes

Contributors other than yourself, if any:

CMEPS Issues Fixed (include github issue #):

Are changes expected to change answers?
 - [X] bit for bit
 - [ ] different at roundoff level
 - [ ] more substantial

Any User Interface Changes (namelist or namelist defaults changes)?
 - [ ] Yes
 - [ ] No

Testing performed if application target is CESM:(either UFS-S2S or CESM testing is required):
- [ ] (recommended) CIME_DRIVER=nuopc scripts_regression_tests.py
   - machines:
   - details (e.g. failed tests):
- [ ] (recommended) CESM testlist_drv.xml
   - machines and compilers:
   - details (e.g. failed tests):
- [ ] (optional) CESM prealpha test
   - machines and compilers
   - details (e.g. failed tests):
- [ ] (other) please described in detail
   - machines and compilers
   - details (e.g. failed tests):

Testing performed if application target is UFS-coupled:
- [ ] (recommended) UFS-coupled testing
   - description:
   - details (e.g. failed tests):

Testing performed if application target is UFS-HAFS:
- [ ] (recommended) UFS-HAFS testing
   - description:
   - details (e.g. failed tests):

Hashes used for testing:
- [ ] CESM:
  - repository to check out: https://github.com/ESCOMP/CESM.git
  - branch:
  - hash:
- [ ] UFS-coupled, then umbrella repostiory to check out and associated hash:
  - repository to check out:
  - branch:
  - hash:
- [ ] UFS-HAFS, then umbrella repostiory to check out and associated hash:
  - repository to check out:
  - branch:
  - hash:
