### PR TITLE
fixed run sequence bug for G and C compsets (only for CESM)

### DIFF
--- a/cime_config/runseq/runseq_general.py
+++ b/cime_config/runseq/runseq_general.py
@@ -89,16 +89,20 @@ def gen_runseq(case, coupling_times):
         runseq.enter_time_loop(atm_cpl_time, newtime=inner_loop)
         #------------------
 
-        if (cpl_seq_option == 'OPTION1'):
+        if (cpl_seq_option == 'OPTION1' or cpl_seq_option == 'OPTION2'):
             if cpl_add_aoflux:
                 runseq.add_action("MED med_phases_aofluxes_run" , run_ocn and run_atm and (med_to_ocn or med_to_atm))
             runseq.add_action("MED med_phases_prep_ocn_accum"   , med_to_ocn)
             runseq.add_action("MED med_phases_ocnalb_run"       , (run_ocn and run_atm and (med_to_ocn or med_to_atm)) and not xcompset)
             runseq.add_action("MED med_phases_diag_ocn"         , run_ocn and diag_mode) 
-            runseq.enter_time_loop(ocn_cpl_time, newtime=inner_loop, addextra_atsign=True)
+
+        if (cpl_seq_option == 'OPTION1'):
+            if ocn_cpl_time != atm_cpl_time:
+                runseq.enter_time_loop(ocn_cpl_time, newtime=inner_loop, addextra_atsign=True)
             runseq.add_action("MED med_phases_prep_ocn_avg"    , med_to_ocn and ocn_outer_loop)
             runseq.add_action("MED -> OCN :remapMethod=redist" , med_to_ocn and ocn_outer_loop)
-            runseq.leave_time_loop(inner_loop, addextra_atsign=True)
+            if ocn_cpl_time != atm_cpl_time:
+                runseq.leave_time_loop(inner_loop, addextra_atsign=True)
 
         runseq.add_action("MED med_phases_prep_lnd"        , med_to_lnd)
         runseq.add_action("MED -> LND :remapMethod=redist" , med_to_lnd)


### PR DESCRIPTION
### Description of changes
fixed run sequence bug for G and C compsets (only for CESM)

### Specific notes
This PR fixes generated run sequence bug for G and C compsets  that were introduced in the PR https://github.com/ESCOMP/CMEPS/pull/215

Contributors other than yourself, if any:

CMEPS Issues Fixed:

Are changes expected to change answers?
 - [x] bit for bit
 - [ ] different at roundoff level
 - [ ] more substantial

Any User Interface Changes (namelist or namelist defaults changes)?
 - [ ] Yes
 - [x] No (reverts to previous correct run sequence for C and G compsets)

Testing performed if application target is CESM:(either UFS-S2S or CESM testing is required): Manual examination of run sequence
- [ ] (recommended) CIME_DRIVER=nuopc scripts_regression_tests.py
   - machines:
   - details (e.g. failed tests):
- [ ] (recommended) CESM testlist_drv.xml
   - machines and compilers:
   - details (e.g. failed tests):
- [ ] (optional) CESM prealpha test
   - machines and compilers
   - details (e.g. failed tests):
- [ ] (other) please described in detail
   - machines and compilers
   - details (e.g. failed tests):

Testing performed if application target is UFS-coupled:
- [ ] (recommended) UFS-coupled testing
   - description:
   - details (e.g. failed tests):

Testing performed if application target is UFS-HAFS:
- [ ] (recommended) UFS-HAFS testing
   - description:
   - details (e.g. failed tests):

Hashes used for testing:
- [ ] CESM:
  - repository to check out: https://github.com/ESCOMP/CESM.git
  - branch:
  - hash:cmeps0.13.19

