### PR TITLE
only one shared modelio namelist per component

### DIFF
--- a/cime_config/buildexe
+++ b/cime_config/buildexe
@@ -84,7 +84,7 @@ def _main_func():
     if not os.path.isdir(bld_root):
         os.makedirs(bld_root)
 
-    with open(os.path.join(bld_root,'Filepath'), 'w') as out:
+    with open(os.path.join(bld_root,'Filepath'), 'w', encoding="utf-8") as out:
         cmeps_dir = os.path.join(os.path.dirname(__file__), os.pardir)
         # SourceMods dir needs to be first listed
         out.write(os.path.join(caseroot, "SourceMods", "src.drv") + "\n")

--- a/cime_config/buildnml
+++ b/cime_config/buildnml
@@ -488,11 +488,12 @@ def _create_component_modelio_namelists(confdir, case, files):
                 for entry in entries:
                     nmlgen.add_default(entry)
 
-                if model == "cpl":
-                    modelio_file = "med_modelio.nml" + inst_string
-                else:
-                    modelio_file = model + "_modelio.nml" + inst_string
-                nmlgen.write_nuopc_modelio_file(os.path.join(confdir, modelio_file))
+                if inst_index == 1:
+                    if model == "cpl":      
+                        modelio_file = "med_modelio.nml"
+                    else:
+                        modelio_file = model + "_modelio.nml"
+                    nmlgen.write_nuopc_modelio_file(os.path.join(confdir, modelio_file))
 
                 # Output the following to nuopc.runconfig
                 moddiro = case.get_value('RUNDIR')

--- a/cime_config/buildnml
+++ b/cime_config/buildnml
@@ -301,7 +301,7 @@ def _create_drv_namelists(case, infile, confdir, nmlgen, files):
     #--------------------------------
 
     # Read nuopc.runconfig
-    with open(nuopc_config_file, 'r') as f:
+    with open(nuopc_config_file, 'r', encoding="utf-8") as f:
         lines_cpl = f.readlines()
 
     # Look for only active components except CPL
@@ -313,7 +313,7 @@ def _create_drv_namelists(case, infile, confdir, nmlgen, files):
             comp_config_file = os.path.join(caseroot,"Buildconf","{}conf".format(case.get_value("COMP_{}".format(comp))),
                                             "{}.configure".format(case.get_value("COMP_{}".format(comp))))
             if os.path.isfile(comp_config_file):
-                with open(comp_config_file, 'r') as f:
+                with open(comp_config_file, 'r', encoding="utf-8") as f:
                     lines_comp = f.readlines()
 
             if lines_comp:
@@ -331,7 +331,7 @@ def _create_drv_namelists(case, infile, confdir, nmlgen, files):
                             lines_cpl_new.append(line_comp)
 
                 # Write to a file
-                with open(nuopc_config_file, 'w') as f:
+                with open(nuopc_config_file, 'w', encoding="utf-8") as f:
                     for line in lines_cpl_new:
                         f.write(line)
 
@@ -363,7 +363,7 @@ def _create_drv_namelists(case, infile, confdir, nmlgen, files):
         dicts = {}
         for infile in infiles:
             dict_ = {}
-            with open(infile) as myfile:
+            with open(infile, "r", encoding="utf-8") as myfile:
                 for line in myfile:
                     if "=" in line and '!' not in line:
                         name, var = line.partition("=")[::2]
@@ -405,7 +405,7 @@ def _create_runseq(case, coupling_times, valid_comps):
         if len(valid_comps) == 1:
 
             # Create run sequence with no mediator
-            outfile = open(os.path.join(caseroot, "CaseDocs", "nuopc.runseq"), "w")
+            outfile = open(os.path.join(caseroot, "CaseDocs", "nuopc.runseq"), "w", encoding="utf-8")
             dtime = coupling_times[valid_comps[0].lower() + '_cpl_dt']
             outfile.write ("runSeq:: \n")
             outfile.write ("@" + str(dtime) + " \n")
@@ -502,7 +502,7 @@ def _create_component_modelio_namelists(confdir, case, files):
                 else:
                     logfile = model + inst_string + ".log." + str(lid)
 
-                with open(nuopc_config_file, 'a') as outfile:
+                with open(nuopc_config_file, 'a', encoding="utf-8") as outfile:
                     if model == 'cpl':
                         name = "MED"
                     else:
@@ -540,7 +540,7 @@ def buildnml(case, caseroot, component):
     esmf_aware_threading = case.get_value("ESMF_AWARE_THREADING")
     esmfmkfile = os.getenv("ESMFMKFILE")
     expect(esmfmkfile and os.path.isfile(esmfmkfile),"ESMFMKFILE not found {}".format(esmfmkfile))
-    with open(esmfmkfile, 'r') as f:
+    with open(esmfmkfile, 'r', encoding="utf-8") as f:
         major = None
         minor = None
         for line in f.readlines():

--- a/cime_config/runseq/gen_runseq.py
+++ b/cime_config/runseq/gen_runseq.py
@@ -7,7 +7,7 @@ class RunSeq:
         self.__outfile = None
 
     def __enter__(self):
-        self.__outfile = open(self.__outfile_name, "w")
+        self.__outfile = open(self.__outfile_name, "w", encoding="utf-8")
         self.__outfile.write("runSeq:: \n")
         return self
 


### PR DESCRIPTION
### Description of changes
We were generating a modelio namelist per component instance for cmeps but then only looking for one per component in the fortran.  There really isn't any compelling reason to have one of these per instance, so I have changed the generator to only produce one per component.   This resolves the poor performance of multi instance IO in nuopc.    

### Specific notes

Contributors other than yourself, if any:

CMEPS Issues Fixed (include github issue #):

Are changes expected to change answers?
 - [X] bit for bit
 - [ ] different at roundoff level
 - [ ] more substantial

Any User Interface Changes (namelist or namelist defaults changes)?
 - [ ] Yes
 - [X] No

Testing performed if application target is CESM:(either UFS-S2S or CESM testing is required):
- [ ] (recommended) CIME_DRIVER=nuopc scripts_regression_tests.py
   - machines:
   - details (e.g. failed tests):
- [ ] (recommended) CESM testlist_drv.xml
   - machines and compilers:
   - details (e.g. failed tests):
- [ ] (optional) CESM prealpha test
   - machines and compilers
   - details (e.g. failed tests):
- [ ] (other) please described in detail
   - machines and compilers
   - details (e.g. failed tests):

Testing performed if application target is UFS-coupled:
- [ ] (recommended) UFS-coupled testing
   - description:
   - details (e.g. failed tests):

Testing performed if application target is UFS-HAFS:
- [ ] (recommended) UFS-HAFS testing
   - description:
   - details (e.g. failed tests):

Hashes used for testing:
- [ ] CESM:
  - repository to check out: https://github.com/ESCOMP/CESM.git
  - branch:
  - hash:
- [ ] UFS-coupled, then umbrella repostiory to check out and associated hash:
  - repository to check out:
  - branch:
  - hash:
- [ ] UFS-HAFS, then umbrella repostiory to check out and associated hash:
  - repository to check out:
  - branch:
  - hash:
