### PR TITLE
initialize drydep_nflds to 0

### DIFF
--- a/cesm/nuopc_cap_share/seq_drydep_mod.F90
+++ b/cesm/nuopc_cap_share/seq_drydep_mod.F90
@@ -893,6 +893,7 @@ CONTAINS
     !-----------------------------------------------------------------------------
 
     rc = ESMF_SUCCESS
+    drydep_nflds = 0
 
     !--- Open and read namelist ---
     if ( len_trim(NLFilename) == 0  )then


### PR DESCRIPTION
### Description of changes
initialize drydep_nflds to 0 in seq_drydep_readnl.

Issue found when running CAM test **ERP_Ln9_Vnuopc.ne5pg3_ne5pg3_mg37.QPC6.izumi_nag.cam-outfrq9s_clubbmf** with the nuopc driver. Got the following error (and preceding log message):

> [0] (seq_drydep_init) Number of dry deposition fields transfered is **
================================================================================
> =   BAD TERMINATION OF ONE OF YOUR APPLICATION PROCESSES
> =   PID 117892 RUNNING AT i042.cgd.ucar.edu
> =   EXIT CODE: 9
> =   CLEANING UP REMAINING PROCESSES
> =   YOU CAN IGNORE THE BELOW CLEANUP MESSAGES

### Specific notes

Contributors other than yourself, if any: N/A

CMEPS Issues Fixed (include github issue #): resolves #272

Are changes expected to change answers? (specify if bfb, different at roundoff, more substantial) No answer changes.

Any User Interface Changes (namelist or namelist defaults changes)? no user interface changes

### Testing performed

Testing performed if application target is CESM:
- [ ] (recommended) CIME_DRIVER=nuopc scripts_regression_tests.py
   - machines:
   - details (e.g. failed tests):
- [ ] (recommended) CESM testlist_drv.xml
   - machines and compilers:
   - details (e.g. failed tests):
- [ ] (optional) CESM prealpha test
   - machines and compilers
   - details (e.g. failed tests):
- [x] (other) please described in detail
   - machines and compilers: izumi CAM aux_cam test ERP_Ln9_Vnuopc.ne5pg3_ne5pg3_mg37.QPC6.izumi_nag.cam-outfrq9s_clubbmf with nuopc_driver
   - details (e.g. failed tests): No failures.

Testing performed if application target is UFS-coupled:
- [ ] (recommended) UFS-coupled testing
   - description:
   - details (e.g. failed tests):

Testing performed if application target is UFS-HAFS:
- [ ] (recommended) UFS-HAFS testing
   - description:
   - details (e.g. failed tests):

### Hashes used for testing:

- [ ] CESM:
  - repository to check out: https://github.com/ESCOMP/CESM.git
  - branch/hash:
- [ ] UFS-coupled, then umbrella repostiory to check out and associated hash:
  - repository to check out:
  - branch/hash:
- [ ] UFS-HAFS, then umbrella repostiory to check out and associated hash:
  - repository to check out:
  - branch/hash:
