### PR TITLE
fix for ERS restart problem

### DIFF
--- a/cime_config/namelist_definition_drv.xml
+++ b/cime_config/namelist_definition_drv.xml
@@ -360,13 +360,12 @@
   <!-- =========================================== -->
 
   <entry id="write_restart_at_endofrun">
-    <type>char</type>
+    <type>logical</type>
     <category>nuopc</category>
     <group>ALLCOMP_attributes</group>
     <values>
-      <value>.true.</value>
-      <value rest_option="none">.false.</value>
-      <value rest_option="never">.false.</value>
+      <value>.false.</value>
+      <value rest_option="end">.true.</value>
     </values>
   </entry>
 


### PR DESCRIPTION
### Description of changes
fix for ERS restart problem

### Specific notes
This fixes problems in cesm ERS tests introduced in #221 

Contributors other than yourself, if any: jedwards4b

CMEPS Issues Fixed: issue not introduced

Are changes expected to change answers?
 - [x] bit for bit
 - [ ] different at roundoff level
 - [ ] more substantial

Any User Interface Changes (namelist or namelist defaults changes)?
 - [x] Yes - by default write_restart_at_endofrun is only true if REST_OPTION is 'none'
 - [ ] No

Testing performed if application target is CESM:(either UFS-S2S or CESM testing is required):
- [ ] (recommended) CIME_DRIVER=nuopc scripts_regression_tests.py
   - machines:
   - details (e.g. failed tests):
- [ ] (recommended) CESM testlist_drv.xml
   - machines and compilers:
   - details (e.g. failed tests):
- [ ] (optional) CESM prealpha test
   - machines and compilers
   - details (e.g. failed tests):
- [x] (other) please described in detail
   - machines and compilers cheyenne/intel
   - details (e.g. failed tests): validated that previous broken test ERS_Vnuopc_Ln5.f19_f19_mg17.F2000Nuopc.cheyenne_intel.cam-nuopc_cap  now works

Testing performed if application target is UFS-coupled:
- [ ] (recommended) UFS-coupled testing
   - description:
   - details (e.g. failed tests):

Testing performed if application target is UFS-HAFS:
- [ ] (recommended) UFS-HAFS testing
   - description:
   - details (e.g. failed tests):

Hashes used for testing:
- [ ] CESM:
  - repository to check out: https://github.com/ESCOMP/CESM.git
  - hash: cesm2_3_alpha05b
- [ ] UFS-coupled, then umbrella repostiory to check out and associated hash:
  - repository to check out:
  - branch:
  - hash:
- [ ] UFS-HAFS, then umbrella repostiory to check out and associated hash:
  - repository to check out:
  - branch:
  - hash:
