### PR TITLE
correct COMP_NAME (was CIME_COMP)

### DIFF
--- a/cime_config/buildexe
+++ b/cime_config/buildexe
@@ -105,7 +105,7 @@ def _main_func():
     if os.path.isfile(exename):
         os.remove(exename)
 
-    cmd = "{} exec_se -j {} EXEC_SE={} CIME_COMP=driver {} -f {} "\
+    cmd = "{} exec_se -j {} EXEC_SE={} COMP_NAME=driver {} -f {} "\
         .format(gmake, gmake_j, exename, gmake_args, makefile)
 
 


### PR DESCRIPTION
### Description of changes
Correct replacement of MODEL with COMP_NAME in buildexe.

### Specific notes
Fixes #281
Contributors other than yourself, if any:

CMEPS Issues Fixed (include github issue #):

Are changes expected to change answers? (specify if bfb, different at roundoff, more substantial) 

Any User Interface Changes (namelist or namelist defaults changes)?

### Testing performed
  
Testing performed if application target is CESM:
- [X] (recommended) CIME_DRIVER=nuopc scripts_regression_tests.py
   - machines: cheyenne 
   - details (e.g. failed tests):
- [ ] (recommended) CESM testlist_drv.xml
   - machines and compilers:
   - details (e.g. failed tests):
- [ ] (optional) CESM prealpha test
   - machines and compilers
   - details (e.g. failed tests):
- [X] (other) please described in detail
   - machines and compilers
   - details (e.g. failed tests):  Build case SMS_D.f09_t061.B1850MOM.cheyenne_intel

Testing performed if application target is UFS-coupled:
- [ ] (recommended) UFS-coupled testing
   - description:
   - details (e.g. failed tests):

Testing performed if application target is UFS-HAFS:
- [ ] (recommended) UFS-HAFS testing
   - description:
   - details (e.g. failed tests):

### Hashes used for testing:

- [ ] CESM:
  - repository to check out: https://github.com/ESCOMP/CESM.git
  - branch/hash:
- [ ] UFS-coupled, then umbrella repostiory to check out and associated hash:
  - repository to check out:
  - branch/hash:
- [ ] UFS-HAFS, then umbrella repostiory to check out and associated hash:
  - repository to check out:
  - branch/hash:
