### PR TITLE
Mapping and Pole method changes for WW3DEV->MOM6 coupling

### DIFF
--- a/mediator/esmFldsExchange_cesm_mod.F90
+++ b/mediator/esmFldsExchange_cesm_mod.F90
@@ -77,7 +77,7 @@ contains
     use esmflds               , only : compmed, compatm, complnd, compocn
     use esmflds               , only : compice, comprof, compwav, ncomps
     use esmflds               , only : compglc, num_icesheets, ocn2glc_coupling ! compglc is an array of integers
-    use esmflds               , only : mapbilnr, mapconsf, mapconsd, mappatch, mappatch_uv3d
+    use esmflds               , only : mapbilnr, mapconsf, mapconsd, mappatch, mappatch_uv3d, mapbilnr_nstod
     use esmflds               , only : mapfcopy, mapnstod, mapnstod_consd, mapnstod_consf
     use esmflds               , only : map_glc2ocn_ice, map_glc2ocn_liq, map_rof2ocn_ice, map_rof2ocn_liq
     use esmflds               , only : fldListTo, fldListFr, fldListMed_aoflux, fldListMed_ocnalb
@@ -2228,7 +2228,7 @@ contains
     else
        if ( fldchk(is_local%wrap%FBExp(compocn)         , 'Sw_lamult', rc=rc) .and. &
             fldchk(is_local%wrap%FBImp(compwav, compwav), 'Sw_lamult', rc=rc)) then
-          call addmap(fldListFr(compwav)%flds, 'Sw_lamult', compocn,  mapbilnr, 'one', wav2ocn_smap)
+          call addmap(fldListFr(compwav)%flds, 'Sw_lamult', compocn,  mapbilnr_nstod, 'one', wav2ocn_smap)
           call addmrg(fldListTo(compocn)%flds, 'Sw_lamult', mrg_from=compwav, mrg_fld='Sw_lamult', mrg_type='copy')
        end if
     end if
@@ -2241,7 +2241,7 @@ contains
     else
        if ( fldchk(is_local%wrap%FBExp(compocn)         , 'Sw_ustokes', rc=rc) .and. &
             fldchk(is_local%wrap%FBImp(compwav, compwav), 'Sw_ustokes', rc=rc)) then
-          call addmap(fldListFr(compwav)%flds, 'Sw_ustokes', compocn,  mapbilnr, 'one', wav2ocn_smap)
+          call addmap(fldListFr(compwav)%flds, 'Sw_ustokes', compocn,  mapbilnr_nstod, 'one', wav2ocn_smap)
           call addmrg(fldListTo(compocn)%flds, 'Sw_ustokes', mrg_from=compwav, mrg_fld='Sw_ustokes', mrg_type='copy')
        end if
     end if
@@ -2254,7 +2254,7 @@ contains
     else
        if ( fldchk(is_local%wrap%FBExp(compocn)         , 'Sw_vstokes', rc=rc) .and. &
             fldchk(is_local%wrap%FBImp(compwav, compwav), 'Sw_vstokes', rc=rc)) then
-          call addmap(fldListFr(compwav)%flds, 'Sw_vstokes', compocn,  mapbilnr, 'one', wav2ocn_smap)
+          call addmap(fldListFr(compwav)%flds, 'Sw_vstokes', compocn,  mapbilnr_nstod, 'one', wav2ocn_smap)
           call addmrg(fldListTo(compocn)%flds, 'Sw_vstokes', mrg_from=compwav, mrg_fld='Sw_vstokes', mrg_type='copy')
        end if
     end if
@@ -2267,8 +2267,34 @@ contains
     else
        if ( fldchk(is_local%wrap%FBExp(compocn)         , 'Sw_hstokes', rc=rc) .and. &
             fldchk(is_local%wrap%FBImp(compwav, compwav), 'Sw_hstokes', rc=rc)) then
-          call addmap(fldListFr(compwav)%flds, 'Sw_hstokes', compocn,  mapbilnr, 'one', wav2ocn_smap)
+          call addmap(fldListFr(compwav)%flds, 'Sw_hstokes', compocn,  mapbilnr_nstod, 'one', wav2ocn_smap)
           call addmrg(fldListTo(compocn)%flds, 'Sw_hstokes', mrg_from=compwav, mrg_fld='Sw_hstokes', mrg_type='copy')
+       end if
+    end if
+    !-----------------------------
+    ! to ocn: Partitioned stokes drift components in x-direction
+    !-----------------------------
+    if (phase == 'advertise') then
+       call addfld(fldListFr(compwav)%flds, 'Sw_pstokes_x')
+       call addfld(fldListTo(compocn)%flds, 'Sw_pstokes_x')
+    else
+       if ( fldchk(is_local%wrap%FBExp(compocn)         , 'Sw_pstokes_x', rc=rc) .and. &
+            fldchk(is_local%wrap%FBImp(compwav, compwav), 'Sw_pstokes_x', rc=rc)) then
+          call addmap(fldListFr(compwav)%flds, 'Sw_pstokes_x', compocn,  mapbilnr_nstod, 'one', wav2ocn_smap)
+          call addmrg(fldListTo(compocn)%flds, 'Sw_pstokes_x', mrg_from=compwav, mrg_fld='Sw_pstokes_x', mrg_type='copy')
+       end if
+    end if
+    !-----------------------------
+    ! to ocn: Stokes drift depth from wave
+    !-----------------------------
+    if (phase == 'advertise') then
+       call addfld(fldListFr(compwav)%flds, 'Sw_pstokes_y')
+       call addfld(fldListTo(compocn)%flds, 'Sw_pstokes_y')
+    else
+       if ( fldchk(is_local%wrap%FBExp(compocn)         , 'Sw_pstokes_y', rc=rc) .and. &
+            fldchk(is_local%wrap%FBImp(compwav, compwav), 'Sw_pstokes_y', rc=rc)) then
+          call addmap(fldListFr(compwav)%flds, 'Sw_pstokes_y', compocn,  mapbilnr_nstod, 'one', wav2ocn_smap)
+          call addmrg(fldListTo(compocn)%flds, 'Sw_pstokes_y', mrg_from=compwav, mrg_fld='Sw_pstokes_y', mrg_type='copy')
        end if
     end if
 

--- a/mediator/fd_cesm.yaml
+++ b/mediator/fd_cesm.yaml
@@ -1117,6 +1117,13 @@
        canonical_units: m/s
        description: ocean import - Stokes drift v component
      #
+     - standard_name: Sw_pstokes_x
+       canonical_units: m/s
+       description: Eastward partitioned stokes drift components
+     #
+     - standard_name: Sw_pstokes_y
+       canonical_units: m/s
+       description: Northward partitioned stokes drift components
      #-----------------------------------
      # mediator fields
      #-----------------------------------


### PR DESCRIPTION
### Description of changes

- Adds the new ww3->ocn export fields for SURFBANDS wave coupling method, i.e., the partitioned stokes drift components in x and y directions.
- Changes wav online mapping to bilnr_nstod. This only affects the new ww3dev code since the legacy ww3 code doesn't use online mapping.
- Sets the polemethod to NONE for all of the wave import/export fields and updates the mask for wav->ocn mapping. This is needed because the wave grid has triangles along the tripolar stitch, which triggers an ESMF error when POLEMETHOD_ALLAVG is used. This change also only affects the new ww3dev code since the legacy ww3 code doesn't use online mapping.


### Specific notes

Contributors other than yourself, if any:

CMEPS Issues Fixed (include github issue #):

Are changes expected to change answers?
 - [x] bit for bit
 - [ ] different at roundoff level
 - [ ] more substantial

Any User Interface Changes (namelist or namelist defaults changes)?
 - [ ] Yes
 - [x] No

Testing performed if application target is CESM:(either UFS-S2S or CESM testing is required):
All passing: (including baseline test)
SMS_Vnuopc.f09_g17.B1850.cheyenne_intel
SMS_Vnuopc.T62_g17.G1850ECO.cheyenne_intel
ERS_Vnuopc.TL319_g17.GIAF_JRA.cheyenne_gnu
ERS_Vnuopc.TL319_t061.GMOM_JRA_WD.cheyenne_gnu
SMS_Vnuopc.TL319_t061.GMOM_JRA.cheyenne_intel
ERS_Vnuopc.TL319_t061_wt061.GMOM_JRA_WD.cheyenne_gnu

Hashes used for testing:
cesm2_3_beta06
