### PR TITLE
add support for REST_OPTION end and always write a restart at end of …

### DIFF
--- a/cime_config/buildnml
+++ b/cime_config/buildnml
@@ -48,6 +48,7 @@ def _create_drv_namelists(case, infile, confdir, nmlgen, files):
     config['continue_run'] = '.true.' if case.get_value('CONTINUE_RUN') else '.false.'
     config['flux_epbal'] = 'ocn' if case.get_value('CPL_EPBAL')  == 'ocn' else 'off'
     config['mask_grid'] = case.get_value('MASK_GRID')
+    config['rest_option'] = case.get_value('REST_OPTION')
 
     atm_grid = case.get_value('ATM_GRID')
     lnd_grid = case.get_value('LND_GRID')

--- a/cime_config/namelist_definition_drv.xml
+++ b/cime_config/namelist_definition_drv.xml
@@ -359,6 +359,17 @@
   <!-- All components orbital attributes           -->
   <!-- =========================================== -->
 
+  <entry id="write_restart_at_endofrun">
+    <type>char</type>
+    <category>nuopc</category>
+    <group>ALLCOMP_attributes</group>
+    <values>
+      <value>.true.</value>
+      <value rest_option="none">.false.</value>
+      <value rest_option="never">.false.</value>
+    </values>
+  </entry>
+
   <entry id="Profiling" modify_via_xml="ESMF_PROFILING_LEVEL">
     <type>char</type>
     <category>nuopc</category>

--- a/mediator/med.F90
+++ b/mediator/med.F90
@@ -2579,7 +2579,6 @@ contains
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
 
     if (.not. stopalarmcreated) then
-       print *,__FILE__,__LINE__, 'Create stop alarm'
        call NUOPC_CompAttributeGet(gcomp, name="stop_option", value=stop_option, rc=rc)
        if (ChkErr(rc,__LINE__,u_FILE_u)) return
        call NUOPC_CompAttributeGet(gcomp, name="stop_n", value=cvalue, rc=rc)

--- a/mediator/med_diag_mod.F90
+++ b/mediator/med_diag_mod.F90
@@ -381,22 +381,6 @@ contains
     allocate(budget_counter  (f_size , c_size , p_size)) ! counter, valid only on root pe
     allocate(budget_global_1d(f_size * c_size * p_size)) ! needed for ESMF_VMReduce call
 
-    if (budget_print_inst + budget_print_daily + budget_print_month + budget_print_ann + budget_print_ltann + budget_print_ltend > 0) then
-       ! Set stop alarm (needed for budgets)
-       call NUOPC_CompAttributeGet(gcomp, name="stop_option", value=stop_option, rc=rc)
-       if (ChkErr(rc,__LINE__,u_FILE_u)) return
-       call NUOPC_CompAttributeGet(gcomp, name="stop_n", value=cvalue, rc=rc)
-       if (ChkErr(rc,__LINE__,u_FILE_u)) return
-       read(cvalue,*) stop_n
-       call NUOPC_CompAttributeGet(gcomp, name="stop_ymd", value=cvalue, rc=rc)
-       if (ChkErr(rc,__LINE__,u_FILE_u)) return
-       read(cvalue,*) stop_ymd
-       call NUOPC_MediatorGet(gcomp, mediatorClock=mediatorClock, rc=rc)
-       if (ChkErr(rc,__LINE__,u_FILE_u)) return
-       call alarmInit(mediatorclock, stop_alarm, stop_option, opt_n=stop_n, opt_ymd=stop_ymd, &
-            alarmname='alarm_stop', rc=rc)
-       if (ChkErr(rc,__LINE__,u_FILE_u)) return
-    endif
   end subroutine med_diag_init
 
   integer function get_diag_attribute(gcomp, name, rc)

--- a/mediator/med_time_mod.F90
+++ b/mediator/med_time_mod.F90
@@ -38,6 +38,7 @@ module med_time_mod
        optMonthly        = "monthly"   , &
        optYearly         = "yearly"    , &
        optDate           = "date"      , &
+       optEnd            = "end"       , &
        optGLCCouplingPeriod = "glc_coupling_period"
 
   ! Module data
@@ -154,6 +155,20 @@ contains
        if (ChkErr(rc,__LINE__,u_FILE_u)) return
        update_nextalarm  = .false.
 
+    case (optNever)
+       call ESMF_TimeIntervalSet(AlarmInterval, yy=9999, rc=rc)
+       if (ChkErr(rc,__LINE__,u_FILE_u)) return
+       call ESMF_TimeSet( NextAlarm, yy=9999, mm=12, dd=1, s=0, calendar=cal, rc=rc )
+       if (ChkErr(rc,__LINE__,u_FILE_u)) return
+       update_nextalarm  = .false.
+
+    case (optEnd)
+       call ESMF_TimeIntervalSet(AlarmInterval, yy=9999, rc=rc)
+       if (ChkErr(rc,__LINE__,u_FILE_u)) return
+       call ESMF_TimeSet( NextAlarm, yy=9999, mm=12, dd=1, s=0, calendar=cal, rc=rc )
+       if (ChkErr(rc,__LINE__,u_FILE_u)) return
+       update_nextalarm  = .false.
+
    case (optDate)
       call ESMF_TimeIntervalSet(AlarmInterval, yy=9999, rc=rc)
       if (ChkErr(rc,__LINE__,u_FILE_u)) return
@@ -162,13 +177,6 @@ contains
       call ESMF_TimeSet( NextAlarm, yy=cyy, mm=cmm, dd=cdd, s=ltod, calendar=cal, rc=rc )
       if (ChkErr(rc,__LINE__,u_FILE_u)) return
       update_nextalarm  = .false.
-
-    case (optNever)
-       call ESMF_TimeIntervalSet(AlarmInterval, yy=9999, rc=rc)
-       if (ChkErr(rc,__LINE__,u_FILE_u)) return
-       call ESMF_TimeSet( NextAlarm, yy=9999, mm=12, dd=1, s=0, calendar=cal, rc=rc )
-       if (ChkErr(rc,__LINE__,u_FILE_u)) return
-       update_nextalarm  = .false.
 
     case (optNSteps)
        call ESMF_ClockGet(clock, TimeStep=AlarmInterval, rc=rc)
@@ -224,7 +232,6 @@ contains
        call ESMF_TimeSet( NextAlarm, yy=cyy, mm=1, dd=1, s=0, calendar=cal, rc=rc )
        if (ChkErr(rc,__LINE__,u_FILE_u)) return
        update_nextalarm  = .true.
-
     case default
        call ESMF_LogWrite(subname//'unknown option '//trim(option), ESMF_LOGMSG_ERROR)
        rc = ESMF_FAILURE

--- a/nuopc_cap_share/nuopc_shr_methods.F90
+++ b/nuopc_cap_share/nuopc_shr_methods.F90
@@ -60,8 +60,10 @@ module nuopc_shr_methods
        optNYear          = "nyear"     , &
        optMonthly        = "monthly"   , &
        optYearly         = "yearly"    , &
+       optEnd            = "end"       , &
        optDate           = "date"
 
+  
   ! Module data
   integer, parameter :: SecPerDay = 86400 ! Seconds per day
   integer, parameter :: memdebug_level=1
@@ -558,6 +560,13 @@ contains
        if (chkerr(rc,__LINE__,u_FILE_u)) return
        update_nextalarm  = .false.
 
+    case (optEnd)
+       call ESMF_TimeIntervalSet(AlarmInterval, yy=9999, rc=rc)
+       if (chkerr(rc,__LINE__,u_FILE_u)) return
+       call ESMF_TimeSet( NextAlarm, yy=9999, mm=12, dd=1, s=0, calendar=cal, rc=rc )
+       if (chkerr(rc,__LINE__,u_FILE_u)) return
+       update_nextalarm  = .false.
+
     case (optDate)
        if (.not. present(opt_ymd)) then
           call shr_sys_abort(subname//trim(option)//' requires opt_ymd')
@@ -747,7 +756,7 @@ contains
        call ESMF_TimeSet( NextAlarm, yy=cyy, mm=1, dd=1, s=0, calendar=cal, rc=rc )
        if (chkerr(rc,__LINE__,u_FILE_u)) return
        update_nextalarm  = .true.
-
+       
     case default
        call shr_sys_abort(subname//'unknown option '//trim(option))
 
@@ -766,7 +775,6 @@ contains
           NextAlarm = NextAlarm + AlarmInterval
        enddo
     endif
-
     alarm = ESMF_AlarmCreate( name=lalarmname, clock=clock, ringTime=NextAlarm, &
          ringInterval=AlarmInterval, rc=rc)
     if (chkerr(rc,__LINE__,u_FILE_u)) return


### PR DESCRIPTION
…run unless restart is none or never

### Description of changes

Adds support for REST_OPTION='end', also all runs with any REST_OPTION other that none or never will write a restart file at the end of the run.  

### Specific notes

Contributors other than yourself, if any:

CMEPS Issues Fixed (include github issue #):

Are changes expected to change answers?
 - [X] bit for bit
 - [ ] different at roundoff level
 - [ ] more substantial

Any User Interface Changes (namelist or namelist defaults changes)?
 - [ ] Yes
 - [X] No

Testing performed if application target is CESM:(either UFS-S2S or CESM testing is required):
- [X] (recommended) CIME_DRIVER=nuopc scripts_regression_tests.py
   - machines: cheyenne intel nuopc all pass
   - details (e.g. failed tests):
- [X] (recommended) CESM testlist_drv.xml
   - machines and compilers: cheyenne intel 
   - details (e.g. failed tests):
- [ ] (optional) CESM prealpha test
   - machines and compilers
   - details (e.g. failed tests):
- [ ] (other) please described in detail
   - machines and compilers
   - details (e.g. failed tests):

Testing performed if application target is UFS-coupled:
- [ ] (recommended) UFS-coupled testing
   - description:
   - details (e.g. failed tests):

Testing performed if application target is UFS-HAFS:
- [ ] (recommended) UFS-HAFS testing
   - description:
   - details (e.g. failed tests):

Hashes used for testing:
- [X] CESM: cesm2_3_alpha5b 
  - repository to check out: https://github.com/ESCOMP/CESM.git
  - branch:
  - hash:
- [ ] UFS-coupled, then umbrella repostiory to check out and associated hash:
  - repository to check out:
  - branch:
  - hash:
- [ ] UFS-HAFS, then umbrella repostiory to check out and associated hash:
  - repository to check out:
  - branch:
  - hash:
