### PR TITLE
bugfix for #247

### DIFF
--- a/cime_config/namelist_definition_drv.xml
+++ b/cime_config/namelist_definition_drv.xml
@@ -928,6 +928,7 @@
       currently v0 refers to budgets using POP and v1 refers to budgets using MOM6
     </desc>
     <values>
+      <value>v0</value>
       <value comp_ocn="mom">v1</value>
       <value comp_ocn="pop">v0</value>
     </values>


### PR DESCRIPTION
### Description of changes
This fixes the bug for ERI tests.

### Specific notes
This makes `hist_option` and `hist_n` for instantaneous history files for all components module variables with the name
`hist_option_all_inst` and `hist_n_all_inst`.

Contributors other than yourself, if any: None
CMEPS Issues Fixed: #247 #243 
Are changes expected to change answers? No (bit-for-bit)
Any User Interface Changes (namelist or namelist defaults changes)? No
Testing performed:
Verified that failed test ERI.T62_g16.C1850ECO.cheyenne_intel.pop-ecosys now passes.
Hashes used for testing: CESM: cesm2_3_alpha07a (pre tag)
