### PR TITLE
add flag for check_input_data

### DIFF
--- a/cime_config/namelist_definition_drv.xml
+++ b/cime_config/namelist_definition_drv.xml
@@ -1029,6 +1029,7 @@
   <entry id="mesh_mask" modify_via_xml="MASK_MESH">
     <type>char</type>
     <category>mapping</category>
+    <input_pathname>abs</input_pathname>
     <group>ALLCOMP_attributes</group>
     <desc>
       MESH for model mask (used to create masks and fractions at run time if different than model mesh)
@@ -1042,6 +1043,7 @@
   <entry id="mesh_atm" modify_via_xml="ATM_DOMAIN_MESH">
     <type>char</type>
     <category>mapping</category>
+    <input_pathname>abs</input_pathname>
     <group>ATM_attributes</group>
     <desc>
       MESH description of atm grid
@@ -1055,6 +1057,7 @@
   <entry id="mesh_lnd" modify_via_xml="LND_DOMAIN_MESH">
     <type>char</type>
     <category>mapping</category>
+    <input_pathname>abs</input_pathname>
     <group>LND_attributes</group>
     <desc>
       MESH description of lnd grid
@@ -1068,6 +1071,7 @@
   <entry id="mesh_ocn" modify_via_xml="OCN_DOMAIN_MESH">
     <type>char</type>
     <category>mapping</category>
+    <input_pathname>abs</input_pathname>
     <group>OCN_attributes</group>
     <desc>
       MESH description of ocn grid
@@ -1081,6 +1085,7 @@
   <entry id="mesh_ice" modify_via_xml="ICE_DOMAIN_MESH">
     <type>char</type>
     <category>mapping</category>
+    <input_pathname>abs</input_pathname>
     <group>ICE_attributes</group>
     <desc>
       MESH description of ice grid
@@ -1094,6 +1099,7 @@
   <entry id="mesh_rof" modify_via_xml="ROF_DOMAIN_MESH">
     <type>char</type>
     <category>mapping</category>
+    <input_pathname>abs</input_pathname>
     <group>ROF_attributes</group>
     <desc>
       MESH description of rof grid
@@ -1107,6 +1113,7 @@
   <entry id="mesh_glc" modify_via_xml="GLC_DOMAIN_MESH">
     <type>char</type>
     <category>mapping</category>
+    <input_pathname>abs</input_pathname>
     <group>GLC_attributes</group>
     <desc>
       MESH description of glc grid
@@ -1120,6 +1127,7 @@
   <entry id="mesh_wav" modify_via_xml="WAV_DOMAIN_MESH">
     <type>char</type>
     <category>mapping</category>
+    <input_pathname>abs</input_pathname>
     <group>WAV_attributes</group>
     <desc>
       MESH description of wav grid


### PR DESCRIPTION
### Description of changes
check_input_data needs this flag to properly download mesh files. 

### Specific notes
Change was tested by running the aux_cmeps test suite with flag  --input-dir /glade/scratch/jedwards/inputdata/  to force a new download of inputdata. 

Contributors other than yourself, if any:

CMEPS Issues : Fixes #196 

Are changes expected to change answers?
 - [X] bit for bit
 - [ ] different at roundoff level
 - [ ] more substantial

Any User Interface Changes (namelist or namelist defaults changes)?
 - [ ] Yes
 - [X] No

Testing performed if application target is CESM:(either UFS-S2S or CESM testing is required):
- [ ] (recommended) CIME_DRIVER=nuopc scripts_regression_tests.py
   - machines:
   - details (e.g. failed tests):
- [ ] (recommended) CESM testlist_drv.xml
   - machines and compilers:
   - details (e.g. failed tests):
- [ ] (optional) CESM prealpha test
   - machines and compilers
   - details (e.g. failed tests):
- [ ] (other) please described in detail
   - machines and compilers
   - details (e.g. failed tests):

Testing performed if application target is UFS-coupled:
- [ ] (recommended) UFS-coupled testing
   - description:
   - details (e.g. failed tests):

Testing performed if application target is UFS-HAFS:
- [ ] (recommended) UFS-HAFS testing
   - description:
   - details (e.g. failed tests):

Hashes used for testing:
- [ ] CESM:
  - repository to check out: https://github.com/ESCOMP/CESM.git
  - branch:
  - hash:
- [ ] UFS-coupled, then umbrella repostiory to check out and associated hash:
  - repository to check out:
  - branch:
  - hash:
- [ ] UFS-HAFS, then umbrella repostiory to check out and associated hash:
  - repository to check out:
  - branch:
  - hash:
