### PR TITLE
fix aoflux agrid/xgrid problems found in testing

### DIFF
--- a/cime_config/namelist_definition_drv.xml
+++ b/cime_config/namelist_definition_drv.xml
@@ -364,9 +364,9 @@
     <category>nuopc</category>
     <group>ALLCOMP_attributes</group>
     <values>
-      <value>.true.</value>
-      <value rest_option="none">.false.</value>
-      <value rest_option="never">.false.</value>
+      <value>.false.</value>
+      <!-- <value rest_option="none">.false.</value> -->
+      <!-- <value rest_option="never">.false.</value> -->
     </values>
   </entry>
 

--- a/cime_config/namelist_definition_drv.xml
+++ b/cime_config/namelist_definition_drv.xml
@@ -360,14 +360,13 @@
   <!-- =========================================== -->
 
   <entry id="write_restart_at_endofrun">
-    <type>char</type>
+    <type>logical</type>
     <category>nuopc</category>
     <group>ALLCOMP_attributes</group>
     <values>
       <value>.false.</value>
-      <!-- <value rest_option="none">.false.</value> -->
-      <!-- <value rest_option="never">.false.</value> -->
-    </values>
+      <value rest_option="end">.true.</value>
+      </values>
   </entry>
 
   <entry id="Profiling" modify_via_xml="ESMF_PROFILING_LEVEL">

--- a/cime_config/testdefs/testlist_drv.xml
+++ b/cime_config/testdefs/testlist_drv.xml
@@ -7,9 +7,8 @@
 
   <test compset="A" grid="f19_g17_rx1" name="SMS_Vnuopc_Ld1_N3">
     <machines>
-      <machine name="cheyenne" compiler="intel" category="nuopc"/>
-      <machine name="theia" compiler="intel" category="nuopc"/>
-      <machine name="izumi" compiler="intel" category="nuopc"/>
+      <machine name="cheyenne" compiler="intel" category="aux_cmeps"/>
+      <machine name="izumi" compiler="intel" category="aux_cmeps"/>
     </machines>
     <options>
       <option name="wallclock"> 00:10:00 </option>
@@ -17,19 +16,8 @@
   </test>
   <test compset="A" grid="f19_g17_rx1" name="SMS_Vnuopc_Ln11_D">
     <machines>
-      <machine name="cheyenne" compiler="intel" category="nuopc"/>
-      <machine name="theia" compiler="intel" category="nuopc"/>
-      <machine name="izumi" compiler="intel" category="nuopc"/>
-    </machines>
-    <options>
-      <option name="wallclock"> 00:10:00 </option>
-    </options>
-  </test>
-  <test compset="A" grid="f19_g17_rx1" name="SMS_Vmct_Ld1">
-    <machines>
-      <machine name="cheyenne" compiler="intel" category="nuopc"/>
-      <machine name="theia" compiler="intel" category="nuopc"/>
-      <machine name="izumi" compiler="intel" category="nuopc"/>
+      <machine name="cheyenne" compiler="intel" category="aux_cmeps"/>
+      <machine name="izumi" compiler="intel" category="aux_cmeps"/>
     </machines>
     <options>
       <option name="wallclock"> 00:10:00 </option>
@@ -37,19 +25,8 @@
   </test>
   <test compset="A" grid="f19_g17_rx1" name="ERS_Vnuopc_Ln9_N3">
     <machines>
-      <machine name="cheyenne" compiler="intel" category="nuopc"/>
-      <machine name="theia" compiler="intel" category="nuopc"/>
-      <machine name="izumi" compiler="intel" category="nuopc"/>
-    </machines>
-    <options>
-      <option name="wallclock"> 00:10:00 </option>
-    </options>
-  </test>
-  <test compset="A" grid="f19_g17_rx1" name="ERS_Vmct_Ln9">
-    <machines>
-      <machine name="cheyenne" compiler="intel" category="mctcheck"/>
-      <machine name="theia" compiler="intel" category="mctcheck"/>
-      <machine name="izumi" compiler="intel" category="mctcheck"/>
+      <machine name="cheyenne" compiler="intel" category="aux_cmeps"/>
+      <machine name="izumi" compiler="intel" category="aux_cmeps"/>
     </machines>
     <options>
       <option name="wallclock"> 00:10:00 </option>
@@ -57,19 +34,8 @@
   </test>
   <test compset="ADWAV" grid="ww3a" name="SMS_Vnuopc_Ld2">
     <machines>
-      <machine name="cheyenne" compiler="intel" category="nuopc"/>
-      <machine name="theia" compiler="intel" category="nuopc"/>
-      <machine name="izumi" compiler="intel" category="nuopc"/>
-    </machines>
-    <options>
-      <option name="wallclock"> 00:10:00 </option>
-    </options>
-  </test>
-  <test compset="ADWAV" grid="ww3a" name="SMS_Vmct_Ld2">
-    <machines>
-      <machine name="cheyenne" compiler="intel" category="mctcheck"/>
-      <machine name="theia" compiler="intel" category="mctcheck"/>
-      <machine name="izumi" compiler="intel" category="mctcheck"/>
+      <machine name="cheyenne" compiler="intel" category="aux_cmeps"/>
+      <machine name="izumi" compiler="intel" category="aux_cmeps"/>
     </machines>
     <options>
       <option name="wallclock"> 00:10:00 </option>
@@ -77,19 +43,8 @@
   </test>
   <test compset="A1850DLND" grid="f09_f09_mg17" name="SMS_Vnuopc_Ld3">
     <machines>
-      <machine name="cheyenne" compiler="intel" category="nuopc"/>
-      <machine name="theia" compiler="intel" category="nuopc"/>
-      <machine name="izumi" compiler="intel" category="nuopc"/>
-    </machines>
-    <options>
-      <option name="wallclock"> 00:10:00 </option>
-    </options>
-  </test>
-  <test compset="A1850DLND" grid="f09_f09_mg17" name="SMS_Vmct_Ld3">
-    <machines>
-      <machine name="cheyenne" compiler="intel" category="mctcheck"/>
-      <machine name="theia" compiler="intel" category="mctcheck"/>
-      <machine name="izumi" compiler="intel" category="mctcheck"/>
+      <machine name="cheyenne" compiler="intel" category="aux_cmeps"/>
+      <machine name="izumi" compiler="intel" category="aux_cmeps"/>
     </machines>
     <options>
       <option name="wallclock"> 00:10:00 </option>
@@ -102,19 +57,8 @@
 
   <test compset="X" grid="f19_g17" name="SMS_Vnuopc">
     <machines>
-      <machine name="cheyenne" compiler="intel" category="nuopc"/>
-      <machine name="theia" compiler="intel" category="nuopc"/>
-      <machine name="izumi" compiler="intel" category="nuopc"/>
-    </machines>
-    <options>
-      <option name="wallclock"> 00:20:00 </option>
-    </options>
-  </test>
-  <test compset="X" grid="f19_g17" name="SMS_Vmct">
-    <machines>
-      <machine name="cheyenne" compiler="intel" category="nuopc"/>
-      <machine name="theia" compiler="intel" category="nuopc"/>
-      <machine name="izumi" compiler="intel" category="nuopc"/>
+      <machine name="cheyenne" compiler="intel" category="aux_cmeps"/>
+      <machine name="izumi" compiler="intel" category="aux_cmeps"/>
     </machines>
     <options>
       <option name="wallclock"> 00:20:00 </option>
@@ -122,22 +66,11 @@
   </test>
   <test compset="X" grid="f19_g17" name="ERS_Vnuopc_Ln9">
     <machines>
-      <machine name="cheyenne" compiler="intel" category="nuopc"/>
-      <machine name="theia" compiler="intel" category="nuopc"/>
-      <machine name="izumi" compiler="intel" category="nuopc"/>
+      <machine name="cheyenne" compiler="intel" category="aux_cmeps"/>
+      <machine name="izumi" compiler="intel" category="aux_cmeps"/>
     </machines>
     <options>
       <option name="wallclock"> 00:40:00 </option>
-    </options>
-  </test>
-  <test compset="X" grid="f19_g17" name="ERS_Vmct_Ln9">
-    <machines>
-      <machine name="cheyenne" compiler="intel" category="mctcheck"/>
-      <machine name="theia" compiler="intel" category="mctcheck"/>
-      <machine name="izumi" compiler="intel" category="mctcheck"/>
-    </machines>
-    <options>
-      <option name="wallclock"> 00:20:00 </option>
     </options>
   </test>
 
@@ -147,30 +80,17 @@
 
   <test compset="B1850MOM" grid="f09_t061" name="ERR_Vnuopc_Ld5" testmods="allactive/nuopc_cap_io">
     <machines>
-      <machine name="cheyenne" compiler="intel" category="nuopc"/>
-      <machine name="theia" compiler="intel" category="nuopc"/>
-      <machine name="izumi" compiler="intel" category="nuopc"/>
+      <machine name="cheyenne" compiler="intel" category="aux_cmeps"/>
+      <machine name="izumi" compiler="intel" category="aux_cmeps"/>
     </machines>
     <options>
       <option name="wallclock"> 00:40:00 </option>
     </options>
   </test>
-  <test compset="B1850" grid="f09_g17" name="ERR_Vmct_Ld5" testmods="allactive/nuopc_cap_io">
-    <machines>
-      <machine name="cheyenne" compiler="intel" category="mctcheck"/>
-      <machine name="theia" compiler="intel" category="mctcheck"/>
-      <machine name="izumi" compiler="intel" category="mctcheck"/>
-    </machines>
-    <options>
-      <option name="wallclock"> 00:40:00 </option>
-    </options>
-  </test>
-
   <test compset="B1850" grid="f19_g17" name="ERS_Vnuopc_Ld5" testmods="allactive/nuopc_cap_io">
     <machines>
-      <machine name="cheyenne" compiler="intel" category="nuopc"/>
-      <machine name="theia" compiler="intel" category="nuopc"/>
-      <machine name="izumi" compiler="intel" category="nuopc"/>
+      <machine name="cheyenne" compiler="intel" category="aux_cmeps"/>
+      <machine name="izumi" compiler="intel" category="aux_cmeps"/>
     </machines>
     <options>
       <option name="wallclock"> 00:40:00 </option>
@@ -183,9 +103,8 @@
 
   <test compset="C" grid="T62_g17" name="ERS_Vnuopc_Ld5">
     <machines>
-      <machine name="cheyenne" compiler="intel" category="nuopc"/>
-      <machine name="theia" compiler="intel" category="nuopc"/>
-      <machine name="izumi" compiler="intel" category="nuopc"/>
+      <machine name="cheyenne" compiler="intel" category="aux_cmeps"/>
+      <machine name="izumi" compiler="intel" category="aux_cmeps"/>
     </machines>
     <options>
       <option name="wallclock"> 00:40:00 </option>
@@ -193,9 +112,8 @@
   </test>
   <test compset="CMOM" grid="T62_t061" name="SMS_Vnuopc_Ld5">
     <machines>
-      <machine name="cheyenne" compiler="intel" category="nuopc"/>
-      <machine name="theia" compiler="intel" category="nuopc"/>
-      <machine name="izumi" compiler="intel" category="nuopc"/>
+      <machine name="cheyenne" compiler="intel" category="aux_cmeps"/>
+      <machine name="izumi" compiler="intel" category="aux_cmeps"/>
     </machines>
     <options>
       <option name="wallclock"> 00:40:00 </option>
@@ -203,32 +121,11 @@
   </test>
   <test compset="CMOM" grid="T62_t061" name="ERS_Vnuopc_Ld5">
     <machines>
-      <machine name="cheyenne" compiler="intel" category="nuopc"/>
-      <machine name="theia" compiler="intel" category="nuopc"/>
-      <machine name="izumi" compiler="intel" category="nuopc"/>
+      <machine name="cheyenne" compiler="intel" category="aux_cmeps"/>
+      <machine name="izumi" compiler="intel" category="aux_cmeps"/>
     </machines>
     <options>
       <option name="wallclock"> 00:40:00 </option>
-    </options>
-  </test>
-  <test compset="CMOM" grid="T62_t061" name="SMS_Vmct_Ld5">
-    <machines>
-      <machine name="cheyenne" compiler="intel" category="mctcheck"/>
-      <machine name="theia" compiler="intel" category="mctcheck"/>
-      <machine name="izumi" compiler="intel" category="mctcheck"/>
-    </machines>
-    <options>
-      <option name="wallclock"> 00:10:00 </option>
-    </options>
-  </test>
-  <test compset="CMOM" grid="T62_t061" name="ERS_Vmct_Ld5">
-    <machines>
-      <machine name="cheyenne" compiler="intel" category="mctcheck"/>
-      <machine name="theia" compiler="intel" category="mctcheck"/>
-      <machine name="izumi" compiler="intel" category="mctcheck"/>
-    </machines>
-    <options>
-      <option name="wallclock"> 00:10:00 </option>
     </options>
   </test>
 
@@ -238,9 +135,8 @@
 
   <test compset="G" grid="T62_g17" name="ERS_Vnuopc_Ld5">
     <machines>
-      <machine name="cheyenne" compiler="intel" category="nuopc"/>
-      <machine name="theia" compiler="intel" category="nuopc"/>
-      <machine name="izumi" compiler="intel" category="nuopc"/>
+      <machine name="cheyenne" compiler="intel" category="aux_cmeps"/>
+      <machine name="izumi" compiler="intel" category="aux_cmeps"/>
     </machines>
     <options>
       <option name="wallclock"> 00:10:00 </option>
@@ -248,19 +144,8 @@
   </test>
   <test compset="GMOM" grid="T62_t061" name="SMS_Vnuopc_Ld5">
     <machines>
-      <machine name="cheyenne" compiler="intel" category="nuopc"/>
-      <machine name="theia" compiler="intel" category="nuopc"/>
-      <machine name="izumi" compiler="intel" category="nuopc"/>
-    </machines>
-    <options>
-      <option name="wallclock"> 00:10:00 </option>
-    </options>
-  </test>
-  <test compset="GMOM" grid="T62_t061" name="SMS_Vmct_Ld5">
-    <machines>
-      <machine name="cheyenne" compiler="intel" category="mctcheck"/>
-      <machine name="theia" compiler="intel" category="mctcheck"/>
-      <machine name="izumi" compiler="intel" category="mctcheck"/>
+      <machine name="cheyenne" compiler="intel" category="aux_cmeps"/>
+      <machine name="izumi" compiler="intel" category="aux_cmeps"/>
     </machines>
     <options>
       <option name="wallclock"> 00:10:00 </option>
@@ -268,23 +153,11 @@
   </test>
   <test compset="GMOM" grid="T62_t061" name="ERS_Vnuopc_Ld5">
     <machines>
-      <machine name="cheyenne" compiler="intel" category="nuopc"/>
-      <machine name="theia" compiler="intel" category="nuopc"/>
-      <machine name="izumi" compiler="intel" category="nuopc"/>
+      <machine name="cheyenne" compiler="intel" category="aux_cmeps"/>
+      <machine name="izumi" compiler="intel" category="aux_cmeps"/>
     </machines>
     <options>
       <option name="wallclock"> 00:20:00 </option>
-    </options>
-  </test>
-
-  <test compset="GMOM" grid="T62_t061" name="ERS_Vmct_Ld5">
-    <machines>
-      <machine name="cheyenne" compiler="intel" category="mctcheck"/>
-      <machine name="theia" compiler="intel" category="mctcheck"/>
-      <machine name="izumi" compiler="intel" category="mctcheck"/>
-    </machines>
-    <options>
-      <option name="wallclock"> 00:10:00 </option>
     </options>
   </test>
 
@@ -294,19 +167,8 @@
 
   <test compset="DTEST" grid="T62_g37" name="ERS_Vnuopc_Ld5">
     <machines>
-      <machine name="cheyenne" compiler="intel" category="nuopc"/>
-      <machine name="theia" compiler="intel" category="nuopc"/>
-      <machine name="izumi" compiler="intel" category="nuopc"/>
-    </machines>
-    <options>
-      <option name="wallclock"> 00:10:00 </option>
-    </options>
-  </test>
-  <test compset="DTEST" grid="T62_g37" name="ERS_Vmct_Ld5">
-    <machines>
-      <machine name="cheyenne" compiler="intel" category="mctcheck"/>
-      <machine name="theia" compiler="intel" category="mctcheck"/>
-      <machine name="izumi" compiler="intel" category="mctcheck"/>
+      <machine name="cheyenne" compiler="intel" category="aux_cmeps"/>
+      <machine name="izumi" compiler="intel" category="aux_cmeps"/>
     </machines>
     <options>
       <option name="wallclock"> 00:10:00 </option>
@@ -319,19 +181,8 @@
 
   <test compset="F2000Nuopc" grid="f19_f19_mg17" name="ERS_Vnuopc_Ln5" testmods="cam/nuopc_cap">
     <machines>
-      <machine name="cheyenne" compiler="intel" category="nuopc"/>
-      <machine name="theia" compiler="intel" category="nuopc"/>
-      <machine name="izumi" compiler="intel" category="nuopc"/>
-    </machines>
-    <options>
-      <option name="wallclock"> 00:10:00 </option>
-    </options>
-  </test>
-  <test compset="F2000Nuopc" grid="f19_f19_mg17" name="ERS_Vmct_Ln5" testmods="cam/nuopc_cap">
-    <machines>
-      <machine name="cheyenne" compiler="intel" category="mctcheck"/>
-      <machine name="theia" compiler="intel" category="mctcheck"/>
-      <machine name="izumi" compiler="intel" category="mctcheck"/>
+      <machine name="cheyenne" compiler="intel" category="aux_cmeps"/>
+      <machine name="izumi" compiler="intel" category="aux_cmeps"/>
     </machines>
     <options>
       <option name="wallclock"> 00:10:00 </option>
@@ -344,19 +195,8 @@
 
   <test compset="QPC4" grid="ne16_ne16_mg17" name="ERS_Vnuopc_Ln5" testmods="cam/nuopc_cap">
     <machines>
-      <machine name="cheyenne" compiler="intel" category="nuopc"/>
-      <machine name="theia" compiler="intel" category="nuopc"/>
-      <machine name="izumi" compiler="intel" category="nuopc"/>
-    </machines>
-    <options>
-      <option name="wallclock"> 00:10:00 </option>
-    </options>
-  </test>
-  <test compset="QPC4" grid="ne16_ne16_mg17" name="ERS_Vmct_Ln5" testmods="cam/nuopc_cap">
-    <machines>
-      <machine name="cheyenne" compiler="intel" category="mctcheck"/>
-      <machine name="theia" compiler="intel" category="mctcheck"/>
-      <machine name="izumi" compiler="intel" category="mctcheck"/>
+      <machine name="cheyenne" compiler="intel" category="aux_cmeps"/>
+      <machine name="izumi" compiler="intel" category="aux_cmeps"/>
     </machines>
     <options>
       <option name="wallclock"> 00:10:00 </option>
@@ -369,9 +209,8 @@
 
   <test compset="I2000Clm51Bgc" grid="f19_g17" name="ERS_Vnuopc_Ld5" testmods="clm/default">
     <machines>
-      <machine name="cheyenne" compiler="intel" category="nuopc"/>
-      <machine name="theia" compiler="intel" category="nuopc"/>
-      <machine name="izumi" compiler="intel" category="nuopc"/>
+      <machine name="cheyenne" compiler="intel" category="aux_cmeps"/>
+      <machine name="izumi" compiler="intel" category="aux_cmeps"/>
     </machines>
     <options>
       <option name="wallclock"> 00:20:00 </option>
@@ -379,9 +218,8 @@
   </test>
   <test compset="I1850Clm50Sp" grid="f09_g17" name="ERS_Vnuopc_Ld5" testmods="clm/default">
     <machines>
-      <machine name="cheyenne" compiler="intel" category="nuopc"/>
-      <machine name="theia" compiler="intel" category="nuopc"/>
-      <machine name="izumi" compiler="intel" category="nuopc"/>
+      <machine name="cheyenne" compiler="intel" category="aux_cmeps"/>
+      <machine name="izumi" compiler="intel" category="aux_cmeps"/>
     </machines>
     <options>
       <option name="wallclock"> 00:20:00 </option>
@@ -389,9 +227,8 @@
   </test>
   <test compset="I1850Clm50SpG" grid="f10_f10_mg37" name="ERS_Vnuopc_Lm13">
     <machines>
-      <machine name="cheyenne" compiler="intel" category="nuopc"/>
-      <machine name="theia" compiler="intel" category="nuopc"/>
-      <machine name="izumi" compiler="intel" category="nuopc"/>
+      <machine name="cheyenne" compiler="intel" category="aux_cmeps"/>
+      <machine name="izumi" compiler="intel" category="aux_cmeps"/>
     </machines>
     <options>
       <option name="wallclock"> 00:20:00 </option>
@@ -399,8 +236,8 @@
   </test>
   <test compset="I2000Clm50BgcCropRtm" grid="f10_f10_mg37" name="SMS_D_Ld5_Vnuopc" testmods="rtm/default">
     <machines>
-      <machine name="cheyenne" compiler="intel" category="nuopc"/>
-      <machine name="izumi" compiler="nag" category="nuopc"/>
+      <machine name="cheyenne" compiler="intel" category="aux_cmeps"/>
+      <machine name="izumi" compiler="nag" category="aux_cmeps"/>
     </machines>
     <options>
       <option name="wallclock"> 00:20:00 </option>
@@ -413,7 +250,7 @@
 
   <test name="SMS_D_Ly1_Vnuopc" grid="f09_g17_gl4" compset="T1850Gg">
     <machines>
-      <machine name="cheyenne" compiler="intel" category="nuopc">
+      <machine name="cheyenne" compiler="intel" category="aux_cmeps">
         <options>
           <option name="wallclock">0:20</option>
         </options>
@@ -422,7 +259,7 @@
   </test>
   <test name="ERS_Ly3_Vnuopc" grid="f09_g17_gl4" compset="T1850Gg">
     <machines>
-      <machine name="cheyenne" compiler="intel" category="nuopc">
+      <machine name="cheyenne" compiler="intel" category="aux_cmeps">
         <options>
           <option name="wallclock">0:20</option>
         </options>

--- a/cime_config/testdefs/testlist_drv.xml
+++ b/cime_config/testdefs/testlist_drv.xml
@@ -176,10 +176,18 @@
   </test>
 
   <!-- ======================================= -->
-  <!-- F compsets -->
+  <!-- F/Q compsets -->
   <!-- ======================================= -->
 
-  <test compset="F2000Nuopc" grid="f19_f19_mg17" name="ERS_Vnuopc_Ln5" testmods="cam/nuopc_cap">
+  <test compset="F2000climo" grid="f09_f09_mg17" name="ERP_Ln9" testmods="cam/outfrq9s">
+    <machines>
+      <machine name="cheyenne" compiler="intel" category="aux_cmeps"/>
+    </machines>
+    <options>
+      <option name="wallclock">00:10:00</option>
+    </options>
+  </test>
+  <test compset="QPC4" grid="ne16_ne16_mg17" name="ERS_Vnuopc_Ln5" testmods="cam/nuopc_cap">
     <machines>
       <machine name="cheyenne" compiler="intel" category="aux_cmeps"/>
       <machine name="izumi" compiler="intel" category="aux_cmeps"/>
@@ -188,18 +196,12 @@
       <option name="wallclock"> 00:10:00 </option>
     </options>
   </test>
-
-  <!-- ======================================= -->
-  <!-- Q compsets -->
-  <!-- ======================================= -->
-
-  <test compset="QPC4" grid="ne16_ne16_mg17" name="ERS_Vnuopc_Ln5" testmods="cam/nuopc_cap">
+  <test compset="QPC6" grid="ne5pg3_ne5pg3_mg37" name="ERP_Ln9" testmods="cam/outfrq9s_clubbmf">
     <machines>
-      <machine name="cheyenne" compiler="intel" category="aux_cmeps"/>
-      <machine name="izumi" compiler="intel" category="aux_cmeps"/>
+      <machine name="izumi" compiler="nag" category="aux_cam"/>
     </machines>
     <options>
-      <option name="wallclock"> 00:10:00 </option>
+      <option name="wallclock">00:10:00</option>
     </options>
   </test>
 

--- a/cime_config/testdefs/testlist_drv.xml
+++ b/cime_config/testdefs/testlist_drv.xml
@@ -78,7 +78,7 @@
   <!-- B compsets -->
   <!-- ======================================= -->
 
-  <test compset="B1850MOM" grid="f09_t061" name="ERR_Vnuopc_Ld5" testmods="allactive/nuopc_cap_io">
+  <test compset="B1850MOM" grid="f09_t061" name="ERR_Vnuopc_Ld5" testmods="allactive/defaultio">
     <machines>
       <machine name="cheyenne" compiler="intel" category="aux_cmeps"/>
       <machine name="izumi" compiler="intel" category="aux_cmeps"/>
@@ -87,7 +87,7 @@
       <option name="wallclock"> 00:40:00 </option>
     </options>
   </test>
-  <test compset="B1850" grid="f19_g17" name="ERS_Vnuopc_Ld5" testmods="allactive/nuopc_cap_io">
+  <test compset="B1850" grid="f19_g17" name="ERS_Vnuopc_Ld5" testmods="allactive/defaultio">
     <machines>
       <machine name="cheyenne" compiler="intel" category="aux_cmeps"/>
       <machine name="izumi" compiler="intel" category="aux_cmeps"/>

--- a/mediator/med.F90
+++ b/mediator/med.F90
@@ -2144,11 +2144,7 @@ contains
                is_local%wrap%med_coupling_active(compocn,compatm) = .true.
             end if
             call med_phases_aofluxes_init_fldbuns(gcomp, rc=rc)
-            if (ChkErr(rc,__LINE__,u_FILE_u)) return
-            is_local%wrap%do_med_aoflux = .false.
          end if
-      end if
-      if (is_local%wrap%do_med_aoflux) then
       end if
 
       !---------------------------------------

--- a/mediator/med.F90
+++ b/mediator/med.F90
@@ -1719,8 +1719,7 @@ contains
     !   -- Create mediator specific field bundles (not part of import/export states)
     !   -- Initialize FBExpAccums (to zero), and FBImp (from NStateImp)
     !   -- Read mediator restarts
-    !   -- Initialize route handles
-    !   -- Initialize field bundles for normalization
+    !   -- Initialize route handles field bundles for normalization
     !   -- return!
     ! For second loop:
     !   -- Copy import fields to local FBs
@@ -1756,7 +1755,7 @@ contains
     use med_phases_aofluxes_mod , only : med_phases_aofluxes_run, med_phases_aofluxes_init_fldbuns
     use med_phases_profile_mod  , only : med_phases_profile
     use med_diag_mod            , only : med_diag_zero, med_diag_init
-    use med_map_mod             , only : med_map_mapnorm_init, med_map_routehandles_init, med_map_packed_field_create
+    use med_map_mod             , only : med_map_routehandles_init, med_map_packed_field_create
     use med_io_mod              , only : med_io_init
     use esmFlds                 , only : fldListMed_aoflux
 
@@ -2172,19 +2171,15 @@ contains
 
       !---------------------------------------
       ! Initialize route handles and required normalization field bunds
-      ! Initialized packed field data structures
       !---------------------------------------
-
       call ESMF_LogWrite("before med_map_RouteHandles_init", ESMF_LOGMSG_INFO)
       call med_map_RouteHandles_init(gcomp, is_local%wrap%flds_scalar_name, logunit, rc)
       if (ChkErr(rc,__LINE__,u_FILE_u)) return
       call ESMF_LogWrite("after  med_map_RouteHandles_init", ESMF_LOGMSG_INFO)
 
-      call ESMF_LogWrite("before med_map_mapnorm_init", ESMF_LOGMSG_INFO)
-      call med_map_mapnorm_init(gcomp, rc)
-      if (ChkErr(rc,__LINE__,u_FILE_u)) return
-      call ESMF_LogWrite("after  med_map_mapnorm_init", ESMF_LOGMSG_INFO)
-
+      !---------------------------------------
+      ! Initialized packed field data structures
+      !---------------------------------------
       do ndst = 1,ncomps
          do nsrc = 1,ncomps
             if (is_local%wrap%med_coupling_active(nsrc,ndst)) then

--- a/mediator/med.F90
+++ b/mediator/med.F90
@@ -2101,26 +2101,18 @@ contains
       ! Create field bundles for mediator ocean albedo computation
 
       if ( is_local%wrap%med_coupling_active(compocn,compatm) .or. is_local%wrap%med_coupling_active(compatm,compocn)) then
-
          ! Create field bundles for mediator ocean albedo computation
          fieldCount = med_fldList_GetNumFlds(fldListMed_ocnalb)
          if (fieldCount > 0) then
-
-            ! if (.not. is_local%wrap%med_coupling_active(compatm,compocn)) then
-            !    is_local%wrap%med_coupling_active(compatm,compocn) = .true.
-            ! end if
-
             allocate(fldnames(fieldCount))
             call med_fldList_getfldnames(fldListMed_ocnalb%flds, fldnames, rc=rc)
             if (ChkErr(rc,__LINE__,u_FILE_u)) return
-
             call FB_init(is_local%wrap%FBMed_ocnalb_a, is_local%wrap%flds_scalar_name, &
                  STgeom=is_local%wrap%NStateImp(compatm), fieldnamelist=fldnames, name='FBMed_ocnalb_a', rc=rc)
             if (ChkErr(rc,__LINE__,u_FILE_u)) return
             if (mastertask) then
                write(logunit,'(a)') trim(subname)//' initializing FB FBMed_ocnalb_a'
             end if
-
             call FB_init(is_local%wrap%FBMed_ocnalb_o, is_local%wrap%flds_scalar_name, &
                  STgeom=is_local%wrap%NStateImp(compocn), fieldnamelist=fldnames, name='FBMed_ocnalb_o', rc=rc)
             if (ChkErr(rc,__LINE__,u_FILE_u)) return

--- a/mediator/med.F90
+++ b/mediator/med.F90
@@ -2131,13 +2131,25 @@ contains
       ! NOTE: this section must be done BEFORE the second call to esmFldsExchange
       ! Create field bundles for mediator ocean albedo computation
 
-      if ( is_local%wrap%med_coupling_active(compocn,compatm) .or. &
+      fieldCount = med_fldList_GetNumFlds(fldListMed_aoflux)
+      if ( fieldCount > 0 .and. &
+           is_local%wrap%med_coupling_active(compocn,compatm) .or. &
            is_local%wrap%med_coupling_active(compatm,compocn)) then
-         fieldCount = med_fldList_GetNumFlds(fldListMed_aoflux)
-         if (fieldCount > 0) then
-            call med_phases_aofluxes_init_fldbuns(gcomp, rc=rc)
-            if (ChkErr(rc,__LINE__,u_FILE_u)) return
+         is_local%wrap%do_med_aoflux = .true.
+      else
+         is_local%wrap%do_med_aoflux = .false.
+      end if
+      if (is_local%wrap%do_med_aoflux) then
+         if ( is_local%wrap%aoflux_grid == 'ogrid' .and. .not. &
+            is_local%wrap%med_coupling_active(compatm,compocn)) then
+            is_local%wrap%med_coupling_active(compatm,compocn) = .true.
          end if
+         if ( is_local%wrap%aoflux_grid == 'agrid' .and. .not. &
+            is_local%wrap%med_coupling_active(compocn,compatm)) then
+            is_local%wrap%med_coupling_active(compocn,compatm) = .true.
+         end if
+         call med_phases_aofluxes_init_fldbuns(gcomp, rc=rc)
+         if (ChkErr(rc,__LINE__,u_FILE_u)) return
       end if
 
       !---------------------------------------

--- a/mediator/med.F90
+++ b/mediator/med.F90
@@ -2154,9 +2154,15 @@ contains
 
       ! Force the coupling to be active between atm->ocn to map atm fields to the ocn grid for
       ! the atm/ocn flux computation
-      if (  is_local%wrap%aoflux_grid == 'ogrid' .and. .not. &
-            is_local%wrap%med_coupling_active(compatm,compocn)) then
-         is_local%wrap%med_coupling_active(compatm,compocn) = .true.
+      if (  is_local%wrap%aoflux_grid == 'ogrid') then
+         if ( is_local%wrap%med_coupling_active(compocn,compatm) .and. .not. &
+              is_local%wrap%med_coupling_active(compatm,compocn)) then
+            is_local%wrap%med_coupling_active(compatm,compocn) = .true.
+         end if
+         if ( is_local%wrap%med_coupling_active(compatm,compocn) .and. .not. &
+              is_local%wrap%med_coupling_active(compocn,compatm)) then
+            is_local%wrap%med_coupling_active(compocn,compatm) = .true.
+         end if
       end if
 
       call ESMF_LogWrite("before med_map_RouteHandles_init", ESMF_LOGMSG_INFO)

--- a/mediator/med.F90
+++ b/mediator/med.F90
@@ -2131,24 +2131,24 @@ contains
       ! Create field bundles for mediator ocean albedo computation
 
       fieldCount = med_fldList_GetNumFlds(fldListMed_aoflux)
-      if ( fieldCount > 0 .and. &
-           is_local%wrap%med_coupling_active(compocn,compatm) .or. &
-           is_local%wrap%med_coupling_active(compatm,compocn)) then
-         is_local%wrap%do_med_aoflux = .true.
-      else
-         is_local%wrap%do_med_aoflux = .false.
+      if ( fieldCount > 0 ) then
+         if ( is_local%wrap%med_coupling_active(compocn,compatm) .or. &
+              is_local%wrap%med_coupling_active(compatm,compocn)) then
+            is_local%wrap%do_med_aoflux = .true.
+            if ( is_local%wrap%aoflux_grid == 'ogrid' .and. .not. &
+                 is_local%wrap%med_coupling_active(compatm,compocn)) then
+               is_local%wrap%med_coupling_active(compatm,compocn) = .true.
+            end if
+            if ( is_local%wrap%aoflux_grid == 'agrid' .and. .not. &
+                 is_local%wrap%med_coupling_active(compocn,compatm)) then
+               is_local%wrap%med_coupling_active(compocn,compatm) = .true.
+            end if
+            call med_phases_aofluxes_init_fldbuns(gcomp, rc=rc)
+            if (ChkErr(rc,__LINE__,u_FILE_u)) return
+            is_local%wrap%do_med_aoflux = .false.
+         end if
       end if
       if (is_local%wrap%do_med_aoflux) then
-         if ( is_local%wrap%aoflux_grid == 'ogrid' .and. .not. &
-            is_local%wrap%med_coupling_active(compatm,compocn)) then
-            is_local%wrap%med_coupling_active(compatm,compocn) = .true.
-         end if
-         if ( is_local%wrap%aoflux_grid == 'agrid' .and. .not. &
-            is_local%wrap%med_coupling_active(compocn,compatm)) then
-            is_local%wrap%med_coupling_active(compocn,compatm) = .true.
-         end if
-         call med_phases_aofluxes_init_fldbuns(gcomp, rc=rc)
-         if (ChkErr(rc,__LINE__,u_FILE_u)) return
       end if
 
       !---------------------------------------

--- a/mediator/med.F90
+++ b/mediator/med.F90
@@ -2089,7 +2089,7 @@ contains
       enddo ! loop over n1
 
       !---------------------------------------
-      ! Initialize field bundles needed for ocn albedo and ocn/atm flux calculations
+      ! Initialize field bundles needed for ocn albedo calculation
       !---------------------------------------
 
       ! NOTE: the NStateImp(compocn) or NStateImp(compatm) used below
@@ -2101,14 +2101,9 @@ contains
       ! Create field bundles for mediator ocean albedo computation
 
       if ( is_local%wrap%med_coupling_active(compocn,compatm) .or. is_local%wrap%med_coupling_active(compatm,compocn)) then
-
          ! Create field bundles for mediator ocean albedo computation
          fieldCount = med_fldList_GetNumFlds(fldListMed_ocnalb)
          if (fieldCount > 0) then
-            if (.not. is_local%wrap%med_coupling_active(compatm,compocn)) then
-               is_local%wrap%med_coupling_active(compatm,compocn) = .true.
-            end if
-
             allocate(fldnames(fieldCount))
             call med_fldList_getfldnames(fldListMed_ocnalb%flds, fldnames, rc=rc)
             if (ChkErr(rc,__LINE__,u_FILE_u)) return
@@ -2156,6 +2151,13 @@ contains
       ! Initialize route handles and required normalization field bunds
       ! Initialized packed field data structures
       !---------------------------------------
+
+      ! Force the coupling to be active between atm->ocn to map atm fields to the ocn grid for
+      ! the atm/ocn flux computation
+      if (  is_local%wrap%aoflux_grid == 'ogrid' .and. .not. &
+            is_local%wrap%med_coupling_active(compatm,compocn)) then
+         is_local%wrap%med_coupling_active(compatm,compocn) = .true.
+      end if
 
       call ESMF_LogWrite("before med_map_RouteHandles_init", ESMF_LOGMSG_INFO)
       call med_map_RouteHandles_init(gcomp, is_local%wrap%flds_scalar_name, logunit, rc)

--- a/mediator/med.F90
+++ b/mediator/med.F90
@@ -2134,7 +2134,6 @@ contains
       if ( fieldCount > 0 ) then
          if ( is_local%wrap%med_coupling_active(compocn,compatm) .or. &
               is_local%wrap%med_coupling_active(compatm,compocn)) then
-            is_local%wrap%do_med_aoflux = .true.
             if ( is_local%wrap%aoflux_grid == 'ogrid' .and. .not. &
                  is_local%wrap%med_coupling_active(compatm,compocn)) then
                is_local%wrap%med_coupling_active(compatm,compocn) = .true.

--- a/mediator/med_diag_mod.F90
+++ b/mediator/med_diag_mod.F90
@@ -1454,7 +1454,6 @@ contains
     ! ------------------------------------------------------------------
     rc = ESMF_SUCCESS
     if ( fldbun_fldchk(FB, trim(fldname), rc=rc)) then
-       if (trim(fldname) == 'Foxx_lat') write(6,*)'DEBUG: i am here'
        call fldbun_getdata1d(FB, trim(fldname), data, rc=rc)
        if (ChkErr(rc,__LINE__,u_FILE_u)) return
        ip = period_inst

--- a/mediator/med_internalstate_mod.F90
+++ b/mediator/med_internalstate_mod.F90
@@ -81,7 +81,6 @@ module med_internalstate_mod
     type(ESMF_FieldBundle) :: FBMed_aoflux_o                     ! Ocn/Atm flux output fields on ocn grid
     type(packed_data_type) :: packed_data_aoflux_o2a(nmappers)   ! packed data for mapping ocn->atm
     character(len=CS)      :: aoflux_grid                        ! 'ogrid', 'agrid' or 'xgrid'
-    logical                :: do_med_aoflux                      ! true => do med_aoflux
 
     ! Mapping
     type(ESMF_RouteHandle) :: RH(ncomps,ncomps,nmappers)            ! Routehandles for pairs of components and different mappers

--- a/mediator/med_internalstate_mod.F90
+++ b/mediator/med_internalstate_mod.F90
@@ -71,14 +71,17 @@ module med_internalstate_mod
     type(ESMF_FieldBundle) :: FBImp(ncomps,ncomps)               ! Import data from various components interpolated to various grids
     type(ESMF_FieldBundle) :: FBExp(ncomps)                      ! Export data for various components, on their grid
 
-    ! Mediator field bundles
+    ! Mediator field bundles for ocean albedo 
     type(ESMF_FieldBundle) :: FBMed_ocnalb_o                     ! Ocn albedo on ocn grid
     type(ESMF_FieldBundle) :: FBMed_ocnalb_a                     ! Ocn albedo on atm grid
     type(packed_data_type) :: packed_data_ocnalb_o2a(nmappers)   ! packed data for mapping ocn->atm
+
+    ! Mediator field bundles and other info for atm/ocn flux computation
     type(ESMF_FieldBundle) :: FBMed_aoflux_a                     ! Ocn/Atm flux output fields on atm grid
     type(ESMF_FieldBundle) :: FBMed_aoflux_o                     ! Ocn/Atm flux output fields on ocn grid
     type(packed_data_type) :: packed_data_aoflux_o2a(nmappers)   ! packed data for mapping ocn->atm
     character(len=CS)      :: aoflux_grid                        ! 'ogrid', 'agrid' or 'xgrid'
+    logical                :: do_med_aoflux                      ! true => do med_aoflux
 
     ! Mapping
     type(ESMF_RouteHandle) :: RH(ncomps,ncomps,nmappers)            ! Routehandles for pairs of components and different mappers

--- a/mediator/med_map_mod.F90
+++ b/mediator/med_map_mod.F90
@@ -76,7 +76,7 @@ contains
 
     use ESMF            , only : ESMF_LogWrite, ESMF_LOGMSG_INFO, ESMF_SUCCESS, ESMF_LogFlush
     use ESMF            , only : ESMF_GridComp, ESMF_GridCompGet, ESMF_Field
-    use ESMF            , only : ESMF_FieldBundleGet
+    use ESMF            , only : ESMF_FieldBundleGet, ESMF_FieldBundleIsCreated
     use esmFlds         , only : fldListFr, ncomps, mapunset, compname
     use med_methods_mod , only : med_methods_FB_getFieldN, med_methods_FB_getNameN
 
@@ -130,7 +130,7 @@ contains
                    return
                 end if
                 call ESMF_FieldBundleGet(is_local%wrap%FBImp(n1,n2), fieldCount=fieldCount, rc=rc)
-                if (chkerr(rc,__LINE__,u_FILE_u)) then
+                if (chkerr(rc,__LINE__,u_FILE_u)) return
                 if (fieldCount == 0) then
                   call med_methods_FB_getFieldN(is_local%wrap%FBExp(n2), 1, flddst, rc)
                   if (chkerr(rc,__LINE__,u_FILE_u)) return

--- a/mediator/med_map_mod.F90
+++ b/mediator/med_map_mod.F90
@@ -76,7 +76,7 @@ contains
 
     use ESMF            , only : ESMF_LogWrite, ESMF_LOGMSG_INFO, ESMF_SUCCESS, ESMF_LogFlush
     use ESMF            , only : ESMF_GridComp, ESMF_GridCompGet, ESMF_Field
-    use ESMF            , only : ESMF_FieldBundleGet
+    use ESMF            , only : ESMF_FieldBundleGet, ESMF_FieldBundleIsCreated
     use esmFlds         , only : fldListFr, ncomps, mapunset, compname
     use med_methods_mod , only : med_methods_FB_getFieldN, med_methods_FB_getNameN
 
@@ -121,14 +121,16 @@ contains
                 ! Get source field
                 call med_methods_FB_getFieldN(is_local%wrap%FBImp(n1,n1), 1, fldsrc, rc)
                 if (chkerr(rc,__LINE__,u_FILE_u)) return
+                if (.not. ESMF_FieldBundleIsCreated(is_local%wrap%FBImp(n1,n2))) then
+                   call ESMF_LogWrite(trim(subname)//'FBImp('//trim(compname(n1))//','//trim(compname(n2))//&
+                        ') has not been created', ESMF_LOGMSG_ERROR)
+                   rc = ESMF_FAILURE
+                   return
+                end if
 
                 ! Check number of fields in source FB on destination mesh and get destination field
                 call ESMF_FieldBundleGet(is_local%wrap%FBImp(n1,n2), fieldCount=fieldCount, rc=rc)
-                if (chkerr(rc,__LINE__,u_FILE_u)) then
-                   call ESMF_LogWrite(trim(subname)//'FBImp('//trim(compname(n1),trim(compname(n2)//&
-                        ') has not been created', ESMF_LOGMSG_ERROR)
-                   return
-                end if
+                if (chkerr(rc,__LINE__,u_FILE_u)) return
                 if (fieldCount == 0) then
                   call med_methods_FB_getFieldN(is_local%wrap%FBExp(n2), 1, flddst, rc)
                 else
@@ -684,7 +686,7 @@ contains
             allocate(fieldlist(fieldcount))
             call ESMF_FieldBundleGet(is_local%wrap%FBExp(n1), fieldlist=fieldlist, rc=rc)
             if (ChkErr(rc,__LINE__,u_FILE_u)) return
-          else    
+          else
             allocate(fieldlist(fieldcount))
             call ESMF_FieldBundleGet(is_local%wrap%FBImp(n1,n1), fieldlist=fieldlist, rc=rc)
             if (ChkErr(rc,__LINE__,u_FILE_u)) return

--- a/mediator/med_map_mod.F90
+++ b/mediator/med_map_mod.F90
@@ -76,7 +76,7 @@ contains
 
     use ESMF            , only : ESMF_LogWrite, ESMF_LOGMSG_INFO, ESMF_SUCCESS, ESMF_LogFlush
     use ESMF            , only : ESMF_GridComp, ESMF_GridCompGet, ESMF_Field
-    use ESMF            , only : ESMF_FieldBundleGet, ESMF_FieldBundleIsCreated
+    use ESMF            , only : ESMF_FieldBundleGet
     use esmFlds         , only : fldListFr, ncomps, mapunset, compname
     use med_methods_mod , only : med_methods_FB_getFieldN, med_methods_FB_getNameN
 
@@ -121,22 +121,23 @@ contains
                 ! Get source field
                 call med_methods_FB_getFieldN(is_local%wrap%FBImp(n1,n1), 1, fldsrc, rc)
                 if (chkerr(rc,__LINE__,u_FILE_u)) return
-                if (.not. ESMF_FieldBundleIsCreated(is_local%wrap%FBImp(n1,n2))) then
-                   call ESMF_LogWrite(trim(subname)//'FBImp('//trim(compname(n1))//','//trim(compname(n2))//&
-                        ') has not been created', ESMF_LOGMSG_ERROR)
+
+                ! Check number of fields in source FB on destination mesh and get destination field
+                if (.not. ESMF_FieldBundleIsCreated(is_local%wrap%FBImp(n1,n2))) then  
+                   call ESMF_LogWrite(trim(subname)//'FBImp('//trim(compname(n1))//','//trim(compname(n2))//')'// &
+                        ' has not been created', ESMF_LOGMSG_ERROR, line=__LINE__, file=u_FILE_u)
                    rc = ESMF_FAILURE
                    return
                 end if
-
-                ! Check number of fields in source FB on destination mesh and get destination field
                 call ESMF_FieldBundleGet(is_local%wrap%FBImp(n1,n2), fieldCount=fieldCount, rc=rc)
-                if (chkerr(rc,__LINE__,u_FILE_u)) return
+                if (chkerr(rc,__LINE__,u_FILE_u)) then
                 if (fieldCount == 0) then
                   call med_methods_FB_getFieldN(is_local%wrap%FBExp(n2), 1, flddst, rc)
+                  if (chkerr(rc,__LINE__,u_FILE_u)) return
                 else
                   call med_methods_FB_getFieldN(is_local%wrap%FBImp(n1,n2), 1, flddst, rc)
+                  if (chkerr(rc,__LINE__,u_FILE_u)) return
                 end if
-                if (chkerr(rc,__LINE__,u_FILE_u)) return
 
                 ! Loop over fields
                 do nf = 1,size(fldListFr(n1)%flds)
@@ -686,7 +687,7 @@ contains
             allocate(fieldlist(fieldcount))
             call ESMF_FieldBundleGet(is_local%wrap%FBExp(n1), fieldlist=fieldlist, rc=rc)
             if (ChkErr(rc,__LINE__,u_FILE_u)) return
-          else
+          else    
             allocate(fieldlist(fieldcount))
             call ESMF_FieldBundleGet(is_local%wrap%FBImp(n1,n1), fieldlist=fieldlist, rc=rc)
             if (ChkErr(rc,__LINE__,u_FILE_u)) return

--- a/mediator/med_map_mod.F90
+++ b/mediator/med_map_mod.F90
@@ -122,9 +122,13 @@ contains
                 call med_methods_FB_getFieldN(is_local%wrap%FBImp(n1,n1), 1, fldsrc, rc)
                 if (chkerr(rc,__LINE__,u_FILE_u)) return
 
-                ! Check number of fields in FB and get destination field
+                ! Check number of fields in source FB on destination mesh and get destination field
                 call ESMF_FieldBundleGet(is_local%wrap%FBImp(n1,n2), fieldCount=fieldCount, rc=rc)
-                if (chkerr(rc,__LINE__,u_FILE_u)) return
+                if (chkerr(rc,__LINE__,u_FILE_u)) then
+                   call ESMF_LogWrite(trim(subname)//'FBImp('//trim(compname(n1),trim(compname(n2)//&
+                        ') has not been created', ESMF_LOGMSG_ERROR)
+                   return
+                end if
                 if (fieldCount == 0) then
                   call med_methods_FB_getFieldN(is_local%wrap%FBExp(n2), 1, flddst, rc)
                 else

--- a/mediator/med_phases_aofluxes_mod.F90
+++ b/mediator/med_phases_aofluxes_mod.F90
@@ -189,7 +189,7 @@ contains
        end do
     end if
 
-    ! Create required field bundles and active coupling flags
+    ! Create required field bundles 
     if (is_local%wrap%aoflux_grid == 'ogrid' .or. is_local%wrap%aoflux_grid == 'agrid') then
 
        ! Create the field bundle is_local%wrap%FBImp(compatm,compocn) if needed
@@ -222,9 +222,6 @@ contains
                trim(compname(compocn))//'_'//trim(compname(compatm))
        end if
 
-       ! Force med_coupling_active flag to be true for atm<->ocn
-       is_local%wrap%med_coupling_active(compatm,compocn) = .true.
-       is_local%wrap%med_coupling_active(compocn,compatm) = .true.
     end if
 
   end subroutine med_phases_aofluxes_init_fldbuns

--- a/mediator/med_phases_aofluxes_mod.F90
+++ b/mediator/med_phases_aofluxes_mod.F90
@@ -20,7 +20,7 @@ module med_phases_aofluxes_mod
   use ESMF                  , only : ESMF_TERMORDER_SRCSEQ, ESMF_REGION_TOTAL, ESMF_MESHLOC_ELEMENT, ESMF_MAXSTR
   use ESMF                  , only : ESMF_XGRIDSIDE_B, ESMF_XGRIDSIDE_A, ESMF_END_ABORT, ESMF_LOGERR_PASSTHRU
   use ESMF                  , only : ESMF_Mesh, ESMF_MeshGet, ESMF_XGrid, ESMF_XGridCreate, ESMF_TYPEKIND_R8
-  use ESMF                  , only : ESMF_LogWrite, ESMF_LOGMSG_INFO, ESMF_SUCCESS, ESMF_LOGMSG_ERROR, ESMF_FAILURE
+  use ESMF                  , only : ESMF_LogWrite, ESMF_LOGMSG_INFO, ESMF_SUCCESS
   use ESMF                  , only : ESMF_Finalize, ESMF_LogFoundError
   use med_kind_mod          , only : CX=>SHR_KIND_CX, CS=>SHR_KIND_CS, CL=>SHR_KIND_CL, R8=>SHR_KIND_R8
   use med_internalstate_mod , only : InternalState
@@ -31,7 +31,7 @@ module med_phases_aofluxes_mod
   use med_methods_mod       , only : FB_GetFldPtr => med_methods_FB_GetFldPtr
   use med_utils_mod         , only : chkerr       => med_utils_chkerr
   use med_map_mod           , only : med_map_field
-  use esmFlds               , only : compatm, compocn, coupling_mode, mapconsd, mapconsf, mapfcopy
+  use esmFlds               , only : compatm, compocn, coupling_mode, mapconsd, mapconsf
   use perf_mod              , only : t_startf, t_stopf
 
   implicit none
@@ -152,65 +152,75 @@ contains
     integer, intent(out) :: rc
 
     ! local variables
-    integer                :: n
-    type(InternalState)    :: is_local
-    integer                :: fieldcount
+    integer             :: n
+    integer             :: fieldcount
+    type(InternalState) :: is_local
     character(len=*),parameter :: subname=' (med_phases_aofluxes_init_fldbuns) '
     !---------------------------------------
 
     ! Create field bundles for mediator ocean/atmosphere flux computation
     ! This is needed regardless of the grid on which the atm/ocn flux computation is done on
+
+    ! Get the internal state from the mediator Component.
+    nullify(is_local%wrap)
+    call ESMF_GridCompGetInternalState(gcomp, is_local, rc)
+    if (chkerr(rc,__LINE__,u_FILE_u)) return
+
+    ! Set module variable fldnames_aof_out
     fieldCount = med_fldList_GetNumFlds(fldListMed_aoflux)
-    if (fieldCount > 0) then
+    allocate(fldnames_aof_out(fieldCount))
+    call med_fldList_getfldnames(fldListMed_aoflux%flds, fldnames_aof_out, rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
 
-       ! Get the internal state from the mediator Component.
-       nullify(is_local%wrap)
-       call ESMF_GridCompGetInternalState(gcomp, is_local, rc)
-       if (chkerr(rc,__LINE__,u_FILE_u)) return
+    ! Initialize FBMed_aoflux_a
+    call FB_init(is_local%wrap%FBMed_aoflux_a, is_local%wrap%flds_scalar_name, &
+         STgeom=is_local%wrap%NStateImp(compatm), fieldnamelist=fldnames_aof_out, name='FBMed_aoflux_a', rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+    if (mastertask) then
+       write(logunit,*)
+       write(logunit,'(a)') trim(subname)//' initialized FB FBMed_aoflux_a'
+    end if
 
-       ! Set module variable fldnames_aof_out
-       allocate(fldnames_aof_out(fieldCount))
-       call med_fldList_getfldnames(fldListMed_aoflux%flds, fldnames_aof_out, rc=rc)
-       if (ChkErr(rc,__LINE__,u_FILE_u)) return
+    ! Initialize FBMed_aoflux_o
+    call FB_init(is_local%wrap%FBMed_aoflux_o, is_local%wrap%flds_scalar_name, &
+         STgeom=is_local%wrap%NStateImp(compocn), fieldnamelist=fldnames_aof_out, name='FBMed_aoflux_o', rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+    if (mastertask) then
+       write(logunit,'(a)') trim(subname)//' initialized FB FBMed_aoflux_o'
+       write(logunit,'(a)') trim(subname)//' following are the fields in FBMed_aoflux_o and FBMed_aoflux_a'
+       do n = 1,fieldcount
+          write(logunit,'(a)')'   FBmed_aoflux fieldname = '//trim(fldnames_aof_out(n))
+       end do
+    end if
 
-       ! Initialize FBMed_aoflux_a
-       call FB_init(is_local%wrap%FBMed_aoflux_a, is_local%wrap%flds_scalar_name, &
-            STgeom=is_local%wrap%NStateImp(compatm), fieldnamelist=fldnames_aof_out, name='FBMed_aoflux_a', rc=rc)
-       if (ChkErr(rc,__LINE__,u_FILE_u)) return
-       if (mastertask) then
-          write(logunit,*)
-          write(logunit,'(a)') trim(subname)//' initializing FB FBMed_aoflux_a'
-       end if
-
-       ! Initialize FBMed_aoflux_o
-       call FB_init(is_local%wrap%FBMed_aoflux_o, is_local%wrap%flds_scalar_name, &
-            STgeom=is_local%wrap%NStateImp(compocn), fieldnamelist=fldnames_aof_out, name='FBMed_aoflux_o', rc=rc)
-       if (ChkErr(rc,__LINE__,u_FILE_u)) return
-       if (mastertask) then
-          write(logunit,'(a)') trim(subname)//' initializing FB FBMed_aoflux_o'
-          write(logunit,'(a)') trim(subname)//' following are the fields in FBMed_aoflux_o and FBMed_aoflux_a'
-          do n = 1,fieldcount
-             write(logunit,'(a)')'   FBmed_aoflux fieldname = '//trim(fldnames_aof_out(n))
-          end do
-       end if
-
-       ! The following assumes that the mediator atm/ocn flux calculation will be done on the ocean grid
-       if (is_local%wrap%aoflux_grid == 'ogrid') then  ! aoflux_grid is ocn
-          if (.not. ESMF_FieldBundleIsCreated(is_local%wrap%FBImp(compatm,compocn), rc=rc)) then
-             if (mastertask) then
-                write(logunit,'(a)') trim(subname)//' creating field bundle FBImp(compatm,compocn)'
-             end if
-             call FB_init(is_local%wrap%FBImp(compatm,compocn), is_local%wrap%flds_scalar_name, &
-                  STgeom=is_local%wrap%NStateImp(compocn), STflds=is_local%wrap%NStateImp(compatm), &
-                  name='FBImp'//trim(compname(compatm))//'_'//trim(compname(compocn)), rc=rc)
-             if (ChkErr(rc,__LINE__,u_FILE_u)) return
-          end if
+    ! If aoflux_grid is ocn...
+    if (is_local%wrap%aoflux_grid == 'ogrid') then
+       
+       ! Create the field bundle is_local%wrap%FBImp(compatm,compocn) if needed
+       if (.not. ESMF_FieldBundleIsCreated(is_local%wrap%FBImp(compatm,compocn), rc=rc)) then
           if (mastertask) then
-             write(logunit,'(a)') trim(subname)//' initializing FBs for '// &
-                  trim(compname(compatm))//'_'//trim(compname(compocn))
+             write(logunit,'(a)') trim(subname)//' creating field bundle FBImp(compatm,compocn)'
           end if
+          call FB_init(is_local%wrap%FBImp(compatm,compocn), is_local%wrap%flds_scalar_name, &
+               STgeom=is_local%wrap%NStateImp(compocn), STflds=is_local%wrap%NStateImp(compatm), &
+               name='FBImp'//trim(compname(compatm))//'_'//trim(compname(compocn)), rc=rc)
+          if (ChkErr(rc,__LINE__,u_FILE_u)) return
        end if
-    end if ! end if fieldcount > 0
+       if (mastertask) then
+          write(logunit,'(a)') trim(subname)//' initializing FBs for '// &
+               trim(compname(compatm))//'_'//trim(compname(compocn))
+       end if
+
+       ! RESET the active coupling to permit atm/ocn flux computation on ogrid if needed
+       if ( is_local%wrap%med_coupling_active(compocn,compatm) .and. .not. &
+            is_local%wrap%med_coupling_active(compatm,compocn)) then
+          is_local%wrap%med_coupling_active(compatm,compocn) = .true.
+       end if
+       if ( is_local%wrap%med_coupling_active(compatm,compocn) .and. .not. &
+            is_local%wrap%med_coupling_active(compocn,compatm)) then
+          is_local%wrap%med_coupling_active(compocn,compatm) = .true.
+       end if
+    end if
 
   end subroutine med_phases_aofluxes_init_fldbuns
 
@@ -508,8 +518,7 @@ contains
     ! - output aoflux attributes are on the atm mesh
     ! --------------------------------------------
 
-    use med_methods_mod , only : FB_init => med_methods_FB_init
-    use med_map_mod     , only : med_map_rh_is_created
+    use med_methods_mod, only : FB_init => med_methods_FB_init
 
     ! Arguments
     type(ESMF_GridComp)   , intent(inout) :: gcomp
@@ -526,7 +535,6 @@ contains
     real(r8), pointer   :: dataptr1d(:)
     type(ESMF_Mesh)     :: mesh_src
     type(ESMF_Mesh)     :: mesh_dst
-    integer             :: maptype
     character(len=*),parameter :: subname=' (med_aofluxes_init_atmgrid) '
     !-----------------------------------------------------------------------
 
@@ -562,22 +570,6 @@ contains
     if (chkerr(rc,__LINE__,u_FILE_u)) return
 
     ! ------------------------
-    ! Determine maptype for ocn->atm mapping
-    ! ------------------------
-
-    if (med_map_RH_is_created(is_local%wrap%RH(compocn,compatm,:), mapfcopy, rc=rc)) then
-       maptype = mapfcopy
-    else if (med_map_RH_is_created(is_local%wrap%RH(compocn,compatm,:), mapconsd, rc=rc)) then
-       maptype = mapconsd
-    else
-       call ESMF_LogWrite(trim(subname)//&
-            ": maptype for atm->ocn mapping of So_mask must be either mapfcopy or mapconsd", &
-            ESMF_LOGMSG_ERROR, line=__LINE__, file=u_FILE_u)
-       rc = ESMF_FAILURE
-       return
-    end if
-
-    ! ------------------------
     ! set aoflux computational mask on atm grid
     ! ------------------------
 
@@ -588,7 +580,7 @@ contains
     call ESMF_FieldBundleGet(FBocn_a, 'So_omask', field=field_dst, rc=rc)
     if (chkerr(rc,__LINE__,u_FILE_u)) return
     call med_map_field( field_src=field_src, field_dst=field_dst, &
-         routehandles=is_local%wrap%RH(compocn,compatm,:), maptype=maptype, rc=rc)
+         routehandles=is_local%wrap%RH(compocn,compatm,:), maptype=mapconsd, rc=rc)
     if (chkerr(rc,__LINE__,u_FILE_u)) return
     call ESMF_FieldGet(field_dst, farrayptr=dataptr1d, rc=rc)
     if (chkerr(rc,__LINE__,u_FILE_u)) return
@@ -605,7 +597,7 @@ contains
     ! set one normalization for ocn-atm mapping if needed
     ! ------------------------
 
-    if (.not. ESMF_FieldIsCreated(is_local%wrap%field_NormOne(compocn,compatm,maptype))) then
+    if (.not. ESMF_FieldIsCreated(is_local%wrap%field_NormOne(compocn,compatm,mapconsd))) then
        ! Get source mesh
        call ESMF_FieldBundleGet(is_local%wrap%FBImp(compocn,compocn), 'So_omask', field=field_src, rc=rc)
        if (ChkErr(rc,__LINE__,u_FILE_u)) return
@@ -617,15 +609,15 @@ contains
        if (chkerr(rc,__LINE__,u_FILE_u)) return
        dataptr1d(:) = 1.0_R8
 
-       ! Create field is_local%wrap%field_NormOne(compocn,compatm,maptype) and fill in its values
+       ! Create field is_local%wrap%field_NormOne(compocn,compatm,mapconsd) and fill in its values
        call ESMF_FieldBundleGet(is_local%wrap%FBImp(compocn,compatm), 'So_omask', field=field_dst, rc=rc)
        if (ChkErr(rc,__LINE__,u_FILE_u)) return
        call ESMF_FieldGet(field_dst, mesh=mesh_dst, rc=rc)
        if (chkerr(rc,__LINE__,u_FILE_u)) return
-       is_local%wrap%field_NormOne(compocn,compatm,maptype) = ESMF_FieldCreate(mesh_dst, &
+       is_local%wrap%field_NormOne(compocn,compatm,mapconsd) = ESMF_FieldCreate(mesh_dst, &
             ESMF_TYPEKIND_R8, meshloc=ESMF_MESHLOC_ELEMENT, rc=rc)
-       call med_map_field( field_src=field_src, field_dst=is_local%wrap%field_NormOne(compocn,compatm,maptype), &
-            routehandles=is_local%wrap%RH(compocn,compatm,:), maptype=maptype, rc=rc)
+       call med_map_field( field_src=field_src, field_dst=is_local%wrap%field_NormOne(compocn,compatm,mapconsd), &
+            routehandles=is_local%wrap%RH(compocn,compatm,:), maptype=mapconsd, rc=rc)
        if (chkerr(rc,__LINE__,u_FILE_u)) return
 
        call ESMF_FieldDestroy(field_src, rc=rc, noGarbage=.true.)
@@ -841,7 +833,7 @@ contains
 
     use ESMF          , only : ESMF_GridComp
     use ESMF          , only : ESMF_LogWrite, ESMF_LogMsg_Info, ESMF_SUCCESS
-    use med_map_mod   , only : med_map_field_packed, med_map_rh_is_created
+    use med_map_mod   , only : med_map_field_packed
     use shr_flux_mod  , only : shr_flux_atmocn
 
     ! Arguments
@@ -857,7 +849,6 @@ contains
     integer             :: n,i,nf                     ! indices
     real(r8), pointer   :: data_normdst(:)
     real(r8), pointer   :: data_dst(:)
-    integer             :: maptype
     character(*),parameter  :: subName = '(med_aofluxes_update) '
     !-----------------------------------------------------------------------
 
@@ -887,39 +878,22 @@ contains
           ! Create destination field
           call ESMF_FieldBundleGet(FBocn_a, fldnames_ocn_in(nf), field=field_dst, rc=rc)
           if (chkerr(rc,__LINE__,u_FILE_u)) return
-
-          ! Determine maptype from ocn->atm
-          if (med_map_RH_is_created(is_local%wrap%RH(compocn,compatm,:), mapfcopy, rc=rc)) then
-             maptype = mapfcopy
-          else if (med_map_RH_is_created(is_local%wrap%RH(compocn,compatm,:), mapconsd, rc=rc)) then
-             maptype = mapconsd
-          else
-             call ESMF_LogWrite(trim(subname)//&
-                  ": maptype for atm->ocn mapping of aofluxes from atm->ocn either mapfcopy or mapconsd", &
-                  ESMF_LOGMSG_ERROR, line=__LINE__, file=u_FILE_u)
-             rc = ESMF_FAILURE
-             return
-          end if
-
           ! Map ocn->atm conservatively without fractions and then do a normalization by 'one'
           call ESMF_FieldRegrid(field_src, field_dst, &
-               routehandle=is_local%wrap%RH(compocn,compatm, maptype), &
+               routehandle=is_local%wrap%RH(compocn,compatm, mapconsd), &
                termorderflag=ESMF_TERMORDER_SRCSEQ, zeroregion=ESMF_REGION_TOTAL, rc=rc)
-
-          ! Normalization of map by 'one' if maptype is not mapfcopy
-          if (maptype /= mapfcopy) then
-             call ESMF_FieldGet(is_local%wrap%field_normOne(compocn,compatm,maptype), farrayPtr=data_normdst, rc=rc)
-             if (chkerr(rc,__LINE__,u_FILE_u)) return
-             call ESMF_FieldGet(field_dst, farrayptr=data_dst, rc=rc)
-             if (chkerr(rc,__LINE__,u_FILE_u)) return
-             do n = 1,size(data_dst)
-                if (data_normdst(n) == 0.0_r8) then
-                   data_dst(n) = 0.0_r8
-                else
-                   data_dst(n) = data_dst(n)/data_normdst(n)
-                end if
-             end do
-          end if
+          ! Normalization of map by 'one'
+          call ESMF_FieldGet(is_local%wrap%field_normOne(compocn,compatm,mapconsd), farrayPtr=data_normdst, rc=rc)
+          if (chkerr(rc,__LINE__,u_FILE_u)) return
+          call ESMF_FieldGet(field_dst, farrayptr=data_dst, rc=rc)
+          if (chkerr(rc,__LINE__,u_FILE_u)) return
+          do n = 1,size(data_dst)
+             if (data_normdst(n) == 0.0_r8) then
+                data_dst(n) = 0.0_r8
+             else
+                data_dst(n) = data_dst(n)/data_normdst(n)
+             end if
+          end do
        end do
 
     else if (is_local%wrap%aoflux_grid == 'xgrid') then
@@ -1025,22 +999,9 @@ contains
              ! Create destination field
              call ESMF_FieldBundleGet(is_local%wrap%FBMed_aoflux_o, fldnames_aof_out(nf), field=field_dst, rc=rc)
              if (chkerr(rc,__LINE__,u_FILE_u)) return
-
-             if (med_map_RH_is_created(is_local%wrap%RH(compocn,compatm,:), mapfcopy, rc=rc)) then
-                maptype = mapfcopy
-             else if (med_map_RH_is_created(is_local%wrap%RH(compocn,compatm,:), mapconsf, rc=rc)) then
-                maptype = mapconsf
-             else
-                call ESMF_LogWrite(trim(subname)//&
-                     ": maptype for atm->ocn mapping of aofluxes from atm->ocn either mapfcopy or mapconsf", &
-                     ESMF_LOGMSG_ERROR, line=__LINE__, file=u_FILE_u)
-                rc = ESMF_FAILURE
-                return
-             end if
-
              ! Map atm->ocn conservatively WITHOUT fractions
              call ESMF_FieldRegrid(field_src, field_dst, &
-                  routehandle=is_local%wrap%RH(compatm, compocn, maptype), &
+                  routehandle=is_local%wrap%RH(compatm, compocn, mapconsf), &
                   termorderflag=ESMF_TERMORDER_SRCSEQ, zeroregion=ESMF_REGION_TOTAL, rc=rc)
           end do
        end if

--- a/mediator/med_phases_aofluxes_mod.F90
+++ b/mediator/med_phases_aofluxes_mod.F90
@@ -1037,9 +1037,9 @@ contains
              call ESMF_FieldBundleGet(is_local%wrap%FBMed_aoflux_o, fldnames_aof_out(nf), field=field_dst, rc=rc)
              if (chkerr(rc,__LINE__,u_FILE_u)) return
              ! Map atm->ocn conservatively WITHOUT fractions
-             if (med_map_RH_is_created(is_local%wrap%RH(compocn,compatm,:), mapfcopy, rc=rc)) then
+             if (med_map_RH_is_created(is_local%wrap%RH(compatm,compocn,:), mapfcopy, rc=rc)) then
                 maptype = mapfcopy
-             else if (med_map_RH_is_created(is_local%wrap%RH(compocn,compatm,:), mapconsf, rc=rc)) then
+             else if (med_map_RH_is_created(is_local%wrap%RH(compatm,compocn,:), mapconsf, rc=rc)) then
                 maptype = mapconsf
              else
                 call ESMF_LogWrite(trim(subname)//&

--- a/mediator/med_phases_aofluxes_mod.F90
+++ b/mediator/med_phases_aofluxes_mod.F90
@@ -20,14 +20,14 @@ module med_phases_aofluxes_mod
   use ESMF                  , only : ESMF_TERMORDER_SRCSEQ, ESMF_REGION_TOTAL, ESMF_MESHLOC_ELEMENT, ESMF_MAXSTR
   use ESMF                  , only : ESMF_XGRIDSIDE_B, ESMF_XGRIDSIDE_A, ESMF_END_ABORT, ESMF_LOGERR_PASSTHRU
   use ESMF                  , only : ESMF_Mesh, ESMF_MeshGet, ESMF_XGrid, ESMF_XGridCreate, ESMF_TYPEKIND_R8
-  use ESMF                  , only : ESMF_LogWrite, ESMF_LOGMSG_INFO, ESMF_SUCCESS
+  use ESMF                  , only : ESMF_LogWrite, ESMF_LOGMSG_INFO, ESMF_SUCCESS, ESMF_LOGMSG_ERROR, ESMF_FAILURE
   use ESMF                  , only : ESMF_Finalize, ESMF_LogFoundError
   use med_kind_mod          , only : CX=>SHR_KIND_CX, CS=>SHR_KIND_CS, CL=>SHR_KIND_CL, R8=>SHR_KIND_R8
   use med_internalstate_mod , only : InternalState, mastertask, logunit
   use med_constants_mod     , only : dbug_flag    => med_constants_dbug_flag
   use med_utils_mod         , only : memcheck     => med_memcheck
   use med_utils_mod         , only : chkerr       => med_utils_chkerr
-  use esmFlds               , only : compatm, compocn, coupling_mode, mapconsd, mapconsf
+  use esmFlds               , only : compatm, compocn, coupling_mode, mapconsd, mapconsf, mapfcopy
   use perf_mod              , only : t_startf, t_stopf
 
   implicit none
@@ -189,9 +189,9 @@ contains
        end do
     end if
 
-    ! If aoflux_grid is ocn...
-    if (is_local%wrap%aoflux_grid == 'ogrid') then
-       
+    ! Create required field bundles and active coupling flags
+    if (is_local%wrap%aoflux_grid == 'ogrid' .or. is_local%wrap%aoflux_grid == 'agrid') then
+
        ! Create the field bundle is_local%wrap%FBImp(compatm,compocn) if needed
        if (.not. ESMF_FieldBundleIsCreated(is_local%wrap%FBImp(compatm,compocn), rc=rc)) then
           if (mastertask) then
@@ -203,19 +203,28 @@ contains
           if (ChkErr(rc,__LINE__,u_FILE_u)) return
        end if
        if (mastertask) then
-          write(logunit,'(a)') trim(subname)//' initializing FBs for '// &
+          write(logunit,'(a)') trim(subname)//' initializing FB for '// &
                trim(compname(compatm))//'_'//trim(compname(compocn))
        end if
 
-       ! RESET the active coupling to permit atm/ocn flux computation on ogrid if needed
-       if ( is_local%wrap%med_coupling_active(compocn,compatm) .and. .not. &
-            is_local%wrap%med_coupling_active(compatm,compocn)) then
-          is_local%wrap%med_coupling_active(compatm,compocn) = .true.
+       ! Create the field bundle is_local%wrap%FBImp(compocn,compatm) if needed
+       if (.not. ESMF_FieldBundleIsCreated(is_local%wrap%FBImp(compocn,compatm), rc=rc)) then
+          if (mastertask) then
+             write(logunit,'(a)') trim(subname)//' creating field bundle FBImp(compocn,compatm)'
+          end if
+          call FB_init(is_local%wrap%FBImp(compocn,compatm), is_local%wrap%flds_scalar_name, &
+               STgeom=is_local%wrap%NStateImp(compatm), STflds=is_local%wrap%NStateImp(compocn), &
+               name='FBImp'//trim(compname(compocn))//'_'//trim(compname(compatm)), rc=rc)
+          if (ChkErr(rc,__LINE__,u_FILE_u)) return
        end if
-       if ( is_local%wrap%med_coupling_active(compatm,compocn) .and. .not. &
-            is_local%wrap%med_coupling_active(compocn,compatm)) then
-          is_local%wrap%med_coupling_active(compocn,compatm) = .true.
+       if (mastertask) then
+          write(logunit,'(a)') trim(subname)//' initializing FB for '// &
+               trim(compname(compocn))//'_'//trim(compname(compatm))
        end if
+
+       ! Force med_coupling_active flag to be true for atm<->ocn
+       is_local%wrap%med_coupling_active(compatm,compocn) = .true.
+       is_local%wrap%med_coupling_active(compocn,compatm) = .true.
     end if
 
   end subroutine med_phases_aofluxes_init_fldbuns
@@ -504,18 +513,15 @@ contains
   subroutine med_aofluxes_init_agrid(gcomp, aoflux_in, aoflux_out, rc)
 
     ! --------------------------------------------
-    ! Initialize aoflux data type and compute mask
-    ! for computations on atm grid
-    ! all aoflux fields are on the atm mesh
-    ! - input atm aoflux attributes are just pointers into
-    !   is_local%wrap%FBImp(compatm,compatm)
-    ! - input ocn aoflux attributes are just pointers into
-    !   is_local%wrap%FBImp(compocn,compatm)
+    ! Initialize aoflux data type and compute mask for computations on atm grid
+    ! - all aoflux fields are on the atm mesh
+    ! - input atm aoflux attributes are just pointers into is_local%wrap%FBImp(compatm,compatm)
+    ! - input ocn aoflux attributes are just pointers into is_local%wrap%FBImp(compocn,compatm)
     ! - output aoflux attributes are on the atm mesh
     ! --------------------------------------------
 
     use med_methods_mod, only : FB_init => med_methods_FB_init
-    use med_map_mod    , only : med_map_field
+    use med_map_mod    , only : med_map_rh_is_created, med_map_field
 
     ! Arguments
     type(ESMF_GridComp)   , intent(inout) :: gcomp
@@ -532,6 +538,7 @@ contains
     real(r8), pointer   :: dataptr1d(:)
     type(ESMF_Mesh)     :: mesh_src
     type(ESMF_Mesh)     :: mesh_dst
+    integer             :: maptype
     character(len=*),parameter :: subname=' (med_aofluxes_init_atmgrid) '
     !-----------------------------------------------------------------------
 
@@ -567,9 +574,27 @@ contains
     if (chkerr(rc,__LINE__,u_FILE_u)) return
 
     ! ------------------------
+    ! Determine maptype for ocn->atm mapping
+    ! ------------------------
+
+    if (med_map_RH_is_created(is_local%wrap%RH(compocn,compatm,:), mapfcopy, rc=rc)) then
+       maptype = mapfcopy
+    else if (med_map_RH_is_created(is_local%wrap%RH(compocn,compatm,:), mapconsd, rc=rc)) then
+       maptype = mapconsd
+    else
+       call ESMF_LogWrite(trim(subname)//&
+            ": maptype for atm->ocn mapping of So_mask must be either mapfcopy or mapconsd", &
+            ESMF_LOGMSG_ERROR, line=__LINE__, file=u_FILE_u)
+       rc = ESMF_FAILURE
+       return
+    end if
+
+    ! ------------------------
     ! set aoflux computational mask on atm grid
     ! ------------------------
 
+    ! Compute mask is the ocean mask mapped to atm grid (conservatively without fractions)
+    ! This computes So_omask in FBocn_a - but the assumption is that it already is there
     ! Compute mask is the ocean mask mapped to atm grid (conservatively without fractions)
     ! This computes So_omask in FBocn_a - but the assumption is that it already is there
     call ESMF_FieldBundleGet(is_local%wrap%FBImp(compocn,compocn), 'So_omask', field=field_src, rc=rc)
@@ -577,7 +602,7 @@ contains
     call ESMF_FieldBundleGet(FBocn_a, 'So_omask', field=field_dst, rc=rc)
     if (chkerr(rc,__LINE__,u_FILE_u)) return
     call med_map_field( field_src=field_src, field_dst=field_dst, &
-         routehandles=is_local%wrap%RH(compocn,compatm,:), maptype=mapconsd, rc=rc)
+         routehandles=is_local%wrap%RH(compocn,compatm,:), maptype=maptype, rc=rc)
     if (chkerr(rc,__LINE__,u_FILE_u)) return
     call ESMF_FieldGet(field_dst, farrayptr=dataptr1d, rc=rc)
     if (chkerr(rc,__LINE__,u_FILE_u)) return
@@ -594,7 +619,7 @@ contains
     ! set one normalization for ocn-atm mapping if needed
     ! ------------------------
 
-    if (.not. ESMF_FieldIsCreated(is_local%wrap%field_NormOne(compocn,compatm,mapconsd))) then
+    if (.not. ESMF_FieldIsCreated(is_local%wrap%field_NormOne(compocn,compatm,maptype))) then
        ! Get source mesh
        call ESMF_FieldBundleGet(is_local%wrap%FBImp(compocn,compocn), 'So_omask', field=field_src, rc=rc)
        if (ChkErr(rc,__LINE__,u_FILE_u)) return
@@ -606,15 +631,15 @@ contains
        if (chkerr(rc,__LINE__,u_FILE_u)) return
        dataptr1d(:) = 1.0_R8
 
-       ! Create field is_local%wrap%field_NormOne(compocn,compatm,mapconsd) and fill in its values
+       ! Create field is_local%wrap%field_NormOne(compocn,compatm,maptype) and fill in its values
        call ESMF_FieldBundleGet(is_local%wrap%FBImp(compocn,compatm), 'So_omask', field=field_dst, rc=rc)
        if (ChkErr(rc,__LINE__,u_FILE_u)) return
        call ESMF_FieldGet(field_dst, mesh=mesh_dst, rc=rc)
        if (chkerr(rc,__LINE__,u_FILE_u)) return
-       is_local%wrap%field_NormOne(compocn,compatm,mapconsd) = ESMF_FieldCreate(mesh_dst, &
+       is_local%wrap%field_NormOne(compocn,compatm,maptype) = ESMF_FieldCreate(mesh_dst, &
             ESMF_TYPEKIND_R8, meshloc=ESMF_MESHLOC_ELEMENT, rc=rc)
-       call med_map_field( field_src=field_src, field_dst=is_local%wrap%field_NormOne(compocn,compatm,mapconsd), &
-            routehandles=is_local%wrap%RH(compocn,compatm,:), maptype=mapconsd, rc=rc)
+       call med_map_field( field_src=field_src, field_dst=is_local%wrap%field_NormOne(compocn,compatm,maptype), &
+            routehandles=is_local%wrap%RH(compocn,compatm,:), maptype=maptype, rc=rc)
        if (chkerr(rc,__LINE__,u_FILE_u)) return
 
        call ESMF_FieldDestroy(field_src, rc=rc, noGarbage=.true.)
@@ -830,7 +855,7 @@ contains
 
     use ESMF          , only : ESMF_GridComp
     use ESMF          , only : ESMF_LogWrite, ESMF_LogMsg_Info, ESMF_SUCCESS
-    use med_map_mod   , only : med_map_field_packed
+    use med_map_mod   , only : med_map_field_packed, med_map_rh_is_created
     use shr_flux_mod  , only : shr_flux_atmocn
 
     ! Arguments
@@ -846,6 +871,7 @@ contains
     integer             :: n,i,nf                     ! indices
     real(r8), pointer   :: data_normdst(:)
     real(r8), pointer   :: data_dst(:)
+    integer             :: maptype
     character(*),parameter  :: subName = '(med_aofluxes_update) '
     !-----------------------------------------------------------------------
 
@@ -872,25 +898,42 @@ contains
           ! Create source field
           call ESMF_FieldBundleGet(is_local%wrap%FBImp(compocn,compocn), fldnames_ocn_in(nf), field=field_src, rc=rc)
           if (chkerr(rc,__LINE__,u_FILE_u)) return
+
           ! Create destination field
           call ESMF_FieldBundleGet(FBocn_a, fldnames_ocn_in(nf), field=field_dst, rc=rc)
           if (chkerr(rc,__LINE__,u_FILE_u)) return
-          ! Map ocn->atm conservatively without fractions and then do a normalization by 'one'
-          call ESMF_FieldRegrid(field_src, field_dst, &
-               routehandle=is_local%wrap%RH(compocn,compatm, mapconsd), &
+
+          ! Determine maptype from ocn->atm
+          if (med_map_RH_is_created(is_local%wrap%RH(compocn,compatm,:), mapfcopy, rc=rc)) then
+             maptype = mapfcopy
+          else if (med_map_RH_is_created(is_local%wrap%RH(compocn,compatm,:), mapconsd, rc=rc)) then
+             maptype = mapconsd
+          else
+             call ESMF_LogWrite(trim(subname)//&
+                  ": maptype for atm->ocn mapping of aofluxes from atm->ocn either mapfcopy or mapconsd", &
+                  ESMF_LOGMSG_ERROR, line=__LINE__, file=u_FILE_u)
+             rc = ESMF_FAILURE
+             return
+          end if
+
+          ! Map ocn->atm conservatively without fractions
+          call ESMF_FieldRegrid(field_src, field_dst, routehandle=is_local%wrap%RH(compocn,compatm, maptype), &
                termorderflag=ESMF_TERMORDER_SRCSEQ, zeroregion=ESMF_REGION_TOTAL, rc=rc)
+
           ! Normalization of map by 'one'
-          call ESMF_FieldGet(is_local%wrap%field_normOne(compocn,compatm,mapconsd), farrayPtr=data_normdst, rc=rc)
-          if (chkerr(rc,__LINE__,u_FILE_u)) return
-          call ESMF_FieldGet(field_dst, farrayptr=data_dst, rc=rc)
-          if (chkerr(rc,__LINE__,u_FILE_u)) return
-          do n = 1,size(data_dst)
-             if (data_normdst(n) == 0.0_r8) then
-                data_dst(n) = 0.0_r8
-             else
-                data_dst(n) = data_dst(n)/data_normdst(n)
-             end if
-          end do
+          if (maptype /= mapfcopy) then
+             call ESMF_FieldGet(is_local%wrap%field_normOne(compocn,compatm,maptype), farrayPtr=data_normdst, rc=rc)
+             if (chkerr(rc,__LINE__,u_FILE_u)) return
+             call ESMF_FieldGet(field_dst, farrayptr=data_dst, rc=rc)
+             if (chkerr(rc,__LINE__,u_FILE_u)) return
+             do n = 1,size(data_dst)
+                if (data_normdst(n) == 0.0_r8) then
+                   data_dst(n) = 0.0_r8
+                else
+                   data_dst(n) = data_dst(n)/data_normdst(n)
+                end if
+             end do
+          end if
        end do
 
     else if (is_local%wrap%aoflux_grid == 'xgrid') then
@@ -997,8 +1040,19 @@ contains
              call ESMF_FieldBundleGet(is_local%wrap%FBMed_aoflux_o, fldnames_aof_out(nf), field=field_dst, rc=rc)
              if (chkerr(rc,__LINE__,u_FILE_u)) return
              ! Map atm->ocn conservatively WITHOUT fractions
+             if (med_map_RH_is_created(is_local%wrap%RH(compocn,compatm,:), mapfcopy, rc=rc)) then
+                maptype = mapfcopy
+             else if (med_map_RH_is_created(is_local%wrap%RH(compocn,compatm,:), mapconsf, rc=rc)) then
+                maptype = mapconsf
+             else
+                call ESMF_LogWrite(trim(subname)//&
+                     ": maptype for atm->ocn mapping of aofluxes from atm->ocn either mapfcopy or mapconsf", &
+                     ESMF_LOGMSG_ERROR, line=__LINE__, file=u_FILE_u)
+                rc = ESMF_FAILURE
+                return
+             end if
              call ESMF_FieldRegrid(field_src, field_dst, &
-                  routehandle=is_local%wrap%RH(compatm, compocn, mapconsf), &
+                  routehandle=is_local%wrap%RH(compatm, compocn, maptype), &
                   termorderflag=ESMF_TERMORDER_SRCSEQ, zeroregion=ESMF_REGION_TOTAL, rc=rc)
           end do
        end if

--- a/mediator/med_phases_aofluxes_mod.F90
+++ b/mediator/med_phases_aofluxes_mod.F90
@@ -23,14 +23,10 @@ module med_phases_aofluxes_mod
   use ESMF                  , only : ESMF_LogWrite, ESMF_LOGMSG_INFO, ESMF_SUCCESS
   use ESMF                  , only : ESMF_Finalize, ESMF_LogFoundError
   use med_kind_mod          , only : CX=>SHR_KIND_CX, CS=>SHR_KIND_CS, CL=>SHR_KIND_CL, R8=>SHR_KIND_R8
-  use med_internalstate_mod , only : InternalState
-  use med_internalstate_mod , only : mastertask, logunit
+  use med_internalstate_mod , only : InternalState, mastertask, logunit
   use med_constants_mod     , only : dbug_flag    => med_constants_dbug_flag
   use med_utils_mod         , only : memcheck     => med_memcheck
-  use med_methods_mod       , only : FB_fldchk    => med_methods_FB_FldChk
-  use med_methods_mod       , only : FB_GetFldPtr => med_methods_FB_GetFldPtr
   use med_utils_mod         , only : chkerr       => med_utils_chkerr
-  use med_map_mod           , only : med_map_field
   use esmFlds               , only : compatm, compocn, coupling_mode, mapconsd, mapconsf
   use perf_mod              , only : t_startf, t_stopf
 
@@ -519,6 +515,7 @@ contains
     ! --------------------------------------------
 
     use med_methods_mod, only : FB_init => med_methods_FB_init
+    use med_map_mod    , only : med_map_field
 
     ! Arguments
     type(ESMF_GridComp)   , intent(inout) :: gcomp


### PR DESCRIPTION
### Description of changes
bug fixes for new agrid/ogrid and restart functionality

### Specific notes

1. add fixes for computing aofluxes on both agrid and xgrid in compsets with data ocean and active atm (i.e. F/Q compsets in CESM)
2. fix problem associated with running ERS/ERR tests with new introduction of write_restart_at_endofrun

Contributors other than yourself, if any:

CMEPS Issues Fixed: None (no issues were raised for the problems being fixed)

Are changes expected to change answers?
 - [x] bit for bit
 - [ ] different at roundoff level
 - [ ] more substantial

Any User Interface Changes (namelist or namelist defaults changes)?
 - [x] Yes - write_restart_at_endofrun default has been changed
 - [ ] No

Testing performed if application target is CESM:(either UFS-S2S or CESM testing is required):
- [ ] (recommended) CIME_DRIVER=nuopc scripts_regression_tests.py
   - machines:
   - details (e.g. failed tests):
- [x] (recommended) CESM testlist_drv.xml
   - machines and compilers: cheyenne/intel
   - details (e.g. failed tests): 
     -  bfb compared to baseline  cmeps0.13.22, 
     - verifed that SMS_Ld7_Vnuopc.f09_g17.B1850.cheyenne_intel.allactive-defaultio cesm2_3_alpha05b_nuopc
- [ ] (optional) CESM prealpha test
   - machines and compilers
   - details (e.g. failed tests):
- [ ] (other) please described in detail
   - machines and compilers
   - details (e.g. failed tests):

Testing performed if application target is UFS-coupled:
- [ ] (recommended) UFS-coupled testing
   - description:
   - details (e.g. failed tests):

Testing performed if application target is UFS-HAFS:
- [ ] (recommended) UFS-HAFS testing
   - description:
   - details (e.g. failed tests):

Hashes used for testing:
- [x] CESM:
  - repository to check out: https://github.com/ESCOMP/CESM.git
  - hashes: cesm2_3_alpha05b with the following changes:
       cime: cime6.0.5  
       cism: cismwrap_2_1_87
       cdeps: cdeps0.12.20
  - [ ] UFS-coupled, then umbrella repostiory to check out and associated hash:
  - repository to check out:
  - branch:
  - hash:
- [ ] UFS-HAFS, then umbrella repostiory to check out and associated hash:
  - repository to check out:
  - branch:
  - hash:
