### PR TITLE
refactor accum field bundles

### DIFF
--- a/cime_config/buildexe
+++ b/cime_config/buildexe
@@ -84,7 +84,7 @@ def _main_func():
     if not os.path.isdir(bld_root):
         os.makedirs(bld_root)
 
-    with open(os.path.join(bld_root,'Filepath'), 'w', encoding='utf-8') as out:
+    with open(os.path.join(bld_root,'Filepath'), 'w', encoding="utf-8") as out:
         cmeps_dir = os.path.join(os.path.dirname(__file__), os.pardir)
         # SourceMods dir needs to be first listed
         out.write(os.path.join(caseroot, "SourceMods", "src.drv") + "\n")

--- a/cime_config/buildexe
+++ b/cime_config/buildexe
@@ -84,7 +84,7 @@ def _main_func():
     if not os.path.isdir(bld_root):
         os.makedirs(bld_root)
 
-    with open(os.path.join(bld_root,'Filepath'), 'w') as out:
+    with open(os.path.join(bld_root,'Filepath'), 'w', encoding='utf-8') as out:
         cmeps_dir = os.path.join(os.path.dirname(__file__), os.pardir)
         # SourceMods dir needs to be first listed
         out.write(os.path.join(caseroot, "SourceMods", "src.drv") + "\n")

--- a/cime_config/buildnml
+++ b/cime_config/buildnml
@@ -488,11 +488,12 @@ def _create_component_modelio_namelists(confdir, case, files):
                 for entry in entries:
                     nmlgen.add_default(entry)
 
-                if model == "cpl":
-                    modelio_file = "med_modelio.nml" + inst_string
-                else:
-                    modelio_file = model + "_modelio.nml" + inst_string
-                nmlgen.write_nuopc_modelio_file(os.path.join(confdir, modelio_file))
+                if inst_index == 1:
+                    if model == "cpl":      
+                        modelio_file = "med_modelio.nml"
+                    else:
+                        modelio_file = model + "_modelio.nml"
+                    nmlgen.write_nuopc_modelio_file(os.path.join(confdir, modelio_file))
 
                 # Output the following to nuopc.runconfig
                 moddiro = case.get_value('RUNDIR')

--- a/cime_config/buildnml
+++ b/cime_config/buildnml
@@ -405,7 +405,7 @@ def _create_runseq(case, coupling_times, valid_comps):
         if len(valid_comps) == 1:
 
             # Create run sequence with no mediator
-            outfile = open(os.path.join(caseroot, "CaseDocs", "nuopc.runseq"), "w")
+            outfile = open(os.path.join(caseroot, "CaseDocs", "nuopc.runseq"), "w", encoding="utf-8")
             dtime = coupling_times[valid_comps[0].lower() + '_cpl_dt']
             outfile.write ("runSeq:: \n")
             outfile.write ("@" + str(dtime) + " \n")

--- a/cime_config/buildnml
+++ b/cime_config/buildnml
@@ -301,7 +301,7 @@ def _create_drv_namelists(case, infile, confdir, nmlgen, files):
     #--------------------------------
 
     # Read nuopc.runconfig
-    with open(nuopc_config_file, 'r') as f:
+    with open(nuopc_config_file, 'r', encoding='utf-8') as f:
         lines_cpl = f.readlines()
 
     # Look for only active components except CPL
@@ -313,7 +313,7 @@ def _create_drv_namelists(case, infile, confdir, nmlgen, files):
             comp_config_file = os.path.join(caseroot,"Buildconf","{}conf".format(case.get_value("COMP_{}".format(comp))),
                                             "{}.configure".format(case.get_value("COMP_{}".format(comp))))
             if os.path.isfile(comp_config_file):
-                with open(comp_config_file, 'r') as f:
+                with open(comp_config_file, 'r', encoding='utf-8') as f:
                     lines_comp = f.readlines()
 
             if lines_comp:
@@ -331,7 +331,7 @@ def _create_drv_namelists(case, infile, confdir, nmlgen, files):
                             lines_cpl_new.append(line_comp)
 
                 # Write to a file
-                with open(nuopc_config_file, 'w') as f:
+                with open(nuopc_config_file, 'w', encoding='utf-8') as f:
                     for line in lines_cpl_new:
                         f.write(line)
 
@@ -363,7 +363,7 @@ def _create_drv_namelists(case, infile, confdir, nmlgen, files):
         dicts = {}
         for infile in infiles:
             dict_ = {}
-            with open(infile) as myfile:
+            with open(infile, encoding='utf-8') as myfile:
                 for line in myfile:
                     if "=" in line and '!' not in line:
                         name, var = line.partition("=")[::2]
@@ -501,7 +501,7 @@ def _create_component_modelio_namelists(confdir, case, files):
                 else:
                     logfile = model + inst_string + ".log." + str(lid)
 
-                with open(nuopc_config_file, 'a') as outfile:
+                with open(nuopc_config_file, 'a', encoding='utf-8') as outfile:
                     if model == 'cpl':
                         name = "MED"
                     else:
@@ -535,11 +535,11 @@ def buildnml(case, caseroot, component):
     if component != "drv":
         raise AttributeError
 
-#   Do a check here of ESMF VERSION, requires 8.1.0 or newer (8.2.0 or newer for esmf_aware_threading)
+    #   Do a check here of ESMF VERSION, requires 8.1.0 or newer (8.2.0 or newer for esmf_aware_threading)
     esmf_aware_threading = case.get_value("ESMF_AWARE_THREADING")
     esmfmkfile = os.getenv("ESMFMKFILE")
     expect(esmfmkfile and os.path.isfile(esmfmkfile),"ESMFMKFILE not found {}".format(esmfmkfile))
-    with open(esmfmkfile, 'r') as f:
+    with open(esmfmkfile, 'r', encoding='utf-8') as f:
         major = None
         minor = None
         for line in f.readlines():

--- a/cime_config/buildnml
+++ b/cime_config/buildnml
@@ -301,7 +301,7 @@ def _create_drv_namelists(case, infile, confdir, nmlgen, files):
     #--------------------------------
 
     # Read nuopc.runconfig
-    with open(nuopc_config_file, 'r', encoding='utf-8') as f:
+    with open(nuopc_config_file, 'r', encoding="utf-8") as f:
         lines_cpl = f.readlines()
 
     # Look for only active components except CPL
@@ -313,7 +313,7 @@ def _create_drv_namelists(case, infile, confdir, nmlgen, files):
             comp_config_file = os.path.join(caseroot,"Buildconf","{}conf".format(case.get_value("COMP_{}".format(comp))),
                                             "{}.configure".format(case.get_value("COMP_{}".format(comp))))
             if os.path.isfile(comp_config_file):
-                with open(comp_config_file, 'r', encoding='utf-8') as f:
+                with open(comp_config_file, 'r', encoding="utf-8") as f:
                     lines_comp = f.readlines()
 
             if lines_comp:
@@ -331,7 +331,7 @@ def _create_drv_namelists(case, infile, confdir, nmlgen, files):
                             lines_cpl_new.append(line_comp)
 
                 # Write to a file
-                with open(nuopc_config_file, 'w', encoding='utf-8') as f:
+                with open(nuopc_config_file, 'w', encoding="utf-8") as f:
                     for line in lines_cpl_new:
                         f.write(line)
 
@@ -363,7 +363,7 @@ def _create_drv_namelists(case, infile, confdir, nmlgen, files):
         dicts = {}
         for infile in infiles:
             dict_ = {}
-            with open(infile, encoding='utf-8') as myfile:
+            with open(infile, "r", encoding="utf-8") as myfile:
                 for line in myfile:
                     if "=" in line and '!' not in line:
                         name, var = line.partition("=")[::2]
@@ -540,7 +540,7 @@ def buildnml(case, caseroot, component):
     esmf_aware_threading = case.get_value("ESMF_AWARE_THREADING")
     esmfmkfile = os.getenv("ESMFMKFILE")
     expect(esmfmkfile and os.path.isfile(esmfmkfile),"ESMFMKFILE not found {}".format(esmfmkfile))
-    with open(esmfmkfile, 'r', encoding='utf-8') as f:
+    with open(esmfmkfile, 'r', encoding="utf-8") as f:
         major = None
         minor = None
         for line in f.readlines():

--- a/cime_config/runseq/gen_runseq.py
+++ b/cime_config/runseq/gen_runseq.py
@@ -7,7 +7,7 @@ class RunSeq:
         self.__outfile = None
 
     def __enter__(self):
-        self.__outfile = open(self.__outfile_name, "w")
+        self.__outfile = open(self.__outfile_name, "w", encoding="utf-8")
         self.__outfile.write("runSeq:: \n")
         return self
 

--- a/mediator/esmFldsExchange_cesm_mod.F90
+++ b/mediator/esmFldsExchange_cesm_mod.F90
@@ -2869,6 +2869,21 @@ contains
     end if
 
     ! ---------------------------------------------------------------------
+    ! to rof: water flux from land (ice surface)
+    ! ---------------------------------------------------------------------
+    if (phase == 'advertise') then
+       call addfld(fldListFr(complnd)%flds, 'Flrl_rofi')
+       call addfld(fldListTo(comprof)%flds, 'Flrl_rofi')
+    else
+       if ( fldchk(is_local%wrap%FBImp(complnd, complnd), 'Flrl_rofi', rc=rc) .and. &
+            fldchk(is_local%wrap%FBExp(comprof)         , 'Flrl_rofi', rc=rc)) then
+          call addmap(fldListFr(complnd)%flds, 'Flrl_rofi', comprof, mapconsf, 'lfrac', lnd2rof_map)
+          call addmrg(fldListTo(comprof)%flds, 'Flrl_rofi', &
+               mrg_from=complnd, mrg_fld='Flrl_rofi', mrg_type='copy_with_weights', mrg_fracname='lfrac')
+       end if
+    end if
+
+    ! ---------------------------------------------------------------------
     ! to rof: water flux from land (liquid glacier, wetland, and lake)
     ! ---------------------------------------------------------------------
     if (phase == 'advertise') then
@@ -2895,32 +2910,6 @@ contains
           call addmap(fldListFr(complnd)%flds, 'Flrl_rofsub', comprof, mapconsf, 'lfrac', lnd2rof_map)
           call addmrg(fldListTo(comprof)%flds, 'Flrl_rofsub', &
                mrg_from=complnd, mrg_fld='Flrl_rofsub', mrg_type='copy_with_weights', mrg_fracname='lfrac')
-       end if
-    end if
-    if (phase == 'advertise') then
-       call addfld(fldListFr(complnd)%flds, 'Flrl_rofdto')
-       call addfld(fldListTo(comprof)%flds, 'Flrl_rofdto')
-    else
-       if ( fldchk(is_local%wrap%FBImp(complnd, complnd), 'Flrl_rofdto', rc=rc) .and. &
-            fldchk(is_local%wrap%FBExp(comprof)         , 'Flrl_rofdto', rc=rc)) then
-          call addmap(fldListFr(complnd)%flds, 'Flrl_rofdto', comprof, mapconsf, 'lfrac', lnd2rof_map)
-          call addmrg(fldListTo(comprof)%flds, 'Flrl_rofdto', &
-               mrg_from=complnd, mrg_fld='Flrl_rofdto', mrg_type='copy_with_weights', mrg_fracname='lfrac')
-       end if
-    end if
-
-    ! ---------------------------------------------------------------------
-    ! to rof: water flux from land direct to ocean
-    ! ---------------------------------------------------------------------
-    if (phase == 'advertise') then
-       call addfld(fldListFr(complnd)%flds, 'Flrl_rofi')
-       call addfld(fldListTo(comprof)%flds, 'Flrl_rofi')
-    else
-       if ( fldchk(is_local%wrap%FBImp(complnd, complnd), 'Flrl_rofi', rc=rc) .and. &
-            fldchk(is_local%wrap%FBExp(comprof)         , 'Flrl_rofi', rc=rc)) then
-          call addmap(fldListFr(complnd)%flds, 'Flrl_rofi', comprof, mapconsf, 'lfrac', lnd2rof_map)
-          call addmrg(fldListTo(comprof)%flds, 'Flrl_rofi', &
-               mrg_from=complnd, mrg_fld='Flrl_rofi', mrg_type='copy_with_weights', mrg_fracname='lfrac')
        end if
     end if
 

--- a/mediator/med.F90
+++ b/mediator/med.F90
@@ -1981,7 +1981,7 @@ contains
       endif
 
       !----------------------------------------------------------
-      ! Create field bundles FBImp, FBExp, FBImpAccum, FBExpAccum
+      ! Create field bundles FBImp, FBExp, FBExpAccum
       !----------------------------------------------------------
 
       if (mastertask) then
@@ -2005,14 +2005,6 @@ contains
             ! Create FBExp(:) with pointers directly into NStateExp(:)
             call FB_init_pointer(is_local%wrap%NStateExp(n1), is_local%wrap%FBExp(n1), &
                  is_local%wrap%flds_scalar_name, name='FBExp'//trim(compname(n1)), rc=rc)
-            if (ChkErr(rc,__LINE__,u_FILE_u)) return
-
-            ! Create import accumulation field bundles
-            call FB_init(is_local%wrap%FBImpAccum(n1,n1), is_local%wrap%flds_scalar_name, &
-                 STgeom=is_local%wrap%NStateImp(n1), STflds=is_local%wrap%NStateImp(n1), &
-                 name='FBImpAccum'//trim(compname(n1)), rc=rc)
-            if (ChkErr(rc,__LINE__,u_FILE_u)) return
-            call FB_reset(is_local%wrap%FBImpAccum(n1,n1), value=czero, rc=rc)
             if (ChkErr(rc,__LINE__,u_FILE_u)) return
 
             ! Create export accumulation field bundles
@@ -2044,8 +2036,7 @@ contains
             if (ChkErr(rc,__LINE__,u_FILE_u)) return
          end if
 
-         ! The following are FBImp and FBImpAccum mapped to different grids.
-         ! FBImp(n1,n1) and FBImpAccum(n1,n1) are handled above
+         ! The following is FBImp mapped to different grids. FBImp(n1,n1) is handled above
          do n2 = 1,ncomps
             if (n1 /= n2 .and. &
                  is_local%wrap%med_coupling_active(n1,n2) .and. &
@@ -2073,19 +2064,8 @@ contains
                       name='FBImp'//trim(compname(n1))//'_'//trim(compname(n2)), rc=rc)
                end if
                if (ChkErr(rc,__LINE__,u_FILE_u)) return
-
-               call FB_init(is_local%wrap%FBImpAccum(n1,n2), is_local%wrap%flds_scalar_name, &
-                    STgeom=is_local%wrap%NStateImp(n2), &
-                    STflds=is_local%wrap%NStateImp(n1), &
-                    name='FBImpAccum'//trim(compname(n1))//'_'//trim(compname(n2)), rc=rc)
-               if (ChkErr(rc,__LINE__,u_FILE_u)) return
-
-               call FB_reset(is_local%wrap%FBImpAccum(n1,n2), value=czero, rc=rc)
-               if (ChkErr(rc,__LINE__,u_FILE_u)) return
-
             endif
          enddo ! loop over n2
-
       enddo ! loop over n1
 
       !---------------------------------------

--- a/mediator/med.F90
+++ b/mediator/med.F90
@@ -1742,6 +1742,7 @@ contains
     use NUOPC                   , only : NUOPC_CompAttributeGet
     use med_fraction_mod        , only : med_fraction_init, med_fraction_set
     use med_phases_restart_mod  , only : med_phases_restart_read
+    use med_phases_prep_rof_mod , only : med_phases_prep_rof_init
     use med_phases_prep_glc_mod , only : med_phases_prep_glc_init
     use med_phases_prep_atm_mod , only : med_phases_prep_atm
     use med_phases_post_atm_mod , only : med_phases_post_atm
@@ -2210,6 +2211,14 @@ contains
       end do
       if (lnd2glc_coupling .or. ocn2glc_coupling) then
          call med_phases_prep_glc_init(gcomp, rc=rc)
+         if (ChkErr(rc,__LINE__,u_FILE_u)) return
+      end if
+
+      !---------------------------------------
+      ! Initialize rof module field bundles here if appropriate
+      !---------------------------------------
+      if (is_local%wrap%med_coupling_active(comprof,complnd)) then
+         call med_phases_prep_rof_init(gcomp, rc=rc)
          if (ChkErr(rc,__LINE__,u_FILE_u)) return
       end if
 

--- a/mediator/med_diag_mod.F90
+++ b/mediator/med_diag_mod.F90
@@ -950,8 +950,6 @@ contains
          areas, lfrac, budget_local, minus=.true., rc=rc)
     call diag_lnd(is_local%wrap%FBImp(complnd,complnd), 'Flrl_rofsub', f_watr_roff, ic,&
          areas, lfrac, budget_local, minus=.true., rc=rc)
-    call diag_lnd(is_local%wrap%FBImp(complnd,complnd), 'Flrl_rofdto', f_watr_roff, ic,&
-         areas, lfrac, budget_local, minus=.true., rc=rc)
     call diag_lnd(is_local%wrap%FBImp(complnd,complnd), 'Flrl_irrig' , f_watr_roff, ic,&
          areas, lfrac, budget_local, minus=.true., rc=rc)
     call diag_lnd(is_local%wrap%FBImp(complnd,complnd), 'Flrl_rofi'  , f_watr_ioff, ic,&
@@ -1129,7 +1127,6 @@ contains
     call diag_rof(is_local%wrap%FBExp(comprof), 'Flrl_rofsur', f_watr_roff, ic, areas, budget_local, rc=rc)
     call diag_rof(is_local%wrap%FBExp(comprof), 'Flrl_rofgwl', f_watr_roff, ic, areas, budget_local, rc=rc)
     call diag_rof(is_local%wrap%FBExp(comprof), 'Flrl_rofsub', f_watr_roff, ic, areas, budget_local, rc=rc)
-    call diag_rof(is_local%wrap%FBExp(comprof), 'Flrl_rofdto', f_watr_roff, ic, areas, budget_local, rc=rc)
     call diag_rof(is_local%wrap%FBExp(comprof), 'Flrl_irrig' , f_watr_roff, ic, areas, budget_local, rc=rc)
     call diag_rof(is_local%wrap%FBExp(comprof), 'Flrl_rofi'  , f_watr_ioff, ic, areas, budget_local, rc=rc)
 

--- a/mediator/med_internalstate_mod.F90
+++ b/mediator/med_internalstate_mod.F90
@@ -88,16 +88,15 @@ module med_internalstate_mod
     type(packed_data_type) :: packed_data(ncomps,ncomps,nmappers)   ! Packed data structure needed to efficiently map field bundles
 
     ! Fractions
-    type(ESMF_FieldBundle) :: FBfrac(ncomps)                     ! Fraction data for various components, on their grid
+    type(ESMF_FieldBundle) :: FBfrac(ncomps)     ! Fraction data for various components, on their grid
 
     ! Accumulators for export field bundles
-    type(ESMF_FieldBundle) :: FBExpAccum(ncomps)                 ! Accumulator for various components export on their grid
-    integer                :: FBExpAccumCnt(ncomps) = 0          ! Accumulator counter for each FBExpAccum
-    logical                :: FBExpAccumFlag(ncomps) = .false.   ! Accumulator flag, if true accumulation was done
+    type(ESMF_FieldBundle) :: FBExpAccumOcn      ! Accumulator for various components export on their grid
+    integer                :: ExpAccumOcnCnt = 0 ! Accumulator counter for each FBExpAccum
 
     ! Component Mesh info
     type(mesh_info_type)   :: mesh_info(ncomps)
-    type(ESMF_FieldBundle) :: FBArea(ncomps)                     ! needed for mediator history writes
+    type(ESMF_FieldBundle) :: FBArea(ncomps)     ! needed for mediator history writes
 
  end type InternalStateStruct
 

--- a/mediator/med_internalstate_mod.F90
+++ b/mediator/med_internalstate_mod.F90
@@ -95,10 +95,6 @@ module med_internalstate_mod
     integer                :: FBExpAccumCnt(ncomps) = 0          ! Accumulator counter for each FBExpAccum
     logical                :: FBExpAccumFlag(ncomps) = .false.   ! Accumulator flag, if true accumulation was done
 
-    ! Accumulators for import field bundles
-    type(ESMF_FieldBundle) :: FBImpAccum(ncomps,ncomps)          ! Accumulator for various components import
-    integer                :: FBImpAccumCnt(ncomps) = 0          ! Accumulator counter for each FBImpAccum
-
     ! Component Mesh info
     type(mesh_info_type)   :: mesh_info(ncomps)
     type(ESMF_FieldBundle) :: FBArea(ncomps)                     ! needed for mediator history writes

--- a/mediator/med_methods_mod.F90
+++ b/mediator/med_methods_mod.F90
@@ -19,14 +19,6 @@ module med_methods_mod
   implicit none
   private
 
-  interface med_methods_FB_accum ; module procedure &
-    med_methods_FB_accumFB2FB
-  end interface
-
-  interface med_methods_FB_copy ; module procedure &
-    med_methods_FB_copyFB2FB
-  end interface
-
   interface med_methods_FieldPtr_compare ; module procedure &
     med_methods_FieldPtr_compare1, &
     med_methods_FieldPtr_compare2
@@ -76,8 +68,6 @@ module med_methods_mod
   private med_methods_Mesh_Print
   private med_methods_Grid_Print
   private med_methods_Field_GetFldPtr
-  private med_methods_FB_copyFB2FB
-  private med_methods_FB_accumFB2FB
   private med_methods_Array_diagnose
 
 !-----------------------------------------------------------------------------
@@ -1280,7 +1270,7 @@ contains
 
   !-----------------------------------------------------------------------------
 
-  subroutine med_methods_FB_copyFB2FB(FBout, FBin, rc)
+  subroutine med_methods_FB_copy(FBout, FBin, rc)
 
     ! ----------------------------------------------
     ! Copy common field names from FBin to FBout
@@ -1291,7 +1281,7 @@ contains
     type(ESMF_FieldBundle), intent(inout) :: FBout
     type(ESMF_FieldBundle), intent(in)    :: FBin
     integer               , intent(out)   :: rc
-    character(len=*), parameter :: subname='(med_methods_FB_copyFB2FB)'
+    character(len=*), parameter :: subname='(med_methods_FB_copy)'
     ! ----------------------------------------------
 
     call ESMF_LogWrite(trim(subname)//": called", ESMF_LOGMSG_INFO)
@@ -1304,11 +1294,11 @@ contains
       call ESMF_LogWrite(trim(subname)//": done", ESMF_LOGMSG_INFO)
     endif
 
-  end subroutine med_methods_FB_copyFB2FB
+  end subroutine med_methods_FB_copy
 
   !-----------------------------------------------------------------------------
 
-  subroutine med_methods_FB_accumFB2FB(FBout, FBin, copy, rc)
+  subroutine med_methods_FB_accum(FBout, FBin, copy, rc)
 
     ! ----------------------------------------------
     ! Accumulate common field names from FBin to FBout
@@ -1334,7 +1324,7 @@ contains
     real(R8), pointer               :: dataPtri2(:,:) => null()
     real(R8), pointer               :: dataPtro2(:,:) => null()
     type(ESMF_Field)                :: lfield
-    character(len=*), parameter     :: subname='(med_methods_FB_accumFB2FB)'
+    character(len=*), parameter     :: subname='(med_methods_FB_accum)'
     ! ----------------------------------------------
 
     if (dbug_flag > 10) then
@@ -1427,7 +1417,7 @@ contains
       call ESMF_LogWrite(trim(subname)//": done", ESMF_LOGMSG_INFO)
     endif
 
-  end subroutine med_methods_FB_accumFB2FB
+  end subroutine med_methods_FB_accum
 
   !-----------------------------------------------------------------------------
 

--- a/mediator/med_phases_history_mod.F90
+++ b/mediator/med_phases_history_mod.F90
@@ -24,7 +24,6 @@ module med_phases_history_mod
   use med_utils_mod         , only : chkerr          => med_utils_ChkErr
   use med_methods_mod       , only : FB_reset        => med_methods_FB_reset
   use med_methods_mod       , only : FB_diagnose     => med_methods_FB_diagnose
-  use med_methods_mod       , only : FB_accum        => med_methods_FB_accum
   use med_methods_mod       , only : State_GetScalar => med_methods_State_GetScalar
   use med_internalstate_mod , only : InternalState, mastertask, logunit
   use med_time_mod          , only : med_time_alarmInit

--- a/mediator/med_phases_post_glc_mod.F90
+++ b/mediator/med_phases_post_glc_mod.F90
@@ -30,7 +30,6 @@ module med_phases_post_glc_mod
   use med_internalstate_mod , only : InternalState, mastertask, logunit
   use med_map_mod           , only : med_map_rh_is_created, med_map_routehandles_init
   use med_map_mod           , only : med_map_field_packed, med_map_field_normalized, med_map_field
-  use med_merge_mod         , only : med_merge_auto
   use glc_elevclass_mod     , only : glc_get_num_elevation_classes
   use glc_elevclass_mod     , only : glc_mean_elevation_virtual
   use glc_elevclass_mod     , only : glc_get_fractional_icecov

--- a/mediator/med_phases_post_glc_mod.F90
+++ b/mediator/med_phases_post_glc_mod.F90
@@ -30,6 +30,7 @@ module med_phases_post_glc_mod
   use med_internalstate_mod , only : InternalState, mastertask, logunit
   use med_map_mod           , only : med_map_rh_is_created, med_map_routehandles_init
   use med_map_mod           , only : med_map_field_packed, med_map_field_normalized, med_map_field
+  use med_merge_mod         , only : med_merge_auto
   use glc_elevclass_mod     , only : glc_get_num_elevation_classes
   use glc_elevclass_mod     , only : glc_mean_elevation_virtual
   use glc_elevclass_mod     , only : glc_get_fractional_icecov

--- a/mediator/med_phases_post_lnd_mod.F90
+++ b/mediator/med_phases_post_lnd_mod.F90
@@ -34,8 +34,6 @@ contains
 
     ! local variables
     type(InternalState) :: is_local
-    integer             :: ns
-    logical             :: first_call = .true.
     character(len=*),parameter :: subname='(med_phases_post_lnd)'
     !-------------------------------------------------------------------------------
 

--- a/mediator/med_phases_prep_atm_mod.F90
+++ b/mediator/med_phases_prep_atm_mod.F90
@@ -128,7 +128,7 @@ contains
     !--- merge all fields to atm
     !---------------------------------------
     if (trim(coupling_mode) == 'cesm' .or. trim(coupling_mode) == 'hafs') then
-       call med_merge_auto(compatm, &
+       call med_merge_auto(&
             is_local%wrap%med_coupling_active(:,compatm), &
             is_local%wrap%FBExp(compatm), &
             is_local%wrap%FBFrac(compatm), &
@@ -138,7 +138,7 @@ contains
             FBMed2=is_local%wrap%FBMed_aoflux_a, rc=rc)
        if (ChkErr(rc,__LINE__,u_FILE_u)) return
     else if (trim(coupling_mode) == 'nems_frac' .or. trim(coupling_mode) == 'nems_orig') then
-       call med_merge_auto(compatm, &
+       call med_merge_auto(&
             is_local%wrap%med_coupling_active(:,compatm), &
             is_local%wrap%FBExp(compatm), &
             is_local%wrap%FBFrac(compatm), &

--- a/mediator/med_phases_prep_ice_mod.F90
+++ b/mediator/med_phases_prep_ice_mod.F90
@@ -80,7 +80,7 @@ contains
     ! ocn->ice is mapped in med_phases_post_ocn
 
     ! auto merges to create FBExp(compice)
-    call med_merge_auto(compice, &
+    call med_merge_auto(&
          is_local%wrap%med_coupling_active(:,compice), &
          is_local%wrap%FBExp(compice), &
          is_local%wrap%FBFrac(compice), &

--- a/mediator/med_phases_prep_lnd_mod.F90
+++ b/mediator/med_phases_prep_lnd_mod.F90
@@ -82,7 +82,7 @@ contains
        ! auto merges to create FBExp(complnd) - other than glc->lnd
        ! The following will merge all fields in fldsSrc
        call t_startf('MED:'//trim(subname)//' merge')
-       call med_merge_auto(complnd, &
+       call med_merge_auto(&
             is_local%wrap%med_coupling_active(:,complnd), &
             is_local%wrap%FBExp(complnd), &
             is_local%wrap%FBFrac(complnd), &

--- a/mediator/med_phases_prep_ocn_mod.F90
+++ b/mediator/med_phases_prep_ocn_mod.F90
@@ -72,7 +72,7 @@ contains
     if ( trim(coupling_mode) == 'cesm' .or. &
          trim(coupling_mode) == 'nems_orig_data' .or. &
          trim(coupling_mode) == 'hafs') then
-       call med_merge_auto(compocn, &
+       call med_merge_auto(&
             is_local%wrap%med_coupling_active(:,compocn), &
             is_local%wrap%FBExp(compocn), &
             is_local%wrap%FBFrac(compocn), &
@@ -81,7 +81,7 @@ contains
             FBMed1=is_local%wrap%FBMed_aoflux_o, rc=rc)
        if (ChkErr(rc,__LINE__,u_FILE_u)) return
     else if (trim(coupling_mode) == 'nems_frac' .or. trim(coupling_mode) == 'nems_orig') then
-       call med_merge_auto(compocn, &
+       call med_merge_auto(&
             is_local%wrap%med_coupling_active(:,compocn), &
             is_local%wrap%FBExp(compocn), &
             is_local%wrap%FBFrac(compocn), &

--- a/mediator/med_phases_prep_rof_mod.F90
+++ b/mediator/med_phases_prep_rof_mod.F90
@@ -302,7 +302,7 @@ contains
        if (chkerr(rc,__LINE__,u_FILE_u)) return
     end if
 
-    call med_merge_auto(comprof, &
+    call med_merge_auto(&
          is_local%wrap%med_coupling_active(:,comprof), &
          is_local%wrap%FBExp(comprof), &
          is_local%wrap%FBFrac(comprof), &

--- a/mediator/med_phases_prep_rof_mod.F90
+++ b/mediator/med_phases_prep_rof_mod.F90
@@ -3,11 +3,11 @@ module med_phases_prep_rof_mod
   !-----------------------------------------------------------------------------
   ! Create rof export fields
   ! - accumulate import lnd fields on the land grid that are sent to rof
-  !   this will be done in med_phases_prep_rof_accum
-  ! - time avergage accumulated import lnd fields when necessary
-  !   map the time averaged accumulated lnd fields to the rof grid
-  !   merge the mapped lnd fields to create FBExp(comprof)
-  !   this will be done in med_phases_prep_rof_avg
+  !   - done in med_phases_prep_rof_accum
+  ! - time avergage accumulated import lnd fields on lnd grid when necessary and
+  !   then map the time averaged accumulated lnd fields to the rof grid
+  !   and then merge the mapped lnd fields to create FBExp(comprof)
+  !   - done in med_phases_prep_rof_avg
   !-----------------------------------------------------------------------------
 
   use med_kind_mod          , only : CX=>SHR_KIND_CX, CS=>SHR_KIND_CS, CL=>SHR_KIND_CL, R8=>SHR_KIND_R8
@@ -18,20 +18,19 @@ module med_phases_prep_rof_mod
   use med_constants_mod     , only : czero            => med_constants_czero
   use med_utils_mod         , only : chkerr           => med_utils_chkerr
   use med_methods_mod       , only : fldbun_getmesh   => med_methods_FB_getmesh
-  use med_methods_mod       , only : fldbun_getdata2d => med_methods_FB_getdata2d
   use med_methods_mod       , only : fldbun_getdata1d => med_methods_FB_getdata1d
   use med_methods_mod       , only : fldbun_diagnose  => med_methods_FB_diagnose
   use med_methods_mod       , only : fldbun_reset     => med_methods_FB_reset
   use med_methods_mod       , only : fldbun_average   => med_methods_FB_average
-  use med_methods_mod       , only : field_getdata2d  => med_methods_Field_getdata2d
   use med_methods_mod       , only : field_getdata1d  => med_methods_Field_getdata1d
   use perf_mod              , only : t_startf, t_stopf
 
   implicit none
   private
 
+  public  :: med_phases_prep_rof_init   ! called from med.F90
+  public  :: med_phases_prep_rof_accum  ! called by med_phases_post_lnd.F90
   public  :: med_phases_prep_rof        ! called by run sequence
-  public  :: med_phases_prep_rof_accum  ! called by med_phases_post_lnd
 
   private :: med_phases_prep_rof_irrig
 
@@ -49,12 +48,17 @@ module med_phases_prep_rof_mod
   character(len=*), parameter :: irrig_normalized_field = 'Flrl_irrig_normalized'
   character(len=*), parameter :: irrig_volr0_field      = 'Flrl_irrig_volr0     '
 
-  ! the following are the fields that will be accumulated from the land
-  character(CS) :: lnd2rof_flds(6) = (/'Flrl_rofsur','Flrl_rofgwl','Flrl_rofsub', &
-                                       'Flrl_rofdto','Flrl_rofi  ','Flrl_irrig '/)
+  ! the following are the fields that will be accumulated from the land and are derived from fldlistTo(comprof)
+  character(CS), allocatable :: lnd2rof_flds(:)
 
   integer :: maptype_lnd2rof
   integer :: maptype_rof2lnd
+
+  ! Accumulation to river field bundles - accumulation is done on the land mesh and then averaged and mapped to the
+  ! rof mesh
+  integer               , public :: lndAccum2rof_cnt
+  type(ESMF_FieldBundle), public :: FBlndAccum2rof_l
+  type(ESMF_FieldBundle), public :: FBlndAccum2rof_r
 
   character(*)    , parameter :: u_FILE_u = &
        __FILE__
@@ -63,6 +67,108 @@ module med_phases_prep_rof_mod
 contains
 !===============================================================================
 
+  subroutine med_phases_prep_rof_init(gcomp, rc)
+
+    !---------------------------------------
+    ! Create module field bundles FBlndAccum2rof_l and FBlndAccum2rof_r
+    ! land accumulation on both complnd and comprof meshes
+    !---------------------------------------
+
+    use ESMF        , only : ESMF_GridComp, ESMF_GridCompGet
+    use ESMF        , only : ESMF_Field, ESMF_FieldGet, ESMF_FieldCreate
+    use ESMF        , only : ESMF_Mesh, ESMF_MESHLOC_ELEMENT
+    use ESMF        , only : ESMF_FieldBundle, ESMF_FieldBundleCreate, ESMF_FieldBundleGet, ESMF_FieldBundleAdd
+    use ESMF        , only : ESMF_LogWrite, ESMF_LOGMSG_INFO, ESMF_SUCCESS
+    use ESMF        , only : ESMF_TYPEKIND_R8
+    use esmFlds     , only : fldListFr, fldlistTo, med_fldlist_GetNumFlds, med_fldlist_getFldInfo
+    use med_map_mod , only : med_map_packed_field_create
+
+    ! input/output variables
+    type(ESMF_GridComp)  :: gcomp
+    integer, intent(out) :: rc
+
+    ! local variables
+    type(InternalState) :: is_local
+    integer             :: n, n1, nflds
+    type(ESMF_Mesh)     :: mesh_l
+    type(ESMF_Mesh)     :: mesh_r
+    type(ESMF_Field)    :: lfield
+    character(len=CS), allocatable  :: fldnames_temp(:)
+    character(len=*),parameter  :: subname=' (med_phases_prep_rof_init) '
+    !---------------------------------------
+
+    rc = ESMF_SUCCESS
+
+    ! Get the internal state
+    nullify(is_local%wrap)
+    call ESMF_GridCompGetInternalState(gcomp, is_local, rc)
+    if (chkErr(rc,__LINE__,u_FILE_u)) return
+
+    ! Determine lnd2rof_flds (module variable) - note that fldListTo is set in esmFldsExchange_cesm.F90
+    ! Remove scalar field from lnd2rof_flds
+    nflds = med_fldlist_getnumflds(fldlistTo(comprof))
+    allocate(fldnames_temp(nflds))
+    do n = 1,nflds
+       call med_fldList_GetFldInfo(fldListTo(comprof), n, fldnames_temp(n))
+    end do
+    do n = 1,nflds
+       if (trim(fldnames_temp(n)) == trim(is_local%wrap%flds_scalar_name)) then
+          do n1 = n, nflds-1
+             fldnames_temp(n1) = fldnames_temp(n1+1)
+          enddo
+          nflds = nflds - 1
+       endif
+    enddo
+    allocate(lnd2rof_flds(nflds))
+    do n = 1,nflds
+       lnd2rof_flds(n) = trim(fldnames_temp(n))
+    end do
+    deallocate(fldnames_temp)
+
+    ! Get lnd and rof meshes
+    call fldbun_getmesh(is_local%wrap%FBImp(complnd,complnd), mesh_l, rc)
+    if (chkerr(rc,__LINE__,u_FILE_u)) return
+    call fldbun_getmesh(is_local%wrap%FBImp(complnd,comprof), mesh_r, rc)
+    if (chkerr(rc,__LINE__,u_FILE_u)) return
+
+    ! Create module field bundle FBlndAccum2rof_l on land mesh and  FBlndAccum2rof_r on rof mesh
+    FBlndAccum2rof_l = ESMF_FieldBundleCreate(name='FBlndAccum2rof_l', rc=rc)
+    if (chkerr(rc,__LINE__,u_FILE_u)) return
+    FBlndAccum2rof_r = ESMF_FieldBundleCreate(name='FBlndAccum2rof_r', rc=rc)
+    if (chkerr(rc,__LINE__,u_FILE_u)) return
+    do n = 1,size(lnd2rof_flds)
+       lfield = ESMF_FieldCreate(mesh_l, ESMF_TYPEKIND_R8, name=lnd2rof_flds(n), meshloc=ESMF_MESHLOC_ELEMENT, rc=rc)
+       if (chkerr(rc,__LINE__,u_FILE_u)) return
+       call ESMF_FieldBundleAdd(FBlndAccum2rof_l, (/lfield/), rc=rc)
+       if (chkerr(rc,__LINE__,u_FILE_u)) return
+       call ESMF_LogWrite(trim(subname)//' adding field '//trim(lnd2rof_flds(n))//' to FBLndAccum2rof_l', &
+            ESMF_LOGMSG_INFO)
+       lfield = ESMF_FieldCreate(mesh_r, ESMF_TYPEKIND_R8, name=lnd2rof_flds(n), meshloc=ESMF_MESHLOC_ELEMENT, rc=rc)
+       if (chkerr(rc,__LINE__,u_FILE_u)) return
+       call ESMF_FieldBundleAdd(FBlndAccum2rof_r, (/lfield/), rc=rc)
+       if (chkerr(rc,__LINE__,u_FILE_u)) return
+       call ESMF_LogWrite(trim(subname)//' adding field '//trim(lnd2rof_flds(n))//' to FBLndAccum2rof_r', &
+            ESMF_LOGMSG_INFO)
+    end do
+
+    ! Initialize field bundles and accumulation count
+    call fldbun_reset(FBlndAccum2rof_l, value=0.0_r8, rc=rc)
+    if (chkerr(rc,__LINE__,u_FILE_u)) return
+    call fldbun_reset(FBlndAccum2rof_r, value=0.0_r8, rc=rc)
+    if (chkerr(rc,__LINE__,u_FILE_u)) return
+    lndAccum2rof_cnt = 0
+
+    ! Create packed mapping from rof->lnd
+    call med_map_packed_field_create(destcomp=comprof, &
+         flds_scalar_name=is_local%wrap%flds_scalar_name, &
+         fldsSrc=fldListFr(complnd)%flds, &
+         FBSrc=FBLndAccum2rof_l, FBDst=FBLndAccum2rof_r, &
+         packed_data=is_local%wrap%packed_data(complnd,comprof,:), rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+
+  end subroutine med_phases_prep_rof_init
+
+  !===============================================================================
   subroutine med_phases_prep_rof_accum(gcomp, rc)
 
     !------------------------------------
@@ -80,7 +186,6 @@ contains
 
     ! input/output variables
     type(ESMF_GridComp)  :: gcomp
-
     integer, intent(out) :: rc
 
     ! local variables
@@ -90,14 +195,9 @@ contains
     integer                   :: ungriddedUBound(1)
     logical                   :: exists
     real(r8), pointer         :: dataptr1d(:) => null()
-    real(r8), pointer         :: dataptr2d(:,:) => null()
     real(r8), pointer         :: dataptr1d_accum(:) => null()
-    real(r8), pointer         :: dataptr2d_accum(:,:) => null()
     type(ESMF_Field)          :: lfield
     type(ESMF_Field)          :: lfield_accum
-    type(ESMF_Field), pointer :: fieldlist(:) => null()
-    type(ESMF_Field), pointer :: fieldlist_accum(:) => null()
-    character(CL), pointer    :: lfieldnamelist(:) => null()
     character(len=*), parameter :: subname='(med_phases_prep_rof_mod: med_phases_prep_rof_accum)'
     !---------------------------------------
 
@@ -119,36 +219,25 @@ contains
             isPresent=exists, rc=rc)
        if (chkerr(rc,__LINE__,u_FILE_u)) return
        if (exists) then
+          call ESMF_FieldBundleGet(FBlndAccum2rof_l, fieldName=trim(lnd2rof_flds(n)), &
+               field=lfield_accum, rc=rc)
+          if (chkerr(rc,__LINE__,u_FILE_u)) return
           call ESMF_FieldBundleGet(is_local%wrap%FBImp(complnd,complnd), fieldName=trim(lnd2rof_flds(n)), &
                field=lfield, rc=rc)
           if (chkerr(rc,__LINE__,u_FILE_u)) return
-          call ESMF_FieldBundleGet(is_local%wrap%FBImpaccum(complnd,complnd), fieldName=trim(lnd2rof_flds(n)), &
-               field=lfield_accum, rc=rc)
+          call field_getdata1d(lfield, dataptr1d, rc=rc)
           if (chkerr(rc,__LINE__,u_FILE_u)) return
-          call ESMF_FieldGet(lfield, ungriddedUBound=ungriddedUBound, rc=rc)
+          call field_getdata1d(lfield_accum, dataptr1d_accum, rc=rc)
           if (chkerr(rc,__LINE__,u_FILE_u)) return
-          if (ungriddedUBound(1) > 0) then
-             call field_getdata2d(lfield, dataptr2d, rc=rc)
-             if (chkerr(rc,__LINE__,u_FILE_u)) return
-             call field_getdata2d(lfield_accum, dataptr2d_accum, rc=rc)
-             if (chkerr(rc,__LINE__,u_FILE_u)) return
-             dataptr2d_accum(:,:) = dataptr2d_accum(:,:) + dataptr2d(:,:)
-          else
-             call field_getdata1d(lfield, dataptr1d, rc=rc)
-             if (chkerr(rc,__LINE__,u_FILE_u)) return
-             call field_getdata1d(lfield_accum, dataptr1d_accum, rc=rc)
-             if (chkerr(rc,__LINE__,u_FILE_u)) return
-             dataptr1d_accum(:) = dataptr1d_accum(:) + dataptr1d(:)
-          end if
+          dataptr1d_accum(:) = dataptr1d_accum(:) + dataptr1d(:)
        end if
     end do
 
     ! Accumulate counter
-    is_local%wrap%FBImpAccumCnt(complnd) = is_local%wrap%FBImpAccumCnt(complnd) + 1
+    lndAccum2rof_cnt =  lndAccum2rof_cnt + 1
 
     if (dbug_flag > 1) then
-       call fldbun_diagnose(is_local%wrap%FBImpAccum(complnd,complnd), &
-            string=trim(subname)//' FBImpAccum(complnd,complnd) ', rc=rc)
+       call fldbun_diagnose(FBlndAccum2rof_l, string=trim(subname)//' FBlndAccum2rof_l accum', rc=rc)
        if (chkerr(rc,__LINE__,u_FILE_u)) return
     end if
 
@@ -186,12 +275,11 @@ contains
     logical                   :: exists
     real(r8), pointer         :: dataptr(:) => null()
     real(r8), pointer         :: dataptr1d(:) => null()
-    real(r8), pointer         :: dataptr2d(:,:) => null()
     type(ESMF_Field)          :: field_irrig_flux
-    integer                   :: fieldcount
     type(ESMF_Field)          :: lfield
-    type(ESMF_Field), pointer :: fieldlist(:) => null()
-    integer                   :: ungriddedUBound(1)
+    type(ESMF_Field)          :: lfield_src
+    type(ESMF_Field)          :: lfield_dst
+    type(ESMF_Field)          :: field_lfrac_lnd
     character(CL), pointer    :: lfieldnamelist(:) => null()
     character(len=*),parameter  :: subname='(med_phases_prep_rof_mod: med_phases_prep_rof)'
     !---------------------------------------
@@ -214,7 +302,7 @@ contains
     ! Average import from land accumuled FB
     !---------------------------------------
 
-    count = is_local%wrap%FBImpAccumCnt(complnd)
+    count = lndAccum2rof_cnt
     if (count == 0) then
        if (mastertask) then
           write(logunit,'(a)')trim(subname)//'accumulation count for land input averging to river is 0 '// &
@@ -223,77 +311,57 @@ contains
     end if
 
     do n = 1,size(lnd2rof_flds)
-       call ESMF_FieldBundleGet(is_local%wrap%FBImpAccum(complnd,complnd), fieldName=trim(lnd2rof_flds(n)), &
-            isPresent=exists, rc=rc)
+       call ESMF_FieldBundleGet(FBlndAccum2rof_l, fieldName=trim(lnd2rof_flds(n)), isPresent=exists, rc=rc)
        if (chkerr(rc,__LINE__,u_FILE_u)) return
        if (exists) then
-          call ESMF_FieldBundleGet(is_local%wrap%FBImpAccum(complnd,complnd), fieldName=trim(lnd2rof_flds(n)), &
-               field=lfield, rc=rc)
+          call ESMF_FieldBundleGet(FBlndAccum2rof_l, fieldName=trim(lnd2rof_flds(n)), field=lfield, rc=rc)
           if (chkerr(rc,__LINE__,u_FILE_u)) return
-          call ESMF_FieldGet(lfield, ungriddedUBound=ungriddedUBound, rc=rc)
+          call field_getdata1d(lfield, dataptr1d, rc=rc)
           if (chkerr(rc,__LINE__,u_FILE_u)) return
-          if (ungriddedUBound(1) > 0) then
-             call field_getdata2d(lfield, dataptr2d, rc=rc)
-             if (chkerr(rc,__LINE__,u_FILE_u)) return
-             if (count == 0) then
-                dataptr2d(:,:) = czero
-             else
-                dataptr2d(:,:) = dataptr2d(:,:) / real(count, r8)
-             end if
+          if (count == 0) then
+             dataptr1d(:) = czero
           else
-             call field_getdata1d(lfield, dataptr1d, rc=rc)
-             if (chkerr(rc,__LINE__,u_FILE_u)) return
-             if (count == 0) then
-                dataptr1d(:) = czero
-             else
-                dataptr1d(:) = dataptr1d(:) / real(count, r8)
-             end if
+             dataptr1d(:) = dataptr1d(:) / real(count, r8)
           end if
        end if
     end do
 
     if (dbug_flag > 1) then
-       call fldbun_diagnose(is_local%wrap%FBImpAccum(complnd,complnd), &
-            string=trim(subname)//' FBImpAccum(complnd,complnd) after avg ', rc=rc)
+       call fldbun_diagnose(FBlndAccum2rof_l, string=trim(subname)//' FBlndAccum2rof_l after avg ', rc=rc)
        if (chkerr(rc,__LINE__,u_FILE_u)) return
     end if
 
     !---------------------------------------
-    ! Map to create FBImpAccum(complnd,comprof)
+    ! Map to create FBlndAccum2rof_r
     !---------------------------------------
 
     ! The following assumes that only land import fields are needed to create the
     ! export fields for the river component and that ALL mappings are done with mapconsf
 
-    if (is_local%wrap%med_coupling_active(complnd,comprof)) then
-       call med_map_field_packed( &
-            FBSrc=is_local%wrap%FBImpAccum(complnd,complnd), &
-            FBDst=is_local%wrap%FBImpAccum(complnd,comprof), &
-            FBFracSrc=is_local%wrap%FBFrac(complnd), &
-            field_normOne=is_local%wrap%field_normOne(complnd,comprof,:), &
-            packed_data=is_local%wrap%packed_data(complnd,comprof,:), &
-            routehandles=is_local%wrap%RH(complnd,comprof,:), rc=rc)
-       if (ChkErr(rc,__LINE__,u_FILE_u)) return
+    call med_map_field_packed( FBSrc=FBlndAccum2rof_l, FBDst=FBlndAccum2rof_r, &
+         FBFracSrc=is_local%wrap%FBFrac(complnd), &
+         field_normOne=is_local%wrap%field_normOne(complnd,comprof,:), &
+         packed_data=is_local%wrap%packed_data(complnd,comprof,:), &
+         routehandles=is_local%wrap%RH(complnd,comprof,:), rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
 
-       if (dbug_flag > 1) then
-          call fldbun_diagnose(is_local%wrap%FBImpAccum(complnd,comprof), &
-               string=trim(subname)//' FBImpAccum(complnd,comprof) after map ', rc=rc)
-          if (chkerr(rc,__LINE__,u_FILE_u)) return
-       end if
+    if (dbug_flag > 1) then
+       call fldbun_diagnose(FBlndAccum2rof_r, string=trim(subname)//' FBlndAccum2rof_r after map ', rc=rc)
+       if (chkerr(rc,__LINE__,u_FILE_u)) return
+    end if
 
-       ! Reset the irrig_flux_field with the map_lnd2rof_irrig calculation below if appropriate
-       if ( NUOPC_IsConnected(is_local%wrap%NStateImp(complnd), fieldname=trim(irrig_flux_field))) then
-          call med_phases_prep_rof_irrig( gcomp, rc=rc )
-          if (chkerr(rc,__LINE__,u_FILE_u)) return
-       else
-          ! This will ensure that no irrig is sent from the land
-          call fldbun_getdata1d(is_local%wrap%FBImpAccum(complnd,comprof), irrig_flux_field, dataptr, rc)
-          dataptr(:) = czero
-       end if
-    endif
+    ! Reset the irrig_flux_field with the map_lnd2rof_irrig calculation below if appropriate
+    if ( NUOPC_IsConnected(is_local%wrap%NStateImp(complnd), fieldname=trim(irrig_flux_field))) then
+       call med_phases_prep_rof_irrig( gcomp, rc=rc )
+       if (chkerr(rc,__LINE__,u_FILE_u)) return
+    else
+       ! This will ensure that no irrig is sent from the land
+       call fldbun_getdata1d(FBlndAccum2rof_r, irrig_flux_field, dataptr, rc)
+       dataptr(:) = czero
+    end if
 
     !---------------------------------------
-    ! auto merges to create FBExp(comprof)
+    ! auto merges to create FBExp(comprof) - assumes that all data is coming from FBlndAccum2rof_r
     !---------------------------------------
 
     if (dbug_flag > 1) then
@@ -302,12 +370,8 @@ contains
        if (chkerr(rc,__LINE__,u_FILE_u)) return
     end if
 
-    call med_merge_auto(&
-         is_local%wrap%med_coupling_active(:,comprof), &
-         is_local%wrap%FBExp(comprof), &
-         is_local%wrap%FBFrac(comprof), &
-         is_local%wrap%FBImpAccum(:,comprof), &
-         fldListTo(comprof), rc=rc)
+    call med_merge_auto(compsrc=complnd, FBout=is_local%wrap%FBExp(comprof), &
+         FBfrac=is_local%wrap%FBFrac(comprof), FBin=FBlndAccum2rof_r, fldListTo=fldListTo(comprof), rc=rc)
     if (chkerr(rc,__LINE__,u_FILE_u)) return
 
     if (dbug_flag > 1) then
@@ -321,28 +385,19 @@ contains
     !---------------------------------------
 
     ! zero counter
-    is_local%wrap%FBImpAccumCnt(complnd) = 0
+    lndAccum2rof_cnt = 0
 
-    ! zero lnd2rof fields in FBImpAccum
+    ! zero lnd2rof fields in FBlndAccum2rof_l
     do n = 1,size(lnd2rof_flds)
        call ESMF_FieldBundleGet(is_local%wrap%FBImp(complnd,complnd), fieldName=trim(lnd2rof_flds(n)), &
             isPresent=exists, rc=rc)
        if (chkerr(rc,__LINE__,u_FILE_u)) return
        if (exists) then
-          call ESMF_FieldBundleGet(is_local%wrap%FBImpaccum(complnd,complnd), fieldName=trim(lnd2rof_flds(n)), &
-               field=lfield, rc=rc)
+          call ESMF_FieldBundleGet(FBlndAccum2rof_l, fieldName=trim(lnd2rof_flds(n)), field=lfield, rc=rc)
           if (chkerr(rc,__LINE__,u_FILE_u)) return
-          call ESMF_FieldGet(lfield, ungriddedUBound=ungriddedUBound, rc=rc)
+          call field_getdata1d(lfield, dataptr1d, rc=rc)
           if (chkerr(rc,__LINE__,u_FILE_u)) return
-          if (ungriddedUBound(1) > 0) then
-             call field_getdata2d(lfield, dataptr2d, rc=rc)
-             if (chkerr(rc,__LINE__,u_FILE_u)) return
-             dataptr2d(:,:) = czero
-          else
-             call field_getdata1d(lfield, dataptr1d, rc=rc)
-             if (chkerr(rc,__LINE__,u_FILE_u)) return
-             dataptr1d(:) = czero
-          end if
+          dataptr1d(:) = czero
        end if
     end do
 
@@ -396,8 +451,6 @@ contains
     type(ESMF_Field)          :: field_import_lnd
     type(ESMF_Field)          :: field_irrig_flux
     type(ESMF_Field)          :: field_lfrac_lnd
-    type(ESMF_Field), pointer :: fieldlist_lnd(:) => null()
-    type(ESMF_Field), pointer :: fieldlist_rof(:) => null()
     type(ESMF_Mesh)           :: lmesh_lnd
     type(ESMF_Mesh)           :: lmesh_rof
     real(r8), pointer         :: volr_l(:) => null()
@@ -539,7 +592,7 @@ contains
     ! flux on the rof grid.
 
     ! First extract accumulated irrigation flux from land
-    call fldbun_getdata1d(is_local%wrap%FBImpAccum(complnd,complnd), trim(irrig_flux_field), irrig_flux_l, rc)
+    call fldbun_getdata1d(FBlndAccum2rof_l, trim(irrig_flux_field), irrig_flux_l, rc)
     if (chkerr(rc,__LINE__,u_FILE_u)) return
 
     ! Fill in values for irrig_normalized_l and irrig_volr0_l
@@ -584,12 +637,12 @@ contains
          field_normdst=field_lfrac_rof, rc=rc)
     if (chkerr(rc,__LINE__,u_FILE_u)) return
 
-    ! Convert to a total irrigation flux on the ROF grid, and put this in the pre-merge FBImpAccum(complnd,comprof)
+    ! Convert to a total irrigation flux on the ROF grid, and put this in the pre-merge FBlndAccum2rof_r
     call field_getdata1d(field_rofIrrig, irrig_normalized_r, rc=rc)
     if (chkerr(rc,__LINE__,u_FILE_u)) return
     call field_getdata1d(field_rofIrrig0, irrig_volr0_r, rc=rc)
     if (chkerr(rc,__LINE__,u_FILE_u)) return
-    call fldbun_getdata1d(is_local%wrap%FBImpAccum(complnd,comprof), trim(irrig_flux_field), irrig_flux_r, rc)
+    call fldbun_getdata1d(FBlndAccum2rof_r, trim(irrig_flux_field), irrig_flux_r, rc)
     if (chkerr(rc,__LINE__,u_FILE_u)) return
     call field_getdata1d(field_rofIrrig0, irrig_volr0_r, rc)
     if (chkerr(rc,__LINE__,u_FILE_u)) return

--- a/mediator/med_phases_prep_wav_mod.F90
+++ b/mediator/med_phases_prep_wav_mod.F90
@@ -80,7 +80,7 @@ contains
        end do
 
        ! auto merges to create FBExp(compwav)
-       call med_merge_auto(compwav, &
+       call med_merge_auto(&
             is_local%wrap%med_coupling_active(:,compwav), &
             is_local%wrap%FBExp(compwav), &
             is_local%wrap%FBFrac(compwav), &

--- a/mediator/med_phases_restart_mod.F90
+++ b/mediator/med_phases_restart_mod.F90
@@ -4,16 +4,16 @@ module med_phases_restart_mod
   ! Write/Read mediator restart files
   !-----------------------------------------------------------------------------
 
-  use med_kind_mod          , only : CX=>SHR_KIND_CX, CS=>SHR_KIND_CS, CL=>SHR_KIND_CL, R8=>SHR_KIND_R8
-  use med_constants_mod     , only : dbug_flag => med_constants_dbug_flag
-  use med_constants_mod     , only : SecPerDay => med_constants_SecPerDay
-  use med_utils_mod         , only : chkerr    => med_utils_ChkErr
-  use med_internalstate_mod , only : mastertask, logunit, InternalState
-  use med_time_mod          , only : med_time_AlarmInit
-  use esmFlds               , only : ncomps, compname, compocn, complnd
-  use perf_mod              , only : t_startf, t_stopf
-  use med_phases_prep_glc_mod, only : FBlndAccum2glc_l, lndAccum2glc_cnt
-  use med_phases_prep_glc_mod, only : FBocnAccum2glc_o, ocnAccum2glc_cnt
+  use med_kind_mod            , only : CX=>SHR_KIND_CX, CS=>SHR_KIND_CS, CL=>SHR_KIND_CL, R8=>SHR_KIND_R8
+  use med_constants_mod       , only : dbug_flag => med_constants_dbug_flag
+  use med_constants_mod       , only : SecPerDay => med_constants_SecPerDay
+  use med_utils_mod           , only : chkerr    => med_utils_ChkErr
+  use med_internalstate_mod   , only : mastertask, logunit, InternalState
+  use med_time_mod            , only : med_time_AlarmInit
+  use esmFlds                 , only : ncomps, compname, compocn, complnd
+  use perf_mod                , only : t_startf, t_stopf
+  use med_phases_prep_glc_mod , only : FBlndAccum2glc_l, lndAccum2glc_cnt
+  use med_phases_prep_glc_mod , only : FBocnAccum2glc_o, ocnAccum2glc_cnt
 
   implicit none
   private
@@ -388,10 +388,6 @@ contains
           call med_io_write(restart_file, iam, next_tod , 'curr_tod' , whead=whead, wdata=wdata, rc=rc)
           if (ChkErr(rc,__LINE__,u_FILE_u)) return
 
-          call med_io_write(restart_file, iam, is_local%wrap%FBExpAccumCnt, 'ExpAccumCnt', &
-               whead=whead, wdata=wdata, rc=rc)
-          if (ChkErr(rc,__LINE__,u_FILE_u)) return
-
           do n = 1,ncomps
              if (is_local%wrap%comp_present(n)) then
                 nx = is_local%wrap%nx(n)
@@ -418,17 +414,22 @@ contains
                    if (ChkErr(rc,__LINE__,u_FILE_u)) return
                 endif
 
-                ! Write export field bundle accumulators
-                ! TODO: only write this out if actually have done accumulation
-                if (ESMF_FieldBundleIsCreated(is_local%wrap%FBExpAccum(n),rc=rc)) then
-                   call med_io_write(restart_file, iam,  is_local%wrap%FBExpAccum(n), &
-                       nx=nx, ny=ny, nt=1, whead=whead, wdata=wdata, pre=trim(compname(n))//'ExpAccum', rc=rc)
-                   if (ChkErr(rc,__LINE__,u_FILE_u)) return
-                endif
              endif
           enddo
 
-          ! Write write accumulation from lnd to glc if lnd->glc coupling is on
+          ! Write export accumulation to ocn
+          if (ESMF_FieldBundleIsCreated(is_local%wrap%FBExpAccumOcn)) then
+             nx = is_local%wrap%nx(compocn)
+             ny = is_local%wrap%ny(compocn)
+             call med_io_write(restart_file, iam,  is_local%wrap%FBExpAccumOcn, &
+                  nx=nx, ny=ny, nt=1, whead=whead, wdata=wdata, pre='ocnExpAccum', rc=rc)
+             if (ChkErr(rc,__LINE__,u_FILE_u)) return
+             call med_io_write(restart_file, iam, is_local%wrap%ExpAccumOcnCnt, 'ocnExpAccum_cnt', &
+                  whead=whead, wdata=wdata, rc=rc)
+             if (ChkErr(rc,__LINE__,u_FILE_u)) return
+          endif
+
+          ! Write accumulation from lnd to glc if lnd->glc coupling is on
           if (ESMF_FieldBundleIsCreated(FBlndAccum2glc_l)) then
              nx = is_local%wrap%nx(complnd)
              ny = is_local%wrap%ny(complnd)
@@ -440,7 +441,7 @@ contains
              if (ChkErr(rc,__LINE__,u_FILE_u)) return
           end if
 
-          ! Write write accumulation from ocn to glc if ocn->glc coupling is on
+          ! Write accumulation from ocn to glc if ocn->glc coupling is on
           if (ESMF_FieldBundleIsCreated(FBocnAccum2glc_o)) then
              nx = is_local%wrap%nx(compocn)
              ny = is_local%wrap%ny(compocn)
@@ -594,9 +595,6 @@ contains
 
     ! Now read in the restart file
 
-    call med_io_read(restart_file, vm, iam, is_local%wrap%FBExpAccumCnt, 'ExpAccumCnt', rc=rc)
-    if (ChkErr(rc,__LINE__,u_FILE_u)) return
-
     do n = 1,ncomps
        if (is_local%wrap%comp_present(n)) then
           ! Read import field bundle
@@ -617,13 +615,16 @@ contains
              if (ChkErr(rc,__LINE__,u_FILE_u)) return
           endif
 
-          ! Read export field bundle accumulator
-          if (ESMF_FieldBundleIsCreated(is_local%wrap%FBExpAccum(n),rc=rc)) then
-             call med_io_read(restart_file, vm, iam, is_local%wrap%FBExpAccum(n), pre=trim(compname(n))//'ExpAccum', rc=rc)
-             if (ChkErr(rc,__LINE__,u_FILE_u)) return
-          endif
        endif
     enddo
+
+    ! Read export field bundle accumulator
+    if (ESMF_FieldBundleIsCreated(is_local%wrap%FBExpAccumOcn,rc=rc)) then
+       call med_io_read(restart_file, vm, iam, is_local%wrap%FBExpAccumOcn, pre='ocnExpAccum', rc=rc)
+       if (ChkErr(rc,__LINE__,u_FILE_u)) return
+       call med_io_read(restart_file, vm, iam, is_local%wrap%ExpAccumOcnCnt, 'ocnExpAccum_cnt', rc=rc)
+       if (ChkErr(rc,__LINE__,u_FILE_u)) return
+    endif
 
     ! If lnd->glc, read accumulation from lnd to glc (CESM only)
     if (ESMF_FieldBundleIsCreated(FBlndAccum2glc_l)) then

--- a/mediator/med_phases_restart_mod.F90
+++ b/mediator/med_phases_restart_mod.F90
@@ -391,9 +391,6 @@ contains
           call med_io_write(restart_file, iam, is_local%wrap%FBExpAccumCnt, 'ExpAccumCnt', &
                whead=whead, wdata=wdata, rc=rc)
           if (ChkErr(rc,__LINE__,u_FILE_u)) return
-          call med_io_write(restart_file, iam, is_local%wrap%FBImpAccumCnt, 'ImpAccumCnt', &
-               whead=whead, wdata=wdata, rc=rc)
-          if (ChkErr(rc,__LINE__,u_FILE_u)) return
 
           do n = 1,ncomps
              if (is_local%wrap%comp_present(n)) then
@@ -426,14 +423,6 @@ contains
                 if (ESMF_FieldBundleIsCreated(is_local%wrap%FBExpAccum(n),rc=rc)) then
                    call med_io_write(restart_file, iam,  is_local%wrap%FBExpAccum(n), &
                        nx=nx, ny=ny, nt=1, whead=whead, wdata=wdata, pre=trim(compname(n))//'ExpAccum', rc=rc)
-                   if (ChkErr(rc,__LINE__,u_FILE_u)) return
-                endif
-
-                ! Write import field bundle accumulators
-                ! TODO: only write this out if actually have done accumulation
-                if (ESMF_FieldBundleIsCreated(is_local%wrap%FBImpAccum(n,n),rc=rc)) then
-                   call med_io_write(restart_file, iam,  is_local%wrap%FBImpAccum(n,n), &
-                       nx=nx, ny=ny, nt=1, whead=whead, wdata=wdata, pre=trim(compname(n))//'ImpAccum', rc=rc)
                    if (ChkErr(rc,__LINE__,u_FILE_u)) return
                 endif
              endif
@@ -607,8 +596,6 @@ contains
 
     call med_io_read(restart_file, vm, iam, is_local%wrap%FBExpAccumCnt, 'ExpAccumCnt', rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
-    call med_io_read(restart_file, vm, iam, is_local%wrap%FBImpAccumCnt, 'ImpAccumCnt', rc=rc)
-    if (ChkErr(rc,__LINE__,u_FILE_u)) return
 
     do n = 1,ncomps
        if (is_local%wrap%comp_present(n)) then
@@ -633,12 +620,6 @@ contains
           ! Read export field bundle accumulator
           if (ESMF_FieldBundleIsCreated(is_local%wrap%FBExpAccum(n),rc=rc)) then
              call med_io_read(restart_file, vm, iam, is_local%wrap%FBExpAccum(n), pre=trim(compname(n))//'ExpAccum', rc=rc)
-             if (ChkErr(rc,__LINE__,u_FILE_u)) return
-          endif
-
-          ! Read import field bundle accumulator
-          if (ESMF_FieldBundleIsCreated(is_local%wrap%FBImpAccum(n,n),rc=rc)) then
-             call med_io_read(restart_file, vm, iam, is_local%wrap%FBImpAccum(n,n), pre=trim(compname(n))//'ImpAccum', rc=rc)
              if (ChkErr(rc,__LINE__,u_FILE_u)) return
           endif
        endif


### PR DESCRIPTION
### Description of changes
refactor accum field bundles and cleanup of mediator phase InitializeIPDv03p4

### Specific notes
This PR does several things.

1. The accumulated import field bundles are no longer arrays and have been removed from `med_internalstate_mod.F90`. All import accumulator field bundles are now module variables in  `med_phases_prep_rof_mod.F90` and `med_phases_prep_glc_mod.F90`. In both of these cases accumulation is done using the import field bundle on the import grid and the averaged, mapped and merged to the export field bundle. 
2. The accumulated export field bundles is no longer an array and only refers to ocean export accumulation. This field bundle now appears in the following section in `med_internalstate_mod.F90`.
```.F90
! Accumulators for export field bundles
    type(ESMF_FieldBundle) :: FBExpAccumOcn      ! Accumulator for various components export on their grid
    integer                :: ExpAccumOcnCnt = 0 ! Accumulator counter for each FBExpAccum
```
3. The mediator subroutine `InitializeIPDv03p4` in `med.F90` serves to optionally modify the decomp/distr of transferred Grid/Mesh. In particular, the transfer of the grid was extremely difficult to follow. The cleanup in this PR makes it much clearer to see what is happening when a grid is transferred to the mediator and needs a new distgrid created for the mediator PEs.

Contributors other than yourself, if any: None

CMEPS Issues Fixed: None

Are changes expected to change answers?
 - [x] bit for bit
 - [ ] different at roundoff level
 - [ ] more substantial

Any User Interface Changes (namelist or namelist defaults changes)?
 - [ ] Yes
 - [x] No

Testing performed if application target is CESM:(either UFS-S2S or CESM testing is required):
- [ ] (recommended) CIME_DRIVER=nuopc scripts_regression_tests.py
   - machines:
   - details (e.g. failed tests):
- [x] (recommended) CESM testlist_drv.xml
   - machines and compilers: cheyenne/intel
   - details (e.g. failed tests): compared to cmeps0.13.25 baseline and generated cmeps0.13.26 baseline
- [ ] (optional) CESM prealpha test
   - machines and compilers
   - details (e.g. failed tests):
- [ ] (other) please described in detail
   - machines and compilers
   - details (e.g. failed tests):

Testing performed if application target is UFS-coupled:
- [ ] (recommended) UFS-coupled testing
   - description:
   - details (e.g. failed tests):

Testing performed if application target is UFS-HAFS:
- [ ] (recommended) UFS-HAFS testing
   - description:
   - details (e.g. failed tests):

Hashes used for testing:
- [x] CESM:
  - repository to check out: https://github.com/ESCOMP/CESM.git
  - tag:  cesm2_3_alpha05b with the following changes:
     [cice6] cesm_cice6_2_0_5
     [cdeps] cdeps0.12.17
     [cime]  cime6.0.5
     [cism]  cismwrap_2_1_87
- [ ] UFS-coupled, then umbrella repostiory to check out and associated hash:
  - repository to check out:
  - branch:
  - hash:
- [ ] UFS-HAFS, then umbrella repostiory to check out and associated hash:
  - repository to check out:
  - branch:
  - hash:
