### PR TITLE
adds DIN_STAGING_ROOT variable

### DIFF
--- a/cime_config/config_component.xml
+++ b/cime_config/config_component.xml
@@ -1685,6 +1685,20 @@
     $CIMEROOT/machines/config_machines.xml</desc>
   </entry>
 
+  <entry id="DIN_STAGING_ROOT">
+    <type>char</type>
+    <default_value>UNSET</default_value>
+    <group>run_din</group>
+    <file>env_run.xml</file>
+    <desc>
+      On some systems the filesystem of DIN_LOC_ROOT is not available on compute nodes and
+      data must be staged to a temporary location.  If this variable is defined it will
+      be used as the root directory of an inputdata staging area.
+      Default values for the target machine are in the
+      $CIMEROOT/machines/config_machines.xml
+    </desc>
+  </entry>
+
   <entry id="DOUT_S_ROOT">
     <type>char</type>
     <default_value>UNSET</default_value>

--- a/cime_config/namelist_definition_drv.xml
+++ b/cime_config/namelist_definition_drv.xml
@@ -346,6 +346,7 @@
   <entry id="mesh_mask" modify_via_xml="MASK_MESH">
     <type>char</type>
     <category>mapping</category>
+    <input_pathname>abs</input_pathname>
     <group>ALLCOMP_attributes</group>
     <desc>
       MESH for model mask (used to create masks and fractions at run time if different than model mesh)
@@ -3798,6 +3799,7 @@
   <entry id="mesh_atm" modify_via_xml="ATM_DOMAIN_MESH">
     <type>char</type>
     <category>mapping</category>
+    <input_pathname>abs</input_pathname>
     <group>ATM_attributes</group>
     <desc>
       MESH description of atm grid
@@ -3857,6 +3859,7 @@
   <entry id="mesh_ice" modify_via_xml="ICE_DOMAIN_MESH">
     <type>char</type>
     <category>mapping</category>
+    <input_pathname>abs</input_pathname>
     <group>ICE_attributes</group>
     <desc>
       MESH description of ice grid
@@ -3883,6 +3886,7 @@
   <entry id="mesh_glc" modify_via_xml="GLC_DOMAIN_MESH">
     <type>char</type>
     <category>mapping</category>
+    <input_pathname>abs</input_pathname>
     <group>ALLCOMP_attributes</group>
     <desc>
       MESH description of glc grid
@@ -3909,6 +3913,7 @@
   <entry id="mesh_lnd" modify_via_xml="LND_DOMAIN_MESH">
     <type>char</type>
     <category>mapping</category>
+    <input_pathname>abs</input_pathname>
     <group>LND_attributes</group>
     <desc>
       MESH description of lnd grid
@@ -3935,6 +3940,7 @@
   <entry id="mesh_ocn" modify_via_xml="OCN_DOMAIN_MESH">
     <type>char</type>
     <category>mapping</category>
+    <input_pathname>abs</input_pathname>
     <group>OCN_attributes</group>
     <desc>
       MESH description of ocn grid
@@ -3961,6 +3967,7 @@
   <entry id="mesh_rof" modify_via_xml="ROF_DOMAIN_MESH">
     <type>char</type>
     <category>mapping</category>
+    <input_pathname>abs</input_pathname>
     <group>ROF_attributes</group>
     <desc>
       MESH description of rof grid
@@ -3987,6 +3994,7 @@
   <entry id="mesh_wav" modify_via_xml="WAV_DOMAIN_MESH">
     <type>char</type>
     <category>mapping</category>
+    <input_pathname>abs</input_pathname>
     <group>WAV_attributes</group>
     <desc>
       MESH description of wav grid


### PR DESCRIPTION
### Description of changes
Adds variable DIN_STAGING_ROOT for systems that cannot access the inputdata location from compute nodes. See https://github.com/ESMCI/cime/pull/4118 for details. 

### Specific notes

Contributors other than yourself, if any:

CMEPS Issues Fixed (include github issue #):

Are changes expected to change answers?
 - [X] bit for bit
 - [ ] different at roundoff level
 - [ ] more substantial

Any User Interface Changes (namelist or namelist defaults changes)?
 - [ ] Yes
 - [X] No

Testing performed if application target is CESM:(either UFS-S2S or CESM testing is required):
- [ ] (recommended) CIME_DRIVER=nuopc scripts_regression_tests.py
   - machines:
   - details (e.g. failed tests):
- [ ] (recommended) CESM testlist_drv.xml
   - machines and compilers:
   - details (e.g. failed tests):
- [ ] (optional) CESM prealpha test
   - machines and compilers
   - details (e.g. failed tests):
- [ ] (other) please described in detail
   - machines and compilers
   - details (e.g. failed tests):

Testing performed if application target is UFS-coupled:
- [ ] (recommended) UFS-coupled testing
   - description:
   - details (e.g. failed tests):

Testing performed if application target is UFS-HAFS:
- [ ] (recommended) UFS-HAFS testing
   - description:
   - details (e.g. failed tests):

Hashes used for testing:
- [ ] CESM:
  - repository to check out: https://github.com/ESCOMP/CESM.git
  - branch:
  - hash:
- [ ] UFS-coupled, then umbrella repostiory to check out and associated hash:
  - repository to check out:
  - branch:
  - hash:
- [ ] UFS-HAFS, then umbrella repostiory to check out and associated hash:
  - repository to check out:
  - branch:
  - hash:
