### PR TITLE
dont repeat user_nl entries

### DIFF
--- a/cime_config/buildnml
+++ b/cime_config/buildnml
@@ -309,7 +309,7 @@ def _create_drv_namelists(case, infile, confdir, nmlgen, files):
             model = model.lower()
             config = {}
             config['component'] = model
-            nmlgen.init_defaults(infile, config, skip_entry_loop=True)
+            nmlgen.init_defaults([], config, skip_entry_loop=True)
             if model == 'cpl':
                 newgroup = "MED_modelio"
             else:
@@ -347,10 +347,6 @@ def _create_drv_namelists(case, infile, confdir, nmlgen, files):
                 nmlgen.set_value("logfile", logfile)
                 inst_index = inst_index + 1
             nmlgen.write_nuopc_config_file(conffile)
-
-
-
-
 
     #--------------------------------
     # Update nuopc.runconfig file if component needs it


### PR DESCRIPTION
### Description of changes
Remove already handled infile from modelio pass in buildnml, this prevents repeats of stuff from user_nl files. 

### Specific notes

Contributors other than yourself, if any:

CMEPS Issues Fixes #288 

Are changes expected to change answers? (specify if bfb, different at roundoff, more substantial) 

Any User Interface Changes (namelist or namelist defaults changes)?

### Testing performed

Testing performed if application target is CESM:
- [ ] (recommended) CIME_DRIVER=nuopc scripts_regression_tests.py
   - machines:
   - details (e.g. failed tests):
- [ ] (recommended) CESM testlist_drv.xml
   - machines and compilers:
   - details (e.g. failed tests):
- [ ] (optional) CESM prealpha test
   - machines and compilers
   - details (e.g. failed tests):
- [ ] (other) please described in detail
   - machines and compilers
   - details (e.g. failed tests):

Testing performed if application target is UFS-coupled:
- [ ] (recommended) UFS-coupled testing
   - description:
   - details (e.g. failed tests):

Testing performed if application target is UFS-HAFS:
- [ ] (recommended) UFS-HAFS testing
   - description:
   - details (e.g. failed tests):

### Hashes used for testing:

- [ ] CESM:
  - repository to check out: https://github.com/ESCOMP/CESM.git
  - branch/hash:
- [ ] UFS-coupled, then umbrella repostiory to check out and associated hash:
  - repository to check out:
  - branch/hash:
- [ ] UFS-HAFS, then umbrella repostiory to check out and associated hash:
  - repository to check out:
  - branch/hash:
