### PR TITLE
use mesh file instead of grid name

### DIFF
--- a/cime_config/buildnml
+++ b/cime_config/buildnml
@@ -62,10 +62,12 @@ def _create_drv_namelists(case, infile, confdir, nmlgen, files):
     config['lnd_grid'] = lnd_grid
     config['ice_grid'] = ice_grid
     config['ocn_grid'] = ocn_grid
-    config['samegrid_atm_lnd'] = 'true' if atm_grid == lnd_grid else 'false'
-    config['samegrid_atm_ice'] = 'true' if atm_grid == ice_grid else 'false'
-    config['samegrid_atm_ocn'] = 'true' if atm_grid == ocn_grid else 'false'
-    config['samegrid_atm_wav'] = 'true' if atm_grid == wav_grid else 'false'
+
+    atm_mesh = case.get_value("ATM_DOMAIN_MESH")
+    config['samegrid_atm_lnd'] = 'true' if atm_mesh == case.get_value("LND_DOMAIN_MESH") else 'false'
+    config['samegrid_atm_ice'] = 'true' if atm_mesh == case.get_value("ICE_DOMAIN_MESH") else 'false'
+    config['samegrid_atm_ocn'] = 'true' if atm_grid == case.get_value("OCN_DOMAIN_MESH") else 'false'
+    config['samegrid_atm_wav'] = 'true' if atm_grid == case.get_value("WAV_DOMAIN_MESH") else 'false'
     config['samegrid_lnd_rof'] = 'true' if lnd_grid == rof_grid else 'false'
 
     # determine if need to set atm_domainfile


### PR DESCRIPTION
### Description of changes
Use comparisons of Mesh file instead of grid to determine if components are on the same grid.
This was done so that vertical component used in grid name does not affect this test.  

### Specific notes

Contributors other than yourself, if any: mvertens

CMEPS Issues Fixed: #284 

Are changes expected to change answers? (specify if bfb, different at roundoff, more substantial) 

Any User Interface Changes (namelist or namelist defaults changes)?

### Testing performed

Testing performed if application target is CESM:
- [ ] (recommended) CIME_DRIVER=nuopc scripts_regression_tests.py
   - machines:
   - details (e.g. failed tests):
- [ ] (recommended) CESM testlist_drv.xml
   - machines and compilers:
   - details (e.g. failed tests):
- [ ] (optional) CESM prealpha test
   - machines and compilers
   - details (e.g. failed tests):
- [ ] (other) please described in detail
   - machines and compilers
   - details (e.g. failed tests):

Testing performed if application target is UFS-coupled:
- [ ] (recommended) UFS-coupled testing
   - description:
   - details (e.g. failed tests):

Testing performed if application target is UFS-HAFS:
- [ ] (recommended) UFS-HAFS testing
   - description:
   - details (e.g. failed tests):

### Hashes used for testing:

- [ ] CESM:
  - repository to check out: https://github.com/ESCOMP/CESM.git
  - branch/hash:
- [ ] UFS-coupled, then umbrella repostiory to check out and associated hash:
  - repository to check out:
  - branch/hash:
- [ ] UFS-HAFS, then umbrella repostiory to check out and associated hash:
  - repository to check out:
  - branch/hash:
