### PR TITLE
Namelist trigger for passing channel depth fields from ROF to LND

### DIFF
--- a/cime_config/namelist_definition_drv.xml
+++ b/cime_config/namelist_definition_drv.xml
@@ -2255,11 +2255,9 @@
     <category>flds</category>
     <group>ALLCOMP_attributes</group>
     <desc>
-      Previously, new fields that were needed to be passed between components
-      for certain compsets were specified by cpp-variables. This has been
-      modified to now be use cases. This use cases are specified in the
-      namelist cpl_flds_inparm and are currently triggered by the xml variable CCSM_BGC.
-      If CCSM_BGC is set to 'CO2A', then flds_co2a will be set to .true.
+      Pass CO2 from ATM to surface components
+      Set this by setting the xml variable BGC_MODE.
+      If BGC_MODE is set to 'CO2A', then flds_co2a will be set to .true.
     </desc>
     <values>
       <value>.false.</value>
@@ -2272,11 +2270,9 @@
     <category>flds</category>
     <group>ALLCOMP_attributes</group>
     <desc>
-      Previously, new fields that were needed to be passed between components
-      for certain compsets were specified by cpp-variables. This has been
-      modified to now be use cases. This use cases are specified in the
-      namelist cpl_flds_inparm and are currently triggered by the xml variable CCSM_BGC.
-      If CCSM_BGC is set to 'CO2B', then flds_co2b will be set to .true.
+      Pass CO2 from ATM to LND and back from LND to ATM
+      Set this by setting the xml variable BGC_MODE.
+      If BGC_MODE is set to 'CO2B', then flds_co2b will be set to .true.
     </desc>
     <values>
       <value>.false.</value>
@@ -2289,11 +2285,9 @@
     <category>flds</category>
     <group>ALLCOMP_attributes</group>
     <desc>
-      Previously, new fields that were needed to be passed between components
-      for certain compsets were specified by cpp-variables. This has been
-      modified to now be use cases. This use cases are specified in the
-      namelist cpl_flds_inparm and are currently triggered by the xml variable CCSM_BGC.
-      If CCSM_BGC is set to 'CO2C', then flds_co2c will be set to .true.
+      Pass CO2 from ATM to surface (OCN/LND) and back from them to ATM
+      Set this by setting the xml variable BGC_MODE.
+      If BGC_MODE is set to 'CO2C', then flds_co2c will be set to .true.
     </desc>
     <values>
       <value>.false.</value>

--- a/cime_config/namelist_definition_drv.xml
+++ b/cime_config/namelist_definition_drv.xml
@@ -2328,6 +2328,19 @@
     </values>
   </entry>
 
+  <entry id="flds_r2l_stream_channel_depths">
+    <type>logical</type>
+    <category>flds</category>
+    <group>ALLCOMP_attributes</group>
+    <desc>
+      Pass channel depths from river component to land component. This is needed for the hillslope
+      model in CTSM.
+    </desc>
+    <values>
+      <value>.false.</value>
+    </values>
+  </entry>
+
   <entry  id="glc_nec" modify_via_xml="GLC_NEC">
     <type>integer</type>
     <category>flds</category>

--- a/mediator/esmFldsExchange_cesm_mod.F90
+++ b/mediator/esmFldsExchange_cesm_mod.F90
@@ -219,7 +219,7 @@ contains
        if (mastertask) then
           write(logunit,'(a,l7)') trim(subname)//' flds_co2a                       = ',flds_co2a
           write(logunit,'(a,l7)') trim(subname)//' flds_co2b                       = ',flds_co2b
-          write(logunit,'(a,l7)') trim(subname)//' flds_co2c                       = ',flds_co2b
+          write(logunit,'(a,l7)') trim(subname)//' flds_co2c                       = ',flds_co2c
           write(logunit,'(a,l7)') trim(subname)//' flds_wiso                       = ',flds_wiso
           write(logunit,'(a,l7)') trim(subname)//' flds_i2o_per_cat                = ',flds_i2o_per_cat
           write(logunit,'(a,l7)') trim(subname)//' flds_r2l_stream_channel_depths  = ',flds_r2l_stream_channel_depths

--- a/mediator/esmFldsExchange_cesm_mod.F90
+++ b/mediator/esmFldsExchange_cesm_mod.F90
@@ -55,6 +55,7 @@ module esmFldsExchange_cesm_mod
   logical             :: flds_co2b
   logical             :: flds_co2c
   logical             :: flds_wiso
+  logical             :: flds_r2l_stream_channel_depths   ! Pass channel depths from ROF to LND
 
   character(*), parameter :: u_FILE_u = &
        __FILE__
@@ -209,16 +210,21 @@ contains
        call NUOPC_CompAttributeGet(gcomp, name='flds_wiso', value=cvalue, rc=rc)
        if (ChkErr(rc,__LINE__,u_FILE_u)) return
        read(cvalue,*) flds_wiso
+       ! are water isotope exchanges enabled?
+       call NUOPC_CompAttributeGet(gcomp, name='flds_r2l_stream_channel_depths', value=cvalue, rc=rc)
+       if (ChkErr(rc,__LINE__,u_FILE_u)) return
+       read(cvalue,*) flds_r2l_stream_channel_depths
 
        ! write diagnostic output
        if (mastertask) then
-          write(logunit,'(a,l7)') trim(subname)//' flds_co2a         = ',flds_co2a
-          write(logunit,'(a,l7)') trim(subname)//' flds_co2b         = ',flds_co2b
-          write(logunit,'(a,l7)') trim(subname)//' flds_co2c         = ',flds_co2b
-          write(logunit,'(a,l7)') trim(subname)//' flds_wiso         = ',flds_wiso
-          write(logunit,'(a,l7)') trim(subname)//' flds_i2o_per_cat  = ',flds_i2o_per_cat
-          write(logunit,'(a,l7)') trim(subname)//' ocn2glc_coupling  = ',ocn2glc_coupling
-          write(logunit,'(a,l7)') trim(subname)//' mapuv_with_cart3d = ',mapuv_with_cart3d
+          write(logunit,'(a,l7)') trim(subname)//' flds_co2a                       = ',flds_co2a
+          write(logunit,'(a,l7)') trim(subname)//' flds_co2b                       = ',flds_co2b
+          write(logunit,'(a,l7)') trim(subname)//' flds_co2c                       = ',flds_co2b
+          write(logunit,'(a,l7)') trim(subname)//' flds_wiso                       = ',flds_wiso
+          write(logunit,'(a,l7)') trim(subname)//' flds_i2o_per_cat                = ',flds_i2o_per_cat
+          write(logunit,'(a,l7)') trim(subname)//' flds_r2l_stream_channel_depths  = ',flds_r2l_stream_channel_depths
+          write(logunit,'(a,l7)') trim(subname)//' ocn2glc_coupling                = ',ocn2glc_coupling
+          write(logunit,'(a,l7)') trim(subname)//' mapuv_with_cart3d               = ',mapuv_with_cart3d
        end if
 
     end if

--- a/mediator/esmFldsExchange_cesm_mod.F90
+++ b/mediator/esmFldsExchange_cesm_mod.F90
@@ -49,13 +49,13 @@ module esmFldsExchange_cesm_mod
   character(len=CX)   :: rof2lnd_map='unset'
   character(len=CX)   :: atm2wav_map='unset'
 
-  logical             :: mapuv_with_cart3d
-  logical             :: flds_i2o_per_cat
-  logical             :: flds_co2a
-  logical             :: flds_co2b
-  logical             :: flds_co2c
-  logical             :: flds_wiso
-  logical             :: flds_r2l_stream_channel_depths   ! Pass channel depths from ROF to LND
+  logical             :: mapuv_with_cart3d              ! Map U/V vector wind fields from ATM to OCN/ICE by rotating in Cartesian 3D space and then back
+  logical             :: flds_i2o_per_cat               ! Ice thickness category fields passed to OCN
+  logical             :: flds_co2a                      ! Pass CO2 from ATM to surface components
+  logical             :: flds_co2b                      ! Pass CO2 from ATM to LND and back from LND to ATM
+  logical             :: flds_co2c                      ! Pass CO2 from ATM to surface (OCN/LND) and back from them to ATM
+  logical             :: flds_wiso                      ! Pass water isotop fields
+  logical             :: flds_r2l_stream_channel_depths ! Pass channel depths from ROF to LND
 
   character(*), parameter :: u_FILE_u = &
        __FILE__


### PR DESCRIPTION
### Description of changes

Add a namelist trigger to turn on passing of channel depth fields needed for the hillslope model.

### Specific notes

Contributors other than yourself, if any: @mvertens @swensosc 

CMEPS Issues Fixed (include github issue #):
  Fixes #241
  Fixes #245

Are changes expected to change answers?
 - [ x] bit for bit

Any User Interface Changes (namelist or namelist defaults changes)?
 - [ x] Yes

Add flds_r2l_stream_channel_depths to ALLCOMPS_attributes config file

Testing performed if application target is CESM:(either UFS-S2S or CESM testing is required):
- [ x] (other) please described in detail
   - machines and compilers: cheyenne_intel
   - details (e.g. failed tests):

SMS_D_Ld5_Vnuopc.f10_f10_mg37.I2000Clm50BgcCrop.cheyenne_intel.mosart-default

Can add flds_r2l_stream_channel_depths to user_nl_cpl and tdepth fields are added when on, and otherwise off.

Hashes used for testing:
- [ x] CTSM:
  - repository to check out: https://github.com/ekluzek/CTSM.git
  - branch: nuopc_default
  - hash: 8dab46ccd5b61b12b142074f84fe87e19fdc0a31

