### PR TITLE
add_container_support

### DIFF
--- a/cime_config/buildexe
+++ b/cime_config/buildexe
@@ -105,7 +105,7 @@ def _main_func():
     if os.path.isfile(exename):
         os.remove(exename)
 
-    cmd = "{} exec_se -j {} EXEC_SE={} MODEL=driver {} -f {} "\
+    cmd = "{} exec_se -j {} EXEC_SE={} CIME_COMP=driver {} -f {} "\
         .format(gmake, gmake_j, exename, gmake_args, makefile)
 
 

--- a/cime_config/config_component.xml
+++ b/cime_config/config_component.xml
@@ -17,6 +17,15 @@
     <desc>List of component classes supported by this driver</desc>
   </entry>
 
+  <entry id="CONTAINER_ENVIRONMENT">
+    <type>char</type>
+    <valid_values></valid_values>
+    <default_value></default_value>
+    <group>case_comp</group>
+    <file>env_case.xml</file>
+    <desc>Container environment to invoke, if any</desc>
+  </entry>
+
   <entry id="COMP_CPL">
     <type>char</type>
     <valid_values>cpl</valid_values>


### PR DESCRIPTION
### Description of changes
Adds support for the crayenv container on cheyenne.  Please see https://github.com/ESCOMP/CESM/wiki/Using-CESM-in-the-Cray-environment-container-on-Cheyenne for usage details.

### Specific notes

Contributors other than yourself, if any:

CMEPS Issues Fixed (include github issue #):

Are changes expected to change answers? (specify if bfb, different at roundoff, more substantial) 

Any User Interface Changes (namelist or namelist defaults changes)?

### Testing performed

Testing performed if application target is CESM:
- [ ] (recommended) CIME_DRIVER=nuopc scripts_regression_tests.py
   - machines:
   - details (e.g. failed tests):
- [ ] (recommended) CESM testlist_drv.xml
   - machines and compilers:
   - details (e.g. failed tests):
- [ ] (optional) CESM prealpha test
   - machines and compilers
   - details (e.g. failed tests):
- [ ] (other) please described in detail
   - machines and compilers
   - details (e.g. failed tests):

Testing performed if application target is UFS-coupled:
- [ ] (recommended) UFS-coupled testing
   - description:
   - details (e.g. failed tests):

Testing performed if application target is UFS-HAFS:
- [ ] (recommended) UFS-HAFS testing
   - description:
   - details (e.g. failed tests):

### Hashes used for testing:

- [ ] CESM:
  - repository to check out: https://github.com/ESCOMP/CESM.git
  - branch/hash:
- [ ] UFS-coupled, then umbrella repostiory to check out and associated hash:
  - repository to check out:
  - branch/hash:
- [ ] UFS-HAFS, then umbrella repostiory to check out and associated hash:
  - repository to check out:
  - branch/hash:
