### PR TITLE
fixed nag compilation problem

### DIFF
--- a/mediator/esmFldsExchange_cesm_mod.F90
+++ b/mediator/esmFldsExchange_cesm_mod.F90
@@ -212,13 +212,13 @@ contains
 
        ! write diagnostic output
        if (mastertask) then
-          write(logunit,'(a,l)') trim(subname)//' flds_co2a         = ',flds_co2a
-          write(logunit,'(a,l)') trim(subname)//' flds_co2b         = ',flds_co2b
-          write(logunit,'(a,l)') trim(subname)//' flds_co2c         = ',flds_co2b
-          write(logunit,'(a,l)') trim(subname)//' flds_wiso         = ',flds_wiso
-          write(logunit,'(a,l)') trim(subname)//' flds_i2o_per_cat  = ',flds_i2o_per_cat
-          write(logunit,'(a,l)') trim(subname)//' ocn2glc_coupling  = ',ocn2glc_coupling
-          write(logunit,'(a,l)') trim(subname)//' mapuv_with_cart3d = ',mapuv_with_cart3d
+          write(logunit,'(a,l7)') trim(subname)//' flds_co2a         = ',flds_co2a
+          write(logunit,'(a,l7)') trim(subname)//' flds_co2b         = ',flds_co2b
+          write(logunit,'(a,l7)') trim(subname)//' flds_co2c         = ',flds_co2b
+          write(logunit,'(a,l7)') trim(subname)//' flds_wiso         = ',flds_wiso
+          write(logunit,'(a,l7)') trim(subname)//' flds_i2o_per_cat  = ',flds_i2o_per_cat
+          write(logunit,'(a,l7)') trim(subname)//' ocn2glc_coupling  = ',ocn2glc_coupling
+          write(logunit,'(a,l7)') trim(subname)//' mapuv_with_cart3d = ',mapuv_with_cart3d
        end if
 
     end if


### PR DESCRIPTION
### Description of changes
fix nag compilation problem

### Specific notes
This lightweight PR fixes a nag compilation problem. 

Contributors other than yourself, if any:

CMEPS Issues Fixed: None

Are changes expected to change answers?
 - [x] bit for bit
 - [ ] different at roundoff level
 - [ ] more substantial

Any User Interface Changes (namelist or namelist defaults changes)?
 - [ ] Yes
 - [x] No

Testing performed if application target is CESM:(either UFS-S2S or CESM testing is required):
- [ ] (recommended) CIME_DRIVER=nuopc scripts_regression_tests.py
   - machines:
   - details (e.g. failed tests):
- [ ] (recommended) CESM testlist_drv.xml
   - machines and compilers:
   - details (e.g. failed tests):
- [ ] (optional) CESM prealpha test
   - machines and compilers
   - details (e.g. failed tests):
- [x] (other) please described in detail
   - machines and compilers izumi/intel
   - details (e.g. failed tests): Verified that the following test now builds SMS_D_Ld3_Vnuopc.f45_g37_rx1.A.izumi_nag

Testing performed if application target is UFS-coupled:
- [ ] (recommended) UFS-coupled testing
   - description:
   - details (e.g. failed tests):

Testing performed if application target is UFS-HAFS:
- [ ] (recommended) UFS-HAFS testing
   - description:
   - details (e.g. failed tests):

Hashes used for testing:
- [ ] CESM:
  - repository to check out: https://github.com/ESCOMP/CESM.git
  - branch:
  - hash: cmeps0.13.20
- [ ] UFS-coupled, then umbrella repostiory to check out and associated hash:
  - repository to check out:
  - branch:
  - hash:
- [ ] UFS-HAFS, then umbrella repostiory to check out and associated hash:
  - repository to check out:
  - branch:
  - hash:
