### PR TITLE
fix typo in config_component_cesm.xml (cesm only)

### DIFF
--- a/cime_config/config_component_cesm.xml
+++ b/cime_config/config_component_cesm.xml
@@ -418,7 +418,7 @@
     <default_value>TIGHT</default_value>
     <values match="last">
       <value compset="_DATM.*_DOCN%SOM"			>OPTION2</value>
-      <value compset="_POP2"				>OPTION2M</value>
+      <value compset="_POP2"				>OPTION2</value>
       <value compset="_MOM6"				>OPTION1</value>
       <value compset="_POP2" grid="oi%gx1v6"		>OPTION1</value>
       <value compset="_POP2" grid="oi%gx1v7"		>OPTION1</value>
@@ -430,13 +430,13 @@
     <file>env_run.xml</file>
     <desc>
       OPTION1 (like RASM_OPTION1 in CPL7) runs prep_ocn_avg, 
-      AFTER the aoflux and ocnalb calculations, thereby reducing
+      BEFORE the aoflux and ocnalb calculations, thereby reducing
       most of the lags and field inconsistency but still allowing the
       ocean to run concurrently with the ice and atmosphere.
       OPTION2 (like CESM1_MOD in CPL7) runs prep_ocn_avg, 
-      BEFORE the aoflux and ocnalb calculations, thereby permitting maximum
+      AFTER the aoflux and ocnalb calculations, thereby permitting maximum
       concurrency
-      TIGHT (like CESM1_MOD_TIGHT), tight coupling
+      TIGHT (like CESM1_MOD_TIGHT), is a tight coupling run sequence
     </desc>
   </entry>
 


### PR DESCRIPTION
### Description of changes
fix typo in config_component_cesm.xml (cesm only)

### Specific notes
This fixes a typo in config_component_cesm.xml and is needed as a high priority for cesm2_3_alpha05b.

Contributors other than yourself, if any:

CMEPS Issues Fixed (include github issue #):

Are changes expected to change answers?
 - [x] bit for bit
 - [ ] different at roundoff level
 - [ ] more substantial

Any User Interface Changes (namelist or namelist defaults changes)?
 - [ ] Yes
 - [x] No

Testing performed if application target is CESM:(either UFS-S2S or CESM testing is required):
- [ ] (recommended) CIME_DRIVER=nuopc scripts_regression_tests.py
   - machines:
   - details (e.g. failed tests):
- [ ] (recommended) CESM testlist_drv.xml
   - machines and compilers:
   - details (e.g. failed tests):
- [ ] (optional) CESM prealpha test
   - machines and compilers
   - details (e.g. failed tests):
- [x] (other) please described in detail
   - machines and compilers cheyenne/gnu
   - details (e.g. failed tests): verified that previous failed test ERS_Vnuopc.T62_g37.G.cheyenne_gnu.pop-cice can now be created

Testing performed if application target is UFS-coupled: NA

Testing performed if application target is UFS-HAFS: NA

Hashes used for testing:
- [x] CESM:
  - repository to check out: https://github.com/ESCOMP/CESM.git
  - hash: cesm2_3_alpha05b
hash:
