### PR TITLE
budget table updates needed for MOM6

### DIFF
--- a/cime_config/buildnml
+++ b/cime_config/buildnml
@@ -33,7 +33,6 @@ def _create_drv_namelists(case, infile, confdir, nmlgen, files):
     config['iyear'] = case.get_value('COMPSET').split('_')[0]
     config['BGC_MODE'] = case.get_value("CCSM_BGC")
     config['CPL_I2O_PER_CAT'] = case.get_value('CPL_I2O_PER_CAT')
-    config['COMP_RUN_BARRIERS'] = case.get_value('COMP_RUN_BARRIERS')
     config['DRV_THREADING'] = case.get_value('DRV_THREADING')
     config['CPL_ALBAV'] = case.get_value('CPL_ALBAV')
     config['CPL_EPBAL'] = case.get_value('CPL_EPBAL')
@@ -44,11 +43,11 @@ def _create_drv_namelists(case, infile, confdir, nmlgen, files):
     config['OS'] = case.get_value('OS')
     config['glc_nec'] = 0 if case.get_value('GLC_NEC') == 0 else case.get_value('GLC_NEC')
     config['timer_level'] = 'pos' if case.get_value('TIMER_LEVEL') >= 1 else 'neg'
-    config['bfbflag'] = 'on' if case.get_value('BFBFLAG') else 'off'
     config['continue_run'] = '.true.' if case.get_value('CONTINUE_RUN') else '.false.'
     config['flux_epbal'] = 'ocn' if case.get_value('CPL_EPBAL')  == 'ocn' else 'off'
     config['mask_grid'] = case.get_value('MASK_GRID')
     config['rest_option'] = case.get_value('REST_OPTION')
+    config['comp_ocn'] = case.get_value('COMP_OCN')
 
     atm_grid = case.get_value('ATM_GRID')
     lnd_grid = case.get_value('LND_GRID')

--- a/cime_config/namelist_definition_drv.xml
+++ b/cime_config/namelist_definition_drv.xml
@@ -919,6 +919,20 @@
     </values>
   </entry>
 
+  <entry id="budget_table_version">
+    <type>char</type>
+    <category>budget</category>
+    <group>MED_attributes</group>
+    <valid_values>v0,v1</valid_values>
+    <desc>
+      currently v0 refers to budgets using POP and v1 refers to budgets using MOM6
+    </desc>
+    <values>
+      <value comp_ocn="mom">v1</value>
+      <value comp_ocn="pop">v0</value>
+    </values>
+  </entry>
+
   <entry id="budget_inst">
     <type>integer</type>
     <category>budget</category>
@@ -2307,7 +2321,7 @@
     <group>ALLCOMP_attributes</group>
     <desc>
       If set to .true. BGC fields will be passed back and forth between the ocean and seaice
-      via the coupler.
+      via the mediator.
     </desc>
     <values>
       <value>.false.</value>

--- a/mediator/med_diag_mod.F90
+++ b/mediator/med_diag_mod.F90
@@ -131,58 +131,58 @@ module med_diag_mod
   ! ---------------------------------
   ! F for field
   ! ---------------------------------
+  integer, parameter :: unset_index = -999
+  integer :: f_area          = unset_index ! area (wrt to unit sphere)
+  integer :: f_heat_frz      = unset_index ! heat : latent, freezing
+  integer :: f_heat_melt     = unset_index ! heat : latent, melting
+  integer :: f_heat_swnet    = unset_index ! heat : short wave, net
+  integer :: f_heat_lwdn     = unset_index ! heat : longwave down
+  integer :: f_heat_lwup     = unset_index ! heat : longwave up
+  integer :: f_heat_latvap   = unset_index ! heat : latent, vaporization
+  integer :: f_heat_latf     = unset_index ! heat : latent, fusion, snow
+  integer :: f_heat_ioff     = unset_index ! heat : latent, fusion, frozen runoff
+  integer :: f_heat_sen      = unset_index ! heat : sensible
+  integer :: f_watr_frz      = unset_index ! water: freezing
+  integer :: f_watr_melt     = unset_index ! water: melting
+  integer :: f_watr_rain     = unset_index ! water: precip, liquid
+  integer :: f_watr_snow     = unset_index ! water: precip, frozen
+  integer :: f_watr_evap     = unset_index ! water: evaporation
+  integer :: f_watr_salt     = unset_index ! water: water equivalent of salt flux
+  integer :: f_watr_roff     = unset_index ! water: runoff/flood
+  integer :: f_watr_ioff     = unset_index ! water: frozen runoff
+  integer :: f_watr_frz_16O  = unset_index ! water isotope: freezing
+  integer :: f_watr_melt_16O = unset_index ! water isotope: melting
+  integer :: f_watr_rain_16O = unset_index ! water isotope: precip, liquid
+  integer :: f_watr_snow_16O = unset_index ! water isotope: prcip, frozen
+  integer :: f_watr_evap_16O = unset_index ! water isotope: evaporation
+  integer :: f_watr_roff_16O = unset_index ! water isotope: runoff/flood
+  integer :: f_watr_ioff_16O = unset_index ! water isotope: frozen runoff
+  integer :: f_watr_frz_18O  = unset_index ! water isotope: freezing
+  integer :: f_watr_melt_18O = unset_index ! water isotope: melting
+  integer :: f_watr_rain_18O = unset_index ! water isotope: precip, liquid
+  integer :: f_watr_snow_18O = unset_index ! water isotope: precip, frozen
+  integer :: f_watr_evap_18O = unset_index ! water isotope: evaporation
+  integer :: f_watr_roff_18O = unset_index ! water isotope: runoff/flood
+  integer :: f_watr_ioff_18O = unset_index ! water isotope: frozen runoff
+  integer :: f_watr_frz_HDO  = unset_index ! water isotope: freezing
+  integer :: f_watr_melt_HDO = unset_index ! water isotope: melting
+  integer :: f_watr_rain_HDO = unset_index ! water isotope: precip, liquid
+  integer :: f_watr_snow_HDO = unset_index ! water isotope: precip, frozen
+  integer :: f_watr_evap_HDO = unset_index ! water isotope: evaporation
+  integer :: f_watr_roff_HDO = unset_index ! water isotope: runoff/flood
+  integer :: f_watr_ioff_HDO = unset_index ! water isotope: frozen runoff
 
-  integer :: f_area          ! area (wrt to unit sphere)
-  integer :: f_heat_frz      ! heat : latent, freezing
-  integer :: f_heat_melt     ! heat : latent, melting
-  integer :: f_heat_swnet    ! heat : short wave, net
-  integer :: f_heat_lwdn     ! heat : longwave down
-  integer :: f_heat_lwup     ! heat : longwave up
-  integer :: f_heat_latvap   ! heat : latent, vaporization
-  integer :: f_heat_latf     ! heat : latent, fusion, snow
-  integer :: f_heat_ioff     ! heat : latent, fusion, frozen runoff
-  integer :: f_heat_sen      ! heat : sensible
-  integer :: f_watr_frz      ! water: freezing
-  integer :: f_watr_melt     ! water: melting
-  integer :: f_watr_rain     ! water: precip, liquid
-  integer :: f_watr_snow     ! water: precip, frozen
-  integer :: f_watr_evap     ! water: evaporation
-  integer :: f_watr_salt     ! water: water equivalent of salt flux
-  integer :: f_watr_roff     ! water: runoff/flood
-  integer :: f_watr_ioff     ! water: frozen runoff
-  integer :: f_watr_frz_16O  ! water isotope: freezing
-  integer :: f_watr_melt_16O ! water isotope: melting
-  integer :: f_watr_rain_16O ! water isotope: precip, liquid
-  integer :: f_watr_snow_16O ! water isotope: prcip, frozen
-  integer :: f_watr_evap_16O ! water isotope: evaporation
-  integer :: f_watr_roff_16O ! water isotope: runoff/flood
-  integer :: f_watr_ioff_16O ! water isotope: frozen runoff
-  integer :: f_watr_frz_18O  ! water isotope: freezing
-  integer :: f_watr_melt_18O ! water isotope: melting
-  integer :: f_watr_rain_18O ! water isotope: precip, liquid
-  integer :: f_watr_snow_18O ! water isotope: precip, frozen
-  integer :: f_watr_evap_18O ! water isotope: evaporation
-  integer :: f_watr_roff_18O ! water isotope: runoff/flood
-  integer :: f_watr_ioff_18O ! water isotope: frozen runoff
-  integer :: f_watr_frz_HDO  ! water isotope: freezing
-  integer :: f_watr_melt_HDO ! water isotope: melting
-  integer :: f_watr_rain_HDO ! water isotope: precip, liquid
-  integer :: f_watr_snow_HDO ! water isotope: precip, frozen
-  integer :: f_watr_evap_HDO ! water isotope: evaporation
-  integer :: f_watr_roff_HDO ! water isotope: runoff/flood
-  integer :: f_watr_ioff_HDO ! water isotope: frozen runoff
+  integer :: f_heat_beg      = unset_index ! 1st index  for heat
+  integer :: f_heat_end      = unset_index ! Last index for heat
+  integer :: f_watr_beg      = unset_index ! 1st index  for water
+  integer :: f_watr_end      = unset_index ! Last index for water
 
-  integer :: f_heat_beg      ! 1st index  for heat
-  integer :: f_heat_end      ! Last index for heat
-  integer :: f_watr_beg      ! 1st index  for water
-  integer :: f_watr_end      ! Last index for water
-
-  integer :: f_16O_beg       ! 1st index  for 16O water isotope
-  integer :: f_16O_end       ! Last index for 16O water isotope
-  integer :: f_18O_beg       ! 1st index  for 18O water isotope
-  integer :: f_18O_end       ! Last index for 18O water isotope
-  integer :: f_HDO_beg       ! 1st index  for HDO water isotope
-  integer :: f_HDO_end       ! Last index for HDO water isotope
+  integer :: f_16O_beg       = unset_index ! 1st index  for 16O water isotope
+  integer :: f_16O_end       = unset_index ! Last index for 16O water isotope
+  integer :: f_18O_beg       = unset_index ! 1st index  for 18O water isotope
+  integer :: f_18O_end       = unset_index ! Last index for 18O water isotope
+  integer :: f_HDO_beg       = unset_index ! 1st index  for HDO water isotope
+  integer :: f_HDO_end       = unset_index ! Last index for HDO water isotope
 
   ! ---------------------------------
   ! water isotopes names and indices
@@ -233,6 +233,8 @@ module med_diag_mod
   character(len=*), parameter :: u_FILE_u  = &
       __FILE__
 
+  character(len=CS) :: budget_table_version
+
 !===============================================================================
 contains
 !===============================================================================
@@ -253,14 +255,19 @@ contains
     integer           :: f_size   ! number of fields
     integer           :: p_size   ! number of period types
     type(ESMF_Clock)  :: mediatorClock
-    character(CS)     :: stop_option
-    integer           :: stop_n   ! Number until restart interval
-    integer           :: stop_ymd ! Restart date (YYYYMMDD)
-    type(ESMF_ALARM)  :: stop_alarm
     character(CS)     :: cvalue
+    logical           :: isPresent, isSet
     ! ------------------------------------------------------------------
 
     rc = ESMF_SUCCESS
+
+    call NUOPC_CompAttributeGet(gcomp, name="budget_table_version", value=cvalue, &
+         isPresent=isPresent, isSet=isSet, rc=rc)
+    if (isPresent .and. isSet) then
+       read(cvalue,*) budget_table_version
+    else
+       budget_table_version = 'v1'
+    end if
 
     call add_to_budget_diag(budget_diags%comps, c_atm_send , 'c2a_atm' ) ! comp index: atm
     call add_to_budget_diag(budget_diags%comps, c_atm_recv , 'a2c_atm' ) ! comp index: atm
@@ -297,55 +304,65 @@ contains
     call add_to_budget_diag(budget_diags%fields, f_heat_latf     ,'hlatfus'     ) ! field  heat : latent, fusion, snow
     call add_to_budget_diag(budget_diags%fields, f_heat_ioff     ,'hiroff'      ) ! field  heat : latent, fusion, frozen runoff
     call add_to_budget_diag(budget_diags%fields, f_heat_sen      ,'hsen'        ) ! field  heat : sensible
+    f_heat_beg = f_heat_frz      ! field  first index for heat
+    f_heat_end = f_heat_sen      ! field  last  index for heat
 
     ! Note that this order is important here to determine f_watr_beg and f_watr_end
-    call add_to_budget_diag(budget_diags%fields, f_watr_frz      ,'wfreeze'     ) ! field  water: freezing
+    if (trim(budget_table_version) == 'v0') then
+       call add_to_budget_diag(budget_diags%fields, f_watr_frz   ,'wfreeze'     ) ! field  water: freezing
+    end if
     call add_to_budget_diag(budget_diags%fields, f_watr_melt     ,'wmelt'       ) ! field  water: melting
     call add_to_budget_diag(budget_diags%fields, f_watr_rain     ,'wrain'       ) ! field  water: precip, liquid
     call add_to_budget_diag(budget_diags%fields, f_watr_snow     ,'wsnow'       ) ! field  water: precip, frozen
     call add_to_budget_diag(budget_diags%fields, f_watr_evap     ,'wevap'       ) ! field  water: evaporation
-    call add_to_budget_diag(budget_diags%fields, f_watr_salt     ,'weqsaltf'    ) ! field  water: water equivalent of salt flux
+    if (trim(budget_table_version) == 'v0') then
+       call add_to_budget_diag(budget_diags%fields, f_watr_salt  ,'weqsaltf'    ) ! field  water: water equivalent of salt flux
+    endif
     call add_to_budget_diag(budget_diags%fields, f_watr_roff     ,'wrunoff'     ) ! field  water: runoff/flood
     call add_to_budget_diag(budget_diags%fields, f_watr_ioff     ,'wfrzrof'     ) ! field  water: frozen runoff
+    if (trim(budget_table_version) == 'v0') then
+       f_watr_beg = f_watr_frz  ! field  firs  index for water
+    else
+       f_watr_beg = f_watr_melt ! field  firs  index for water
+    end if
+    f_watr_end = f_watr_ioff    ! field  last  index for water
 
-    call add_to_budget_diag(budget_diags%fields, f_watr_frz_16O  ,'wfreeze_16O' ) ! field  water isotope: freezing
-    call add_to_budget_diag(budget_diags%fields, f_watr_melt_16O ,'wmelt_16O'   ) ! field  water isotope: melting
-    call add_to_budget_diag(budget_diags%fields, f_watr_rain_16O ,'wrain_16O'   ) ! field  water isotope: precip, liquid
-    call add_to_budget_diag(budget_diags%fields, f_watr_snow_16O ,'wsnow_16O'   ) ! field  water isotope: prcip, frozen
-    call add_to_budget_diag(budget_diags%fields, f_watr_evap_16O ,'wevap_16O'   ) ! field  water isotope: evaporation
-    call add_to_budget_diag(budget_diags%fields, f_watr_roff_16O ,'wrunoff_16O' ) ! field  water isotope: runoff/flood
-    call add_to_budget_diag(budget_diags%fields, f_watr_ioff_16O ,'wfrzrof_16O' ) ! field  water isotope: frozen runoff
-    call add_to_budget_diag(budget_diags%fields, f_watr_frz_18O  ,'wfreeze_18O' ) ! field  water isotope: freezing
-    call add_to_budget_diag(budget_diags%fields, f_watr_melt_18O ,'wmelt_18O'   ) ! field  water isotope: melting
-    call add_to_budget_diag(budget_diags%fields, f_watr_rain_18O ,'wrain_18O'   ) ! field  water isotope: precip, liquid
-    call add_to_budget_diag(budget_diags%fields, f_watr_snow_18O ,'wsnow_18O'   ) ! field  water isotope: precip, frozen
-    call add_to_budget_diag(budget_diags%fields, f_watr_evap_18O ,'wevap_18O'   ) ! field  water isotope: evaporation
-    call add_to_budget_diag(budget_diags%fields, f_watr_roff_18O ,'wrunoff_18O' ) ! field  water isotope: runoff/flood
-    call add_to_budget_diag(budget_diags%fields, f_watr_ioff_18O ,'wfrzrof_18O' ) ! field  water isotope: frozen runoff
-    call add_to_budget_diag(budget_diags%fields, f_watr_frz_HDO  ,'wfreeze_HDO' ) ! field  water isotope: freezing
-    call add_to_budget_diag(budget_diags%fields, f_watr_melt_HDO ,'wmelt_HDO'   ) ! field  water isotope: melting
-    call add_to_budget_diag(budget_diags%fields, f_watr_rain_HDO ,'wrain_HDO'   ) ! field  water isotope: precip, liquid
-    call add_to_budget_diag(budget_diags%fields, f_watr_snow_HDO ,'wsnow_HDO'   ) ! field  water isotope: precip, frozen
-    call add_to_budget_diag(budget_diags%fields, f_watr_evap_HDO ,'wevap_HDO'   ) ! field  water isotope: evaporation
-    call add_to_budget_diag(budget_diags%fields, f_watr_roff_HDO ,'wrunoff_HDO' ) ! field  water isotope: runoff/flood
-    call add_to_budget_diag(budget_diags%fields, f_watr_ioff_HDO ,'wfrzrof_HDO' ) ! field  water isotope: frozen runoff
+    if (flds_wiso) then
+       call add_to_budget_diag(budget_diags%fields, f_watr_frz_16O  ,'wfreeze_16O' ) ! field  water isotope: freezing
+       call add_to_budget_diag(budget_diags%fields, f_watr_melt_16O ,'wmelt_16O'   ) ! field  water isotope: melting
+       call add_to_budget_diag(budget_diags%fields, f_watr_rain_16O ,'wrain_16O'   ) ! field  water isotope: precip, liquid
+       call add_to_budget_diag(budget_diags%fields, f_watr_snow_16O ,'wsnow_16O'   ) ! field  water isotope: prcip, frozen
+       call add_to_budget_diag(budget_diags%fields, f_watr_evap_16O ,'wevap_16O'   ) ! field  water isotope: evaporation
+       call add_to_budget_diag(budget_diags%fields, f_watr_roff_16O ,'wrunoff_16O' ) ! field  water isotope: runoff/flood
+       call add_to_budget_diag(budget_diags%fields, f_watr_ioff_16O ,'wfrzrof_16O' ) ! field  water isotope: frozen runoff
+       f_16O_beg  = f_watr_frz_16O  ! field 1st  index for 16O water isotope
+       f_16O_end  = f_watr_ioff_16O ! field Last index for 16O water isotope
 
-    f_heat_beg = f_heat_frz      ! field  first index for heat
-    f_heat_end = f_heat_sen      ! field  last  index for heat
-    f_watr_beg = f_watr_frz      ! field  firs  index for water
-    f_watr_end = f_watr_ioff     ! field  last  index for water
+       call add_to_budget_diag(budget_diags%fields, f_watr_frz_18O  ,'wfreeze_18O' ) ! field  water isotope: freezing
+       call add_to_budget_diag(budget_diags%fields, f_watr_melt_18O ,'wmelt_18O'   ) ! field  water isotope: melting
+       call add_to_budget_diag(budget_diags%fields, f_watr_rain_18O ,'wrain_18O'   ) ! field  water isotope: precip, liquid
+       call add_to_budget_diag(budget_diags%fields, f_watr_snow_18O ,'wsnow_18O'   ) ! field  water isotope: precip, frozen
+       call add_to_budget_diag(budget_diags%fields, f_watr_evap_18O ,'wevap_18O'   ) ! field  water isotope: evaporation
+       call add_to_budget_diag(budget_diags%fields, f_watr_roff_18O ,'wrunoff_18O' ) ! field  water isotope: runoff/flood
+       call add_to_budget_diag(budget_diags%fields, f_watr_ioff_18O ,'wfrzrof_18O' ) ! field  water isotope: frozen runoff
+       f_18O_beg  = f_watr_frz_18O  ! field 1st  index for 18O water isotope
+       f_18O_end  = f_watr_ioff_18O ! field Last index for 18O water isotope
 
-    f_16O_beg  = f_watr_frz_16O  ! field 1st  index for 16O water isotope
-    f_16O_end  = f_watr_ioff_16O ! field Last index for 16O water isotope
-    f_18O_beg  = f_watr_frz_18O  ! field 1st  index for 18O water isotope
-    f_18O_end  = f_watr_ioff_18O ! field Last index for 18O water isotope
-    f_HDO_beg  = f_watr_frz_HDO  ! field 1st  index for HDO water isotope
-    f_HDO_end  = f_watr_ioff_HDO ! field Last index for HDO water isotope
+       call add_to_budget_diag(budget_diags%fields, f_watr_frz_HDO  ,'wfreeze_HDO' ) ! field  water isotope: freezing
+       call add_to_budget_diag(budget_diags%fields, f_watr_melt_HDO ,'wmelt_HDO'   ) ! field  water isotope: melting
+       call add_to_budget_diag(budget_diags%fields, f_watr_rain_HDO ,'wrain_HDO'   ) ! field  water isotope: precip, liquid
+       call add_to_budget_diag(budget_diags%fields, f_watr_snow_HDO ,'wsnow_HDO'   ) ! field  water isotope: precip, frozen
+       call add_to_budget_diag(budget_diags%fields, f_watr_evap_HDO ,'wevap_HDO'   ) ! field  water isotope: evaporation
+       call add_to_budget_diag(budget_diags%fields, f_watr_roff_HDO ,'wrunoff_HDO' ) ! field  water isotope: runoff/flood
+       call add_to_budget_diag(budget_diags%fields, f_watr_ioff_HDO ,'wfrzrof_HDO' ) ! field  water isotope: frozen runoff
+       f_HDO_beg  = f_watr_frz_HDO  ! field 1st  index for HDO water isotope
+       f_HDO_end  = f_watr_ioff_HDO ! field Last index for HDO water isotope
 
-    ! water isotopes
-    iso0(:)    = (/ f_16O_beg, f_18O_beg, f_hdO_beg /)
-    isof(:)    = (/ f_16O_end, f_18O_end, f_hdO_end /)
-    isoname(:) = (/ 'H216O',   'H218O',   '  HDO'   /)
+       ! water isotopes
+       iso0(:)    = (/ f_16O_beg, f_18O_beg, f_hdO_beg /)
+       isof(:)    = (/ f_16O_end, f_18O_end, f_hdO_end /)
+       isoname(:) = (/ 'H216O',   'H218O',   '  HDO'   /)
+    end if
 
     !-------------------------------------------------------------------------------
     ! Get config variables
@@ -357,18 +374,18 @@ contains
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
     budget_print_month = get_diag_attribute(gcomp, 'budget_month', rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
-    budget_print_ann  = get_diag_attribute(gcomp, 'budget_ann', rc)
+    budget_print_ann = get_diag_attribute(gcomp, 'budget_ann', rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
-    budget_print_ltann  = get_diag_attribute(gcomp, 'budget_ltann', rc)
+    budget_print_ltann = get_diag_attribute(gcomp, 'budget_ltann', rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
-    budget_print_ltend  = get_diag_attribute(gcomp, 'budget_ltend', rc)
+    budget_print_ltend = get_diag_attribute(gcomp, 'budget_ltend', rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
 
     ! period types
     call add_to_budget_diag(budget_diags%periods, period_inst,'    inst')
     if(budget_print_daily > 0) call add_to_budget_diag(budget_diags%periods, period_day ,'   daily')
     if(budget_print_month > 0) call add_to_budget_diag(budget_diags%periods, period_mon ,' monthly')
-    if(budget_print_ann > 0) call add_to_budget_diag(budget_diags%periods, period_ann ,'  annual')
+    if(budget_print_ann   > 0) call add_to_budget_diag(budget_diags%periods, period_ann ,'  annual')
     call add_to_budget_diag(budget_diags%periods, period_inf ,'all_time')
 
     ! allocate module budget arrays
@@ -654,12 +671,14 @@ contains
          areas, lats, afrac, lfrac, ofrac, ifrac, budget_local, rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
 
-    call diag_atm_wiso_recv(is_local%wrap%FBImp(compatm,compatm), 'Faxa_rainc_wiso', &
-         f_watr_rain_16O, f_watr_rain_18O, f_watr_rain_HDO, areas, lats, afrac, lfrac, ofrac, ifrac, budget_local, rc=rc)
-    if (ChkErr(rc,__LINE__,u_FILE_u)) return
-    call diag_atm_wiso_recv(is_local%wrap%FBImp(compatm,compatm), 'Faxa_rainl_wiso', &
-         f_watr_rain_16O, f_watr_rain_18O, f_watr_rain_HDO, areas, lats, afrac, lfrac, ofrac, ifrac, budget_local, rc=rc)
-    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+    if (flds_wiso) then
+       call diag_atm_wiso_recv(is_local%wrap%FBImp(compatm,compatm), 'Faxa_rainc_wiso', &
+            f_watr_rain_16O, f_watr_rain_18O, f_watr_rain_HDO, areas, lats, afrac, lfrac, ofrac, ifrac, budget_local, rc=rc)
+       if (ChkErr(rc,__LINE__,u_FILE_u)) return
+       call diag_atm_wiso_recv(is_local%wrap%FBImp(compatm,compatm), 'Faxa_rainl_wiso', &
+            f_watr_rain_16O, f_watr_rain_18O, f_watr_rain_HDO, areas, lats, afrac, lfrac, ofrac, ifrac, budget_local, rc=rc)
+       if (ChkErr(rc,__LINE__,u_FILE_u)) return
+    end if
 
     ! heat implied by snow flux from atm to mediator
     budget_local(f_heat_latf,c_atm_recv ,ip) = -budget_local(f_watr_snow,c_atm_recv ,ip)*shr_const_latice
@@ -699,9 +718,11 @@ contains
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
 
     ! water isotopes
-    call diag_atm_wiso_send(is_local%wrap%FBImp(compatm,compatm), 'Faxa_evap_wiso', &
-         f_watr_evap_16O, f_watr_evap_18O, f_watr_evap_HDO, &
-         areas, lats, afrac, lfrac, ofrac, ifrac, budget_local, rc=rc)
+    if (flds_wiso) then
+       call diag_atm_wiso_send(is_local%wrap%FBImp(compatm,compatm), 'Faxa_evap_wiso', &
+            f_watr_evap_16O, f_watr_evap_18O, f_watr_evap_HDO, &
+            areas, lats, afrac, lfrac, ofrac, ifrac, budget_local, rc=rc)
+    end if
 
     deallocate(afrac)
     call t_stopf('MED:'//subname)
@@ -955,12 +976,14 @@ contains
     call diag_lnd(is_local%wrap%FBImp(complnd,complnd), 'Flrl_rofi'  , f_watr_ioff, ic,&
          areas, lfrac, budget_local, minus=.true., rc=rc)
 
-    call diag_lnd_wiso(is_local%wrap%FBImp(complnd,complnd), 'Flrl_evap_wiso', &
-         f_watr_evap_16O, f_watr_evap_18O, f_watr_evap_HDO, ic, areas, lfrac, budget_local, rc=rc)
-    call diag_lnd_wiso(is_local%wrap%FBImp(complnd,complnd), 'Flrl_rofl_wiso', &
-         f_watr_roff_16O, f_watr_roff_18O, f_watr_roff_HDO, ic, areas, lfrac, budget_local, rc=rc)
-    call diag_lnd_wiso(is_local%wrap%FBImp(complnd,complnd), 'Flrl_rofi_wiso', &
-         f_watr_ioff_16O, f_watr_ioff_18O, f_watr_ioff_HDO, ic, areas, lfrac, budget_local, rc=rc)
+    if (flds_wiso) then
+       call diag_lnd_wiso(is_local%wrap%FBImp(complnd,complnd), 'Flrl_evap_wiso', &
+            f_watr_evap_16O, f_watr_evap_18O, f_watr_evap_HDO, ic, areas, lfrac, budget_local, rc=rc)
+       call diag_lnd_wiso(is_local%wrap%FBImp(complnd,complnd), 'Flrl_rofl_wiso', &
+            f_watr_roff_16O, f_watr_roff_18O, f_watr_roff_HDO, ic, areas, lfrac, budget_local, rc=rc)
+       call diag_lnd_wiso(is_local%wrap%FBImp(complnd,complnd), 'Flrl_rofi_wiso', &
+            f_watr_ioff_16O, f_watr_ioff_18O, f_watr_ioff_HDO, ic, areas, lfrac, budget_local, rc=rc)
+    end if
 
     budget_local(f_heat_ioff,ic,ip) = -budget_local(f_watr_ioff,ic,ip)*shr_const_latice
 
@@ -981,16 +1004,18 @@ contains
     call diag_lnd(is_local%wrap%FBExp(complnd), 'Faxa_snowl', f_watr_snow, ic, areas, lfrac, budget_local, rc=rc)
     call diag_lnd(is_local%wrap%FBExp(complnd), 'Flrl_flood', f_watr_roff, ic, areas, lfrac, budget_local, minus=.true., rc=rc)
 
-    call diag_lnd_wiso(is_local%wrap%FBExp(complnd), 'Faxa_rainc_wiso', &
-         f_watr_rain_16O, f_watr_rain_18O, f_watr_rain_HDO, ic, areas, lfrac, budget_local, rc=rc)
-    call diag_lnd_wiso(is_local%wrap%FBExp(complnd), 'Faxa_rainl_wiso', &
-         f_watr_rain_16O, f_watr_rain_18O, f_watr_rain_HDO, ic, areas, lfrac, budget_local, rc=rc)
-    call diag_lnd_wiso(is_local%wrap%FBExp(complnd), 'Faxa_snowc_wiso', &
-         f_watr_snow_16O, f_watr_snow_18O, f_watr_snow_HDO, ic, areas, lfrac, budget_local, rc=rc)
-    call diag_lnd_wiso(is_local%wrap%FBExp(complnd), 'Faxa_snowl_wiso', &
-         f_watr_snow_16O, f_watr_snow_18O, f_watr_snow_HDO, ic, areas, lfrac, budget_local, rc=rc)
-    call diag_lnd_wiso(is_local%wrap%FBExp(complnd), 'Flrl_flood_wiso', &
-         f_watr_roff_16O, f_watr_roff_18O, f_watr_roff_HDO, ic, areas, lfrac, budget_local, minus=.true., rc=rc)
+    if (flds_wiso) then
+       call diag_lnd_wiso(is_local%wrap%FBExp(complnd), 'Faxa_rainc_wiso', &
+            f_watr_rain_16O, f_watr_rain_18O, f_watr_rain_HDO, ic, areas, lfrac, budget_local, rc=rc)
+       call diag_lnd_wiso(is_local%wrap%FBExp(complnd), 'Faxa_rainl_wiso', &
+            f_watr_rain_16O, f_watr_rain_18O, f_watr_rain_HDO, ic, areas, lfrac, budget_local, rc=rc)
+       call diag_lnd_wiso(is_local%wrap%FBExp(complnd), 'Faxa_snowc_wiso', &
+            f_watr_snow_16O, f_watr_snow_18O, f_watr_snow_HDO, ic, areas, lfrac, budget_local, rc=rc)
+       call diag_lnd_wiso(is_local%wrap%FBExp(complnd), 'Faxa_snowl_wiso', &
+            f_watr_snow_16O, f_watr_snow_18O, f_watr_snow_HDO, ic, areas, lfrac, budget_local, rc=rc)
+       call diag_lnd_wiso(is_local%wrap%FBExp(complnd), 'Flrl_flood_wiso', &
+            f_watr_roff_16O, f_watr_roff_18O, f_watr_roff_HDO, ic, areas, lfrac, budget_local, minus=.true., rc=rc)
+    end if
 
     budget_local(f_heat_latf,ic,ip) = -budget_local(f_watr_snow,ic,ip)*shr_const_latice
 
@@ -1108,12 +1133,14 @@ contains
     call diag_rof(is_local%wrap%FBImp(comprof,comprof), 'Forr_rofi' , f_watr_ioff, ic, areas, budget_local, minus=.true., rc=rc)
     call diag_rof(is_local%wrap%FBImp(comprof,comprof), 'Firr_rofi' , f_watr_ioff, ic, areas, budget_local, minus=.true., rc=rc)
 
-    call diag_rof_wiso(is_local%wrap%FBExp(comprof), 'Forr_flood_wiso', &
-         f_watr_ioff_16O, f_watr_ioff_18O, f_watr_ioff_HDO, ic, areas, budget_local, rc=rc)
-    call diag_rof_wiso(is_local%wrap%FBExp(comprof), 'Forr_rofl_wiso', &
-         f_watr_roff_16O, f_watr_roff_18O, f_watr_roff_HDO, ic, areas, budget_local, minus=.true., rc=rc)
-    call diag_rof_wiso(is_local%wrap%FBExp(comprof), 'Forr_rofi_wiso', &
-         f_watr_ioff_16O, f_watr_ioff_18O, f_watr_ioff_HDO, ic, areas, budget_local, minus=.true., rc=rc)
+    if (flds_wiso) then
+       call diag_rof_wiso(is_local%wrap%FBExp(comprof), 'Forr_flood_wiso', &
+            f_watr_ioff_16O, f_watr_ioff_18O, f_watr_ioff_HDO, ic, areas, budget_local, rc=rc)
+       call diag_rof_wiso(is_local%wrap%FBExp(comprof), 'Forr_rofl_wiso', &
+            f_watr_roff_16O, f_watr_roff_18O, f_watr_roff_HDO, ic, areas, budget_local, minus=.true., rc=rc)
+       call diag_rof_wiso(is_local%wrap%FBExp(comprof), 'Forr_rofi_wiso', &
+            f_watr_ioff_16O, f_watr_ioff_18O, f_watr_ioff_HDO, ic, areas, budget_local, minus=.true., rc=rc)
+    end if
 
     budget_local(f_heat_ioff,ic,ip) = -budget_local(f_watr_ioff,ic,ip)*shr_const_latice
 
@@ -1130,10 +1157,12 @@ contains
     call diag_rof(is_local%wrap%FBExp(comprof), 'Flrl_irrig' , f_watr_roff, ic, areas, budget_local, rc=rc)
     call diag_rof(is_local%wrap%FBExp(comprof), 'Flrl_rofi'  , f_watr_ioff, ic, areas, budget_local, rc=rc)
 
-    call diag_rof_wiso(is_local%wrap%FBExp(comprof), 'Flrl_rofl_wiso', &
-         f_watr_roff_16O, f_watr_roff_18O, f_watr_roff_HDO, ic, areas, budget_local, rc=rc)
-    call diag_rof_wiso(is_local%wrap%FBExp(comprof), 'Flrl_rofi_wiso', &
+    if (flds_wiso) then
+       call diag_rof_wiso(is_local%wrap%FBExp(comprof), 'Flrl_rofl_wiso', &
+            f_watr_roff_16O, f_watr_roff_18O, f_watr_roff_HDO, ic, areas, budget_local, rc=rc)
+       call diag_rof_wiso(is_local%wrap%FBExp(comprof), 'Flrl_rofi_wiso', &
          f_watr_ioff_16O, f_watr_ioff_18O, f_watr_ioff_HDO, ic, areas, budget_local, rc=rc)
+    end if
 
     budget_local(f_heat_ioff,ic,ip) = -budget_local(f_watr_ioff,ic,ip)*shr_const_latice
 
@@ -1353,7 +1382,9 @@ contains
        end do
     end if
 
-    budget_local(f_watr_frz,ic,ip) = budget_local(f_heat_frz,ic,ip) * HFLXtoWFLX
+    if (f_watr_frz /= unset_index) then
+       budget_local(f_watr_frz,ic,ip) = budget_local(f_heat_frz,ic,ip) * HFLXtoWFLX
+    end if
 
     !-------------------------------
     ! from mediator to ocn
@@ -1378,10 +1409,10 @@ contains
     call diag_ocn(is_local%wrap%FBMed_aoflux_o, 'Faox_evap', f_watr_evap   , ic, areas, ofrac, budget_local, rc=rc)
 
     if (fldbun_fldchk(is_local%wrap%FBExp(compocn), 'Foxx_lat', rc=rc)) then ! POP
-       call diag_ocn(is_local%wrap%FBMed_aoflux_o, 'Faox_lat'  , f_heat_latvap , ic, areas, ofrac, budget_local, rc=rc) 
+       call diag_ocn(is_local%wrap%FBMed_aoflux_o, 'Faox_lat'  , f_heat_latvap , ic, areas, ofrac, budget_local, rc=rc)
     else ! MOM6
-       call diag_ocn(is_local%wrap%FBMed_aoflux_o, 'Faox_evap' , f_heat_latvap , ic, areas, ofrac, budget_local, & 
-            scale=shr_const_latvap, rc=rc) 
+       call diag_ocn(is_local%wrap%FBMed_aoflux_o, 'Faox_evap' , f_heat_latvap , ic, areas, ofrac, budget_local, &
+            scale=shr_const_latvap, rc=rc)
        ! budget_local(f_heat_latvap,ic,ip) = budget_local(f_watr_evap,ic,ip)*shr_const_latvap
     end if
 
@@ -1390,8 +1421,11 @@ contains
     call diag_ocn(is_local%wrap%FBExp(compocn), 'Fioi_bergw', f_watr_melt   , ic, areas, sfrac, budget_local, rc=rc)
     call diag_ocn(is_local%wrap%FBExp(compocn), 'Fioi_melth', f_heat_melt   , ic, areas, sfrac, budget_local, rc=rc)
     call diag_ocn(is_local%wrap%FBExp(compocn), 'Fioi_bergh', f_heat_melt   , ic, areas, sfrac, budget_local, rc=rc)
-    call diag_ocn(is_local%wrap%FBExp(compocn), 'Fioi_salt' , f_watr_salt   , ic, areas, sfrac, budget_local, &
-         scale=SFLXtoWFLX, rc=rc)
+
+    if (f_watr_salt /= unset_index) then
+       call diag_ocn(is_local%wrap%FBExp(compocn), 'Fioi_salt' , f_watr_salt   , ic, areas, sfrac, budget_local, &
+            scale=SFLXtoWFLX, rc=rc)
+    end if
 
     if (fldbun_fldchk(is_local%wrap%FBExp(compocn), 'Foxx_swnet', rc=rc)) then
        call diag_ocn(is_local%wrap%FBExp(compocn), 'Foxx_swnet', f_heat_swnet  , ic, areas, sfrac, budget_local, rc=rc)
@@ -1410,18 +1444,20 @@ contains
     call diag_ocn(is_local%wrap%FBExp(compocn), 'Foxx_rofl' , f_watr_roff   , ic, areas, sfrac, budget_local, rc=rc)
     call diag_ocn(is_local%wrap%FBExp(compocn), 'Foxx_rofi' , f_watr_ioff   , ic, areas, sfrac, budget_local, rc=rc)
 
-    call diag_ocn_wiso(is_local%wrap%FBMed_aoflux_o, 'Faox_evap_wiso', &
-         f_watr_evap_16O, f_watr_evap_18O, f_watr_evap_HDO, ic, areas, ofrac, budget_local, rc=rc)
-    call diag_ocn_wiso(is_local%wrap%FBExp(compocn), 'Fioi_meltw_wiso', &
-         f_watr_melt_16O, f_watr_melt_HDO, f_watr_melt_HDO, ic, areas, sfrac, budget_local, rc=rc)
-    call diag_ocn_wiso(is_local%wrap%FBExp(compocn), 'Fioi_rain_wiso' , &
-         f_watr_rain_16O, f_watr_rain_HDO, f_watr_rain_HDO, ic, areas, sfrac, budget_local, rc=rc)
-    call diag_ocn_wiso(is_local%wrap%FBExp(compocn), 'Fioi_snow_wiso' , &
-         f_watr_snow_16O, f_watr_snow_HDO, f_watr_snow_HDO, ic,  areas, sfrac, budget_local, rc=rc)
-    call diag_ocn_wiso(is_local%wrap%FBExp(compocn), 'Foxx_rofl_wiso' , &
-         f_watr_roff_16O, f_watr_roff_HDO, f_watr_roff_HDO, ic,  areas, sfrac, budget_local, rc=rc)
-    call diag_ocn_wiso(is_local%wrap%FBExp(compocn), 'Foxx_rofi_wiso' , &
-         f_watr_ioff_16O, f_watr_ioff_HDO, f_watr_ioff_HDO, ic,  areas, sfrac, budget_local, rc=rc)
+    if (flds_wiso) then
+       call diag_ocn_wiso(is_local%wrap%FBMed_aoflux_o, 'Faox_evap_wiso', &
+            f_watr_evap_16O, f_watr_evap_18O, f_watr_evap_HDO, ic, areas, ofrac, budget_local, rc=rc)
+       call diag_ocn_wiso(is_local%wrap%FBExp(compocn), 'Fioi_meltw_wiso', &
+            f_watr_melt_16O, f_watr_melt_HDO, f_watr_melt_HDO, ic, areas, sfrac, budget_local, rc=rc)
+       call diag_ocn_wiso(is_local%wrap%FBExp(compocn), 'Fioi_rain_wiso' , &
+            f_watr_rain_16O, f_watr_rain_HDO, f_watr_rain_HDO, ic, areas, sfrac, budget_local, rc=rc)
+       call diag_ocn_wiso(is_local%wrap%FBExp(compocn), 'Fioi_snow_wiso' , &
+            f_watr_snow_16O, f_watr_snow_HDO, f_watr_snow_HDO, ic,  areas, sfrac, budget_local, rc=rc)
+       call diag_ocn_wiso(is_local%wrap%FBExp(compocn), 'Foxx_rofl_wiso' , &
+            f_watr_roff_16O, f_watr_roff_HDO, f_watr_roff_HDO, ic,  areas, sfrac, budget_local, rc=rc)
+       call diag_ocn_wiso(is_local%wrap%FBExp(compocn), 'Foxx_rofi_wiso' , &
+            f_watr_ioff_16O, f_watr_ioff_HDO, f_watr_ioff_HDO, ic,  areas, sfrac, budget_local, rc=rc)
+    end if
 
     budget_local(f_heat_latf,ic,ip) = -budget_local(f_watr_snow,ic,ip)*shr_const_latice
     budget_local(f_heat_ioff,ic,ip) = -budget_local(f_watr_ioff,ic,ip)*shr_const_latice
@@ -1448,6 +1484,7 @@ contains
     real(r8), pointer :: data(:)
     ! ------------------------------------------------------------------
     rc = ESMF_SUCCESS
+
     if ( fldbun_fldchk(FB, trim(fldname), rc=rc)) then
        call fldbun_getdata1d(FB, trim(fldname), data, rc=rc)
        if (ChkErr(rc,__LINE__,u_FILE_u)) return
@@ -1578,10 +1615,12 @@ contains
     call diag_ice_recv(is_local%wrap%FBImp(compice,compice), 'Faii_evap', f_watr_evap, &
          areas, lats, ifrac, budget_local, rc=rc)
 
-    call diag_ice_recv_wiso(is_local%wrap%FBImp(compice,compice), 'Fioi_meltw_wiso', &
-         f_watr_melt_16O, f_watr_melt_18O, f_watr_melt_HDO, areas, lats, ifrac, budget_local, rc=rc)
-    call diag_ice_recv_wiso(is_local%wrap%FBImp(compice,compice), 'Faii_evap_wiso', &
-         f_watr_evap_16O, f_watr_evap_18O, f_watr_evap_HDO, areas, lats, ifrac, budget_local, rc=rc)
+    if (flds_wiso) then
+       call diag_ice_recv_wiso(is_local%wrap%FBImp(compice,compice), 'Fioi_meltw_wiso', &
+            f_watr_melt_16O, f_watr_melt_18O, f_watr_melt_HDO, areas, lats, ifrac, budget_local, rc=rc)
+       call diag_ice_recv_wiso(is_local%wrap%FBImp(compice,compice), 'Faii_evap_wiso', &
+            f_watr_evap_16O, f_watr_evap_18O, f_watr_evap_HDO, areas, lats, ifrac, budget_local, rc=rc)
+    end if
 
     call t_stopf('MED:'//subname)
   end subroutine med_phases_diag_ice_ice2med
@@ -1756,10 +1795,12 @@ contains
     budget_local(f_heat_ioff,ic,ip) = -budget_local(f_watr_ioff,ic,ip)*shr_const_latice
     budget_local(f_watr_frz ,ic,ip) =  budget_local(f_heat_frz ,ic,ip)*HFLXtoWFLX
 
-    call diag_ice_send_wiso(is_local%wrap%FBExp(compice), 'Faxa_rain_wiso', &
-         f_watr_rain_16O, f_watr_rain_18O, f_watr_rain_HDO, areas, lats, ifrac, budget_local, rc=rc)
-    call diag_ice_send_wiso(is_local%wrap%FBExp(compice), 'Faxa_snow_wiso', &
-         f_watr_snow_16O, f_watr_snow_18O, f_watr_snow_HDO, areas, lats, ifrac, budget_local, rc=rc)
+    if (flds_wiso) then
+       call diag_ice_send_wiso(is_local%wrap%FBExp(compice), 'Faxa_rain_wiso', &
+            f_watr_rain_16O, f_watr_rain_18O, f_watr_rain_HDO, areas, lats, ifrac, budget_local, rc=rc)
+       call diag_ice_send_wiso(is_local%wrap%FBExp(compice), 'Faxa_snow_wiso', &
+            f_watr_snow_16O, f_watr_snow_18O, f_watr_snow_HDO, areas, lats, ifrac, budget_local, rc=rc)
+    end if
 
     call t_stopf('MED:'//subname)
   end subroutine med_phases_diag_ice_med2ice
@@ -2094,6 +2135,12 @@ contains
             sum(data(f_watr_beg:f_watr_end,ica,ip)) + sum(data(f_watr_beg:f_watr_end,icl,ip)) + &
             sum(data(f_watr_beg:f_watr_end,icn,ip)) + sum(data(f_watr_beg:f_watr_end,ics,ip)) + &
             sum(data(f_watr_beg:f_watr_end,ico,ip))
+
+       if (trim(budget_table_version) == 'v1') then
+          write(diagunit,*) ' '
+          write(diagunit,FAH) subname,trim(str)//' SALT BUDGET (kg m-2 s-1): period = ',&
+               trim(budget_diags%periods(ip)%name),': date = ',date,tod
+       end if
 
        if ( flds_wiso ) then
           do is = 1, nisotopes

--- a/mediator/med_diag_mod.F90
+++ b/mediator/med_diag_mod.F90
@@ -272,7 +272,7 @@ contains
        budget_table_version = 'v1'
     end if
     if (mastertask) then
-       write(logunit,'(a)') trim(subname) //' budget table version is '//trim(budget_table_version)  
+       write(logunit,'(a)') trim(subname) //' budget table version is '//trim(budget_table_version)
     end if
 
     call add_to_budget_diag(budget_diags%comps, c_atm_send , 'c2a_atm' ) ! comp index: atm
@@ -746,6 +746,7 @@ contains
        call diag_atm_wiso_send(is_local%wrap%FBImp(compatm,compatm), 'Faxa_evap_wiso', &
             f_watr_evap_16O, f_watr_evap_18O, f_watr_evap_HDO, &
             areas, lats, afrac, lfrac, ofrac, ifrac, budget_local, rc=rc)
+       if (ChkErr(rc,__LINE__,u_FILE_u)) return
     end if
 
     deallocate(afrac)
@@ -984,29 +985,42 @@ contains
     end do
 
     call diag_lnd(is_local%wrap%FBImp(complnd,complnd), 'Fall_swnet', f_heat_swnet  , ic, areas, lfrac, budget_local, rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
     call diag_lnd(is_local%wrap%FBImp(complnd,complnd), 'Fall_lwup' , f_heat_lwup   , ic, areas, lfrac, budget_local, rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
     call diag_lnd(is_local%wrap%FBImp(complnd,complnd), 'Fall_lat'  , f_heat_latvap , ic, areas, lfrac, budget_local, rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
     call diag_lnd(is_local%wrap%FBImp(complnd,complnd), 'Fall_sen'  , f_heat_sen    , ic, areas, lfrac, budget_local, rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
     call diag_lnd(is_local%wrap%FBImp(complnd,complnd), 'Fall_evap' , f_watr_evap   , ic, areas, lfrac, budget_local, rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
 
     call diag_lnd(is_local%wrap%FBImp(complnd,complnd), 'Flrl_rofsur', f_watr_roff, ic,&
          areas, lfrac, budget_local, minus=.true., rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
     call diag_lnd(is_local%wrap%FBImp(complnd,complnd), 'Flrl_rofgwl', f_watr_roff, ic,&
          areas, lfrac, budget_local, minus=.true., rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
     call diag_lnd(is_local%wrap%FBImp(complnd,complnd), 'Flrl_rofsub', f_watr_roff, ic,&
          areas, lfrac, budget_local, minus=.true., rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
     call diag_lnd(is_local%wrap%FBImp(complnd,complnd), 'Flrl_irrig' , f_watr_roff, ic,&
          areas, lfrac, budget_local, minus=.true., rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
     call diag_lnd(is_local%wrap%FBImp(complnd,complnd), 'Flrl_rofi'  , f_watr_ioff, ic,&
          areas, lfrac, budget_local, minus=.true., rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
 
     if (flds_wiso) then
        call diag_lnd_wiso(is_local%wrap%FBImp(complnd,complnd), 'Flrl_evap_wiso', &
             f_watr_evap_16O, f_watr_evap_18O, f_watr_evap_HDO, ic, areas, lfrac, budget_local, rc=rc)
+       if (ChkErr(rc,__LINE__,u_FILE_u)) return
        call diag_lnd_wiso(is_local%wrap%FBImp(complnd,complnd), 'Flrl_rofl_wiso', &
             f_watr_roff_16O, f_watr_roff_18O, f_watr_roff_HDO, ic, areas, lfrac, budget_local, rc=rc)
+       if (ChkErr(rc,__LINE__,u_FILE_u)) return
        call diag_lnd_wiso(is_local%wrap%FBImp(complnd,complnd), 'Flrl_rofi_wiso', &
             f_watr_ioff_16O, f_watr_ioff_18O, f_watr_ioff_HDO, ic, areas, lfrac, budget_local, rc=rc)
+       if (ChkErr(rc,__LINE__,u_FILE_u)) return
     end if
 
     budget_local(f_heat_ioff,ic,ip) = -budget_local(f_watr_ioff,ic,ip)*shr_const_latice
@@ -1022,21 +1036,31 @@ contains
        budget_local(f_area,ic,ip) = budget_local(f_area,ic,ip) + areas(n)*lfrac(n)
     end do
     call diag_lnd(is_local%wrap%FBExp(complnd), 'Faxa_lwdn' , f_heat_lwdn, ic, areas, lfrac, budget_local, rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
     call diag_lnd(is_local%wrap%FBExp(complnd), 'Faxa_rainc', f_watr_rain, ic, areas, lfrac, budget_local, rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
     call diag_lnd(is_local%wrap%FBExp(complnd), 'Faxa_rainl', f_watr_rain, ic, areas, lfrac, budget_local, rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
     call diag_lnd(is_local%wrap%FBExp(complnd), 'Faxa_snowc', f_watr_snow, ic, areas, lfrac, budget_local, rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
     call diag_lnd(is_local%wrap%FBExp(complnd), 'Faxa_snowl', f_watr_snow, ic, areas, lfrac, budget_local, rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
     call diag_lnd(is_local%wrap%FBExp(complnd), 'Flrl_flood', f_watr_roff, ic, areas, lfrac, budget_local, minus=.true., rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
 
     if (flds_wiso) then
        call diag_lnd_wiso(is_local%wrap%FBExp(complnd), 'Faxa_rainc_wiso', &
             f_watr_rain_16O, f_watr_rain_18O, f_watr_rain_HDO, ic, areas, lfrac, budget_local, rc=rc)
+       if (ChkErr(rc,__LINE__,u_FILE_u)) return
        call diag_lnd_wiso(is_local%wrap%FBExp(complnd), 'Faxa_rainl_wiso', &
             f_watr_rain_16O, f_watr_rain_18O, f_watr_rain_HDO, ic, areas, lfrac, budget_local, rc=rc)
+       if (ChkErr(rc,__LINE__,u_FILE_u)) return
        call diag_lnd_wiso(is_local%wrap%FBExp(complnd), 'Faxa_snowc_wiso', &
             f_watr_snow_16O, f_watr_snow_18O, f_watr_snow_HDO, ic, areas, lfrac, budget_local, rc=rc)
+       if (ChkErr(rc,__LINE__,u_FILE_u)) return
        call diag_lnd_wiso(is_local%wrap%FBExp(complnd), 'Faxa_snowl_wiso', &
             f_watr_snow_16O, f_watr_snow_18O, f_watr_snow_HDO, ic, areas, lfrac, budget_local, rc=rc)
+       if (ChkErr(rc,__LINE__,u_FILE_u)) return
        call diag_lnd_wiso(is_local%wrap%FBExp(complnd), 'Flrl_flood_wiso', &
             f_watr_roff_16O, f_watr_roff_18O, f_watr_roff_HDO, ic, areas, lfrac, budget_local, minus=.true., rc=rc)
     end if
@@ -1153,17 +1177,24 @@ contains
     ip = period_inst
 
     call diag_rof(is_local%wrap%FBImp(comprof,comprof), 'Flrr_flood', f_watr_roff, ic, areas, budget_local, rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
     call diag_rof(is_local%wrap%FBImp(comprof,comprof), 'Forr_rofl' , f_watr_roff, ic, areas, budget_local, minus=.true., rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
     call diag_rof(is_local%wrap%FBImp(comprof,comprof), 'Forr_rofi' , f_watr_ioff, ic, areas, budget_local, minus=.true., rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
     call diag_rof(is_local%wrap%FBImp(comprof,comprof), 'Firr_rofi' , f_watr_ioff, ic, areas, budget_local, minus=.true., rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
 
     if (flds_wiso) then
        call diag_rof_wiso(is_local%wrap%FBExp(comprof), 'Forr_flood_wiso', &
             f_watr_ioff_16O, f_watr_ioff_18O, f_watr_ioff_HDO, ic, areas, budget_local, rc=rc)
+       if (ChkErr(rc,__LINE__,u_FILE_u)) return
        call diag_rof_wiso(is_local%wrap%FBExp(comprof), 'Forr_rofl_wiso', &
             f_watr_roff_16O, f_watr_roff_18O, f_watr_roff_HDO, ic, areas, budget_local, minus=.true., rc=rc)
+       if (ChkErr(rc,__LINE__,u_FILE_u)) return
        call diag_rof_wiso(is_local%wrap%FBExp(comprof), 'Forr_rofi_wiso', &
             f_watr_ioff_16O, f_watr_ioff_18O, f_watr_ioff_HDO, ic, areas, budget_local, minus=.true., rc=rc)
+       if (ChkErr(rc,__LINE__,u_FILE_u)) return
     end if
 
     budget_local(f_heat_ioff,ic,ip) = -budget_local(f_watr_ioff,ic,ip)*shr_const_latice
@@ -1176,16 +1207,23 @@ contains
     ip = period_inst
 
     call diag_rof(is_local%wrap%FBExp(comprof), 'Flrl_rofsur', f_watr_roff, ic, areas, budget_local, rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
     call diag_rof(is_local%wrap%FBExp(comprof), 'Flrl_rofgwl', f_watr_roff, ic, areas, budget_local, rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
     call diag_rof(is_local%wrap%FBExp(comprof), 'Flrl_rofsub', f_watr_roff, ic, areas, budget_local, rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
     call diag_rof(is_local%wrap%FBExp(comprof), 'Flrl_irrig' , f_watr_roff, ic, areas, budget_local, rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
     call diag_rof(is_local%wrap%FBExp(comprof), 'Flrl_rofi'  , f_watr_ioff, ic, areas, budget_local, rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
 
     if (flds_wiso) then
        call diag_rof_wiso(is_local%wrap%FBExp(comprof), 'Flrl_rofl_wiso', &
             f_watr_roff_16O, f_watr_roff_18O, f_watr_roff_HDO, ic, areas, budget_local, rc=rc)
+       if (ChkErr(rc,__LINE__,u_FILE_u)) return
        call diag_rof_wiso(is_local%wrap%FBExp(comprof), 'Flrl_rofi_wiso', &
          f_watr_ioff_16O, f_watr_ioff_18O, f_watr_ioff_HDO, ic, areas, budget_local, rc=rc)
+       if (ChkErr(rc,__LINE__,u_FILE_u)) return
     end if
 
     budget_local(f_heat_ioff,ic,ip) = -budget_local(f_watr_ioff,ic,ip)*shr_const_latice
@@ -1302,8 +1340,11 @@ contains
     do ns = 1,num_icesheets
        areas => is_local%wrap%mesh_info(compglc(ns))%areas
        call diag_glc(is_local%wrap%FBImp(compglc(ns),compglc(ns)), 'Fogg_rofl', f_watr_roff, ic, areas, budget_local, minus=.true., rc=rc)
+       if (ChkErr(rc,__LINE__,u_FILE_u)) return
        call diag_glc(is_local%wrap%FBImp(compglc(ns),compglc(ns)), 'Fogg_rofi', f_watr_ioff, ic, areas, budget_local, minus=.true., rc=rc)
+       if (ChkErr(rc,__LINE__,u_FILE_u)) return
        call diag_glc(is_local%wrap%FBImp(compglc(ns),compglc(ns)), 'Figg_rofi', f_watr_ioff, ic, areas, budget_local, minus=.true., rc=rc)
+       if (ChkErr(rc,__LINE__,u_FILE_u)) return
     end do
 
     budget_local(f_heat_ioff,ic,ip) = -budget_local(f_watr_ioff,ic,ip)*shr_const_latice
@@ -1423,62 +1464,89 @@ contains
 
     if (fldbun_fldchk(is_local%wrap%FBExp(compocn), 'Foxx_lwnet', rc=rc)) then ! MOM6
        call diag_ocn(is_local%wrap%FBMed_aoflux_o        , 'Faox_lwup', f_heat_lwup, ic, areas, ofrac, budget_local, rc=rc)
+       if (ChkErr(rc,__LINE__,u_FILE_u)) return
        call diag_ocn(is_local%wrap%FBImp(compatm,compocn), 'Faxa_lwdn', f_heat_lwdn, ic, areas, ofrac, budget_local, rc=rc)
+       if (ChkErr(rc,__LINE__,u_FILE_u)) return
     else ! POP
        call diag_ocn(is_local%wrap%FBMed_aoflux_o, 'Faox_lwup' , f_heat_lwup   , ic, areas, ofrac, budget_local, rc=rc)
+       if (ChkErr(rc,__LINE__,u_FILE_u)) return
        call diag_ocn(is_local%wrap%FBExp(compocn), 'Faxa_lwdn' , f_heat_lwdn   , ic, areas, sfrac, budget_local, rc=rc)
+       if (ChkErr(rc,__LINE__,u_FILE_u)) return
     end if
 
     call diag_ocn(is_local%wrap%FBMed_aoflux_o, 'Faox_sen' , f_heat_sen    , ic, areas, ofrac, budget_local, rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
     call diag_ocn(is_local%wrap%FBMed_aoflux_o, 'Faox_evap', f_watr_evap   , ic, areas, ofrac, budget_local, rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
 
     if (fldbun_fldchk(is_local%wrap%FBExp(compocn), 'Foxx_lat', rc=rc)) then ! POP
        call diag_ocn(is_local%wrap%FBMed_aoflux_o, 'Faox_lat'  , f_heat_latvap , ic, areas, ofrac, budget_local, rc=rc)
+       if (ChkErr(rc,__LINE__,u_FILE_u)) return
     else ! MOM6
        call diag_ocn(is_local%wrap%FBMed_aoflux_o, 'Faox_evap' , f_heat_latvap , ic, areas, ofrac, budget_local, &
             scale=shr_const_latvap, rc=rc)
-       ! budget_local(f_heat_latvap,ic,ip) = budget_local(f_watr_evap,ic,ip)*shr_const_latvap
+       if (ChkErr(rc,__LINE__,u_FILE_u)) return
     end if
 
 
     call diag_ocn(is_local%wrap%FBExp(compocn), 'Fioi_meltw', f_watr_melt   , ic, areas, sfrac, budget_local, rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
     call diag_ocn(is_local%wrap%FBExp(compocn), 'Fioi_bergw', f_watr_melt   , ic, areas, sfrac, budget_local, rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
     call diag_ocn(is_local%wrap%FBExp(compocn), 'Fioi_melth', f_heat_melt   , ic, areas, sfrac, budget_local, rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
     call diag_ocn(is_local%wrap%FBExp(compocn), 'Fioi_bergh', f_heat_melt   , ic, areas, sfrac, budget_local, rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
 
     call diag_ocn(is_local%wrap%FBExp(compocn), 'Fioi_salt' , f_watr_salt   , ic, areas, sfrac, budget_local, &
          scale=SFLXtoWFLX, rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
 
     if (fldbun_fldchk(is_local%wrap%FBExp(compocn), 'Foxx_swnet', rc=rc)) then
        call diag_ocn(is_local%wrap%FBExp(compocn), 'Foxx_swnet', f_heat_swnet  , ic, areas, sfrac, budget_local, rc=rc)
+       if (ChkErr(rc,__LINE__,u_FILE_u)) return
     else if (fldbun_fldchk(is_local%wrap%FBExp(compocn), 'Foxx_swnet_vdr', rc=rc) .and. &
              fldbun_fldchk(is_local%wrap%FBExp(compocn), 'Foxx_swnet_vdf', rc=rc) .and. &
              fldbun_fldchk(is_local%wrap%FBExp(compocn), 'Foxx_swnet_idr', rc=rc) .and. &
              fldbun_fldchk(is_local%wrap%FBExp(compocn), 'Foxx_swnet_idf', rc=rc)) then
        call diag_ocn(is_local%wrap%FBExp(compocn), 'Foxx_swnet_vdr', f_heat_swnet  , ic, areas, sfrac, budget_local, rc=rc)
+       if (ChkErr(rc,__LINE__,u_FILE_u)) return
        call diag_ocn(is_local%wrap%FBExp(compocn), 'Foxx_swnet_vdf', f_heat_swnet  , ic, areas, sfrac, budget_local, rc=rc)
+       if (ChkErr(rc,__LINE__,u_FILE_u)) return
        call diag_ocn(is_local%wrap%FBExp(compocn), 'Foxx_swnet_idr', f_heat_swnet  , ic, areas, sfrac, budget_local, rc=rc)
+       if (ChkErr(rc,__LINE__,u_FILE_u)) return
        call diag_ocn(is_local%wrap%FBExp(compocn), 'Foxx_swnet_idf', f_heat_swnet  , ic, areas, sfrac, budget_local, rc=rc)
+       if (ChkErr(rc,__LINE__,u_FILE_u)) return
     end if
 
     call diag_ocn(is_local%wrap%FBExp(compocn), 'Faxa_rain' , f_watr_rain   , ic, areas, sfrac, budget_local, rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
     call diag_ocn(is_local%wrap%FBExp(compocn), 'Faxa_snow' , f_watr_snow   , ic, areas, sfrac, budget_local, rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
     call diag_ocn(is_local%wrap%FBExp(compocn), 'Foxx_rofl' , f_watr_roff   , ic, areas, sfrac, budget_local, rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
     call diag_ocn(is_local%wrap%FBExp(compocn), 'Foxx_rofi' , f_watr_ioff   , ic, areas, sfrac, budget_local, rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
 
     if (flds_wiso) then
        call diag_ocn_wiso(is_local%wrap%FBMed_aoflux_o, 'Faox_evap_wiso', &
             f_watr_evap_16O, f_watr_evap_18O, f_watr_evap_HDO, ic, areas, ofrac, budget_local, rc=rc)
+       if (ChkErr(rc,__LINE__,u_FILE_u)) return
        call diag_ocn_wiso(is_local%wrap%FBExp(compocn), 'Fioi_meltw_wiso', &
             f_watr_melt_16O, f_watr_melt_HDO, f_watr_melt_HDO, ic, areas, sfrac, budget_local, rc=rc)
+       if (ChkErr(rc,__LINE__,u_FILE_u)) return
        call diag_ocn_wiso(is_local%wrap%FBExp(compocn), 'Fioi_rain_wiso' , &
             f_watr_rain_16O, f_watr_rain_HDO, f_watr_rain_HDO, ic, areas, sfrac, budget_local, rc=rc)
+       if (ChkErr(rc,__LINE__,u_FILE_u)) return
        call diag_ocn_wiso(is_local%wrap%FBExp(compocn), 'Fioi_snow_wiso' , &
             f_watr_snow_16O, f_watr_snow_HDO, f_watr_snow_HDO, ic,  areas, sfrac, budget_local, rc=rc)
+       if (ChkErr(rc,__LINE__,u_FILE_u)) return
        call diag_ocn_wiso(is_local%wrap%FBExp(compocn), 'Foxx_rofl_wiso' , &
             f_watr_roff_16O, f_watr_roff_HDO, f_watr_roff_HDO, ic,  areas, sfrac, budget_local, rc=rc)
+       if (ChkErr(rc,__LINE__,u_FILE_u)) return
        call diag_ocn_wiso(is_local%wrap%FBExp(compocn), 'Foxx_rofi_wiso' , &
             f_watr_ioff_16O, f_watr_ioff_HDO, f_watr_ioff_HDO, ic,  areas, sfrac, budget_local, rc=rc)
+       if (ChkErr(rc,__LINE__,u_FILE_u)) return
     end if
 
     budget_local(f_heat_latf,ic,ip) = -budget_local(f_watr_snow,ic,ip)*shr_const_latice
@@ -1604,10 +1672,13 @@ contains
 
     call diag_ice_recv(is_local%wrap%FBImp(compice,compice), 'Fioi_melth', f_heat_melt, &
          areas, lats, ifrac, budget_local, minus=.true., rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
     call diag_ice_recv(is_local%wrap%FBImp(compice,compice), 'Fioi_meltw', f_watr_melt, &
          areas, lats, ifrac, budget_local, minus=.true., rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
     call diag_ice_recv(is_local%wrap%FBImp(compice,compice), 'Fioi_salt', f_watr_salt, &
          areas, lats, ifrac, budget_local, minus=.true., scale=SFLXtoWFLX, rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
 
     if ( fldbun_fldchk(is_local%wrap%FBImp(compice,compice), 'Fioi_swpen_vdr', rc=rc) .and. &
          fldbun_fldchk(is_local%wrap%FBImp(compice,compice), 'Fioi_swpen_vdf', rc=rc) .and. &
@@ -1615,33 +1686,45 @@ contains
          fldbun_fldchk(is_local%wrap%FBImp(compice,compice), 'Fioi_swpen_idf', rc=rc)) then
        call diag_ice_recv(is_local%wrap%FBImp(compice,compice), 'Fioi_swpen_vdr', f_heat_swnet, &
             areas, lats, ifrac, budget_local, minus=.true., rc=rc)
+       if (ChkErr(rc,__LINE__,u_FILE_u)) return
        call diag_ice_recv(is_local%wrap%FBImp(compice,compice), 'Fioi_swpen_vdf', f_heat_swnet, &
             areas, lats, ifrac, budget_local, minus=.true., rc=rc)
+       if (ChkErr(rc,__LINE__,u_FILE_u)) return
        call diag_ice_recv(is_local%wrap%FBImp(compice,compice), 'Fioi_swpen_idr', f_heat_swnet, &
             areas, lats, ifrac, budget_local, minus=.true., rc=rc)
+       if (ChkErr(rc,__LINE__,u_FILE_u)) return
        call diag_ice_recv(is_local%wrap%FBImp(compice,compice), 'Fioi_swpen_idf', f_heat_swnet, &
             areas, lats, ifrac, budget_local, minus=.true., rc=rc)
+       if (ChkErr(rc,__LINE__,u_FILE_u)) return
     else
        call diag_ice_recv(is_local%wrap%FBImp(compice,compice), 'Fioi_swpen', f_heat_swnet, &
             areas, lats, ifrac, budget_local, minus=.true., rc=rc)
+       if (ChkErr(rc,__LINE__,u_FILE_u)) return
     end if
     call diag_ice_recv(is_local%wrap%FBImp(compice,compice), 'Faii_swnet', f_heat_swnet, &
          areas, lats, ifrac, budget_local, rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
 
     call diag_ice_recv(is_local%wrap%FBImp(compice,compice), 'Faii_lwup', f_heat_lwup, &
          areas, lats, ifrac, budget_local, rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
     call diag_ice_recv(is_local%wrap%FBImp(compice,compice), 'Faii_lat', f_heat_latvap, &
          areas, lats, ifrac, budget_local, rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
     call diag_ice_recv(is_local%wrap%FBImp(compice,compice), 'Faii_sen', f_heat_sen, &
          areas, lats, ifrac, budget_local, rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
     call diag_ice_recv(is_local%wrap%FBImp(compice,compice), 'Faii_evap', f_watr_evap, &
          areas, lats, ifrac, budget_local, rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
 
     if (flds_wiso) then
        call diag_ice_recv_wiso(is_local%wrap%FBImp(compice,compice), 'Fioi_meltw_wiso', &
             f_watr_melt_16O, f_watr_melt_18O, f_watr_melt_HDO, areas, lats, ifrac, budget_local, rc=rc)
+       if (ChkErr(rc,__LINE__,u_FILE_u)) return
        call diag_ice_recv_wiso(is_local%wrap%FBImp(compice,compice), 'Faii_evap_wiso', &
             f_watr_evap_16O, f_watr_evap_18O, f_watr_evap_HDO, areas, lats, ifrac, budget_local, rc=rc)
+       if (ChkErr(rc,__LINE__,u_FILE_u)) return
     end if
 
     call t_stopf('MED:'//subname)
@@ -1788,9 +1871,13 @@ contains
     end do
 
     call diag_ice_send(is_local%wrap%FBExp(compice), 'Faxa_lwdn', f_heat_lwdn, areas, lats, ifrac, budget_local, rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
     call diag_ice_send(is_local%wrap%FBExp(compice), 'Faxa_rain', f_watr_rain, areas, lats, ifrac, budget_local, rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
     call diag_ice_send(is_local%wrap%FBExp(compice), 'Faxa_snow', f_watr_snow, areas, lats, ifrac, budget_local, rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
     call diag_ice_send(is_local%wrap%FBExp(compice), 'Fixx_rofi', f_watr_ioff, areas, lats, ifrac, budget_local, rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
 
     if ( fldbun_fldchk(is_local%wrap%FBExp(compice), 'Fioo_q', rc=rc)) then
        call fldbun_getdata1d(is_local%wrap%FBExp(compice), 'Fioo_q', data, rc=rc)
@@ -1820,8 +1907,10 @@ contains
     if (flds_wiso) then
        call diag_ice_send_wiso(is_local%wrap%FBExp(compice), 'Faxa_rain_wiso', &
             f_watr_rain_16O, f_watr_rain_18O, f_watr_rain_HDO, areas, lats, ifrac, budget_local, rc=rc)
+       if (ChkErr(rc,__LINE__,u_FILE_u)) return
        call diag_ice_send_wiso(is_local%wrap%FBExp(compice), 'Faxa_snow_wiso', &
             f_watr_snow_16O, f_watr_snow_18O, f_watr_snow_HDO, areas, lats, ifrac, budget_local, rc=rc)
+       if (ChkErr(rc,__LINE__,u_FILE_u)) return
     end if
 
     call t_stopf('MED:'//subname)


### PR DESCRIPTION
### Description of changes
CESM budget table updates needed for MOM6

### Specific notes
This PR targets budget table fixes and updates needed when using MOM6 as the ocean component in CESM.
In particular a new salt budget table is used when MOM6 is present and is not there when POP is present.
This PR should not effect non-CESM applications since they currently do not use the budget module.

Contributors other than yourself, if any: @jedwards4b 

CMEPS Issues Fixed: None

Are changes expected to change answers? No - bit for bit.

Any User Interface Changes (namelist or namelist defaults changes)? Yes. Addition of `budget_table_version` to `nuopc.runconfig.` For POP, this is set to `v0` and for MOM6 its set to `v1`.

Testing performed if application target is CESM:(either UFS-S2S or CESM testing is required):
1. On cheyenne, ran SMS_Vnuopc_Ld5.f19_g17.B1850.cheyenne_intel.allactive-defaultio with and without the new changes and compared daily budget table outputs. 
2. On cheyenne, worked closely with with @gustavo-marques  to run various B compsets using MOM6 at a variety of resolutions to verify the correctness of the budgets.

Hashes used for testing:
- [x] CESM: cesm2_3_beta06

