### PR TITLE
new run sequence for B1850 nuopc validation

### DIFF
--- a/.github/workflows/extbuild.yml
+++ b/.github/workflows/extbuild.yml
@@ -19,7 +19,7 @@ jobs:
       CXX: mpicxx
       CPPFLAGS: "-I/usr/include -I/usr/local/include"
       # Versions of all dependencies can be updated here
-      ESMF_VERSION: ESMF_8_1_0_beta_snapshot_47
+      ESMF_VERSION: ESMF_8_2_0_beta_snapshot_14
       PNETCDF_VERSION: pnetcdf-1.12.2
       NETCDF_FORTRAN_VERSION: v4.5.2
       # PIO version is awkward

--- a/cime_config/config_component_cesm.xml
+++ b/cime_config/config_component_cesm.xml
@@ -414,25 +414,29 @@
 
   <entry id="CPL_SEQ_OPTION">
     <type>char</type>
-    <valid_values>TIGHT,RASM</valid_values>
+    <valid_values>TIGHT,OPTION1,OPTION2</valid_values>
     <default_value>TIGHT</default_value>
     <values match="last">
-      <value compset="_DATM.*_DOCN%SOM"			>RASM</value>
-      <value compset="_POP2"				>RASM</value>
-      <value compset="_MOM6"				>RASM</value>
-      <value compset="_POP2" grid="oi%gx1v6"		>RASM</value>
-      <value compset="_POP2" grid="oi%gx1v7"		>RASM</value>
-      <value compset="_DATM%NYF.*_SLND.*_DICE.*_DOCN"	>RASM</value>
-      <value compset="_XATM.*_XLND.*_XICE.*_XOCN"	>RASM</value>
-      <value compset="_SOCN"				>RASM</value>
+      <value compset="_DATM.*_DOCN%SOM"			>OPTION2</value>
+      <value compset="_POP2"				>OPTION2M</value>
+      <value compset="_MOM6"				>OPTION1</value>
+      <value compset="_POP2" grid="oi%gx1v6"		>OPTION1</value>
+      <value compset="_POP2" grid="oi%gx1v7"		>OPTION1</value>
+      <value compset="_DATM%NYF.*_SLND.*_DICE.*_DOCN"	>OPTION2</value>
+      <value compset="_XATM.*_XLND.*_XICE.*_XOCN"	>OPTION2</value>
+      <value compset="_SOCN"				>OPTION2</value>
     </values>
     <group>run_coupling</group>
     <file>env_run.xml</file>
     <desc>
-      RASM runs prep ocean before the ocean coupling reducing
-      most of the lags and field inconsistency but still allowing the ocean to run
-      concurrently with the ice and atmosphere.
-      TIGHT are consistent with the old variables ocean_tight_coupling = true in the driver.
+      OPTION1 (like RASM_OPTION1 in CPL7) runs prep_ocn_avg, 
+      AFTER the aoflux and ocnalb calculations, thereby reducing
+      most of the lags and field inconsistency but still allowing the
+      ocean to run concurrently with the ice and atmosphere.
+      OPTION2 (like CESM1_MOD in CPL7) runs prep_ocn_avg, 
+      BEFORE the aoflux and ocnalb calculations, thereby permitting maximum
+      concurrency
+      TIGHT (like CESM1_MOD_TIGHT), tight coupling
     </desc>
   </entry>
 

--- a/cime_config/runseq/gen_runseq.py
+++ b/cime_config/runseq/gen_runseq.py
@@ -30,9 +30,12 @@ class RunSeq:
         else:
             return -1
 
-    def enter_time_loop(self, coupling_time, active=True, newtime=True):
+    def enter_time_loop(self, coupling_time, active=True, newtime=True, addextra_atsign=False):
         if newtime:
-            self.__outfile.write ("@" + str(coupling_time) + " \n" )
+            if addextra_atsign:
+                self.__outfile.write ("@@" + str(coupling_time) + " \n" )
+            else:
+                self.__outfile.write ("@" + str(coupling_time) + " \n" )
             if active:
                 self.__time_loop.append((self.time_loop+1, self.active_depth+1))
             else:
@@ -42,14 +45,17 @@ class RunSeq:
         if if_add:
             self.__outfile.write ("  {}\n".format(action))
 
-    def leave_time_loop(self, leave_time, if_write_hist_rest=False ):
+    def leave_time_loop(self, leave_time, if_write_hist_rest=False, addextra_atsign=False ):
         if leave_time and self.__time_loop:
             _, active_depth = self.__time_loop.pop()
             if if_write_hist_rest or active_depth == 0:
                 self.__outfile.write ("  MED med_phases_history_write        \n" )
                 self.__outfile.write ("  MED med_phases_restart_write        \n" )
                 self.__outfile.write ("  MED med_phases_profile              \n" )
-            self.__outfile.write ("@ \n" )
+            if addextra_atsign: 
+                self.__outfile.write ("@@ \n" )
+            else:
+                self.__outfile.write ("@ \n" )
 
     def __exit_sequence(self):
         while self.__time_loop:

--- a/cime_config/runseq/runseq_general.py
+++ b/cime_config/runseq/runseq_general.py
@@ -81,19 +81,24 @@ def gen_runseq(case, coupling_times):
         runseq.enter_time_loop(ocn_cpl_time, newtime=ocn_outer_loop)
         #------------------
 
-        runseq.add_action("MED med_phases_prep_ocn_avg"    , med_to_ocn and ocn_outer_loop)
-        runseq.add_action("MED -> OCN :remapMethod=redist" , med_to_ocn and ocn_outer_loop)
+        if (cpl_seq_option == 'OPTION2'):
+            runseq.add_action("MED med_phases_prep_ocn_avg"    , med_to_ocn and ocn_outer_loop)
+            runseq.add_action("MED -> OCN :remapMethod=redist" , med_to_ocn and ocn_outer_loop)
 
         #------------------
         runseq.enter_time_loop(atm_cpl_time, newtime=inner_loop)
         #------------------
 
-        if (cpl_seq_option == 'RASM'):
+        if (cpl_seq_option == 'OPTION1'):
             if cpl_add_aoflux:
                 runseq.add_action("MED med_phases_aofluxes_run" , run_ocn and run_atm and (med_to_ocn or med_to_atm))
             runseq.add_action("MED med_phases_prep_ocn_accum"   , med_to_ocn)
             runseq.add_action("MED med_phases_ocnalb_run"       , (run_ocn and run_atm and (med_to_ocn or med_to_atm)) and not xcompset)
             runseq.add_action("MED med_phases_diag_ocn"         , run_ocn and diag_mode) 
+            runseq.enter_time_loop(ocn_cpl_time, newtime=inner_loop, addextra_atsign=True)
+            runseq.add_action("MED med_phases_prep_ocn_avg"    , med_to_ocn and ocn_outer_loop)
+            runseq.add_action("MED -> OCN :remapMethod=redist" , med_to_ocn and ocn_outer_loop)
+            runseq.leave_time_loop(inner_loop, addextra_atsign=True)
 
         runseq.add_action("MED med_phases_prep_lnd"        , med_to_lnd)
         runseq.add_action("MED -> LND :remapMethod=redist" , med_to_lnd)

--- a/drivers/cime/esm_time_mod.F90
+++ b/drivers/cime/esm_time_mod.F90
@@ -162,7 +162,7 @@ contains
              end if
              close(unitn)
              call ESMF_LogWrite(trim(subname)//" read driver restart from file = "//trim(restart_file), &
-                  ESMF_LOGMSG_ERROR)
+                  ESMF_LOGMSG_INFO)
 
              call esm_time_read_restart(restart_file, start_ymd, start_tod, curr_ymd, curr_tod, rc)
              if (ChkErr(rc,__LINE__,u_FILE_u)) return

--- a/mediator/esmFldsExchange_cesm_mod.F90
+++ b/mediator/esmFldsExchange_cesm_mod.F90
@@ -1322,8 +1322,13 @@ contains
           if ( fldchk(is_local%wrap%FBExp(compocn), 'Foxx_rofl'//iso(n) , rc=rc)) then
              ! liquid from river and possibly flood from river to ocean
              if (fldchk(is_local%wrap%FBImp(comprof, comprof), 'Forr_rofl'//iso(n) , rc=rc)) then
-                call addmap(fldListFr(comprof)%flds, 'Forr_rofl'//iso(n), &
-                     compocn, map_rof2ocn_liq, 'none', rof2ocn_liq_rmap)
+                if (trim(rof2ocn_liq_rmap) == 'unset') then
+                   call addmap(fldListFr(comprof)%flds, 'Forr_rofl'//iso(n), &
+                        compocn, mapconsd, 'none', 'unset')
+                else
+                   call addmap(fldListFr(comprof)%flds, 'Forr_rofl'//iso(n), &
+                        compocn, map_rof2ocn_liq, 'none', rof2ocn_liq_rmap)
+                end if
                 if (fldchk(is_local%wrap%FBImp(comprof, comprof), 'Flrr_flood'//iso(n), rc=rc)) then
                    call addmap(fldListFr(comprof)%flds, 'Flrr_flood'//iso(n), &
                         compocn, mapconsd, 'one', rof2ocn_fmap)
@@ -1348,8 +1353,13 @@ contains
           if ( fldchk(is_local%wrap%FBExp(compocn), 'Foxx_rofi'//iso(n) , rc=rc)) then
              ! ice from river to ocean
              if (fldchk(is_local%wrap%FBImp(comprof, comprof), 'Forr_rofi'//iso(n) , rc=rc)) then
-                call addmap(fldListFr(comprof)%flds, 'Forr_rofi'//iso(n), &
-                     compocn, map_rof2ocn_ice, 'none', rof2ocn_ice_rmap)
+                if (trim(rof2ocn_ice_rmap) == 'unset') then
+                   call addmap(fldListFr(comprof)%flds, 'Forr_rofi'//iso(n), &
+                        compocn, mapconsd, 'none', 'unset')
+                else
+                   call addmap(fldListFr(comprof)%flds, 'Forr_rofi'//iso(n), &
+                        compocn, map_rof2ocn_ice, 'none', rof2ocn_ice_rmap)
+                end if
                 call addmrg(fldListTo(compocn)%flds, 'Foxx_rofi'//iso(n), &
                      mrg_from=comprof, mrg_fld='Forr_rofi', mrg_type='sum')
              end if

--- a/mediator/med.F90
+++ b/mediator/med.F90
@@ -2547,7 +2547,7 @@ contains
     endif
 
     ! check and set the component clock against the driver clock
-    call NUOPC_CompCheckSetClock(gcomp, driverClock, rc=rc)
+    call NUOPC_CompCheckSetClock(gcomp, driverClock, checkTimeStep=.false., rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
 
     !--------------------------------


### PR DESCRIPTION
### Description of changes
new run sequence for B1850 nuopc validation

### Specific notes
This PR requires ESMF https://github.com/esmf-org/esmf/releases/tag/ESMF_8_2_0_beta_snapshot_13 and later snapshots.
With this new snapshot, this PR does the following:
1) Enables a new run RASM_OPTION1 sequence for fully coupled CESM nuopc simulations. 
The new run sequence will look like the following:
```
@432000
@10800
@3600
@1800
  MED med_phases_aofluxes_run
  MED med_phases_prep_ocn_accum
  MED med_phases_ocnalb_run
  MED med_phases_diag_ocn
@@3600
  MED med_phases_prep_ocn_avg
  MED -> OCN :remapMethod=redist
@@
```
With this new run sequence, careful comparison with the RASM_OPTION1 cesm simulation validated this configuration for NUOPC with POP.
2) A fix to the budget table has been put in place to fix problems with MOM6 budgets when running a fully coupled simulation.

**NOTE: prealpha tests need to be run before this PR can be migrated from a draft status.**

Contributors other than yourself, if any:

CMEPS Issues Fixed (include github issue #):

Are changes expected to change answers?
 - [ ] bit for bit
 - [ ] different at roundoff level
 - [x] more substantial - ONLY for B compsets in CESM

Any User Interface Changes (namelist or namelist defaults changes)?
 - [ ] Yes
 - [x] No

Testing performed if application target is CESM:(either UFS-S2S or CESM testing is required):
- [ ] (recommended) CIME_DRIVER=nuopc scripts_regression_tests.py
   - machines:
   - details (e.g. failed tests):
- [ ] (recommended) CESM testlist_drv.xml
   - machines and compilers:
   - details (e.g. failed tests):
- [ ] (optional) CESM prealpha test
   - machines and compilers
   - details (e.g. failed tests):
- [x] (other) please described in detail
   - machines and compilers: cheyenne/intel
   - details (e.g. failed tests): compare new run sequence for B1850 f19_g17 with mct version and verified that new runsequence resolve older problem in validation!

Testing performed if application target is UFS-coupled:
- [ ] (recommended) UFS-coupled testing
   - description:
   - details (e.g. failed tests):

Testing performed if application target is UFS-HAFS:
- [ ] (recommended) UFS-HAFS testing
   - description:
   - details (e.g. failed tests):

Hashes used for testing:
- [x] CESM:
  - repository to check out: https://github.com/ESCOMP/CESM.git
  - hash: cesm2_3_beta04
- [ ] UFS-coupled, then umbrella repostiory to check out and associated hash:
  - repository to check out:
  - branch:
  - hash:
- [ ] UFS-HAFS, then umbrella repostiory to check out and associated hash:
  - repository to check out:
  - branch:
  - hash:
