### PR TITLE
fix name of driver log

### DIFF
--- a/cime_config/buildnml
+++ b/cime_config/buildnml
@@ -350,6 +350,8 @@ def _create_drv_namelists(case, infile, confdir, nmlgen, files):
                 nmlgen.set_value("diro", case.get_value('RUNDIR'))
                 if model == 'cpl':
                     logfile = 'med' + inst_string + ".log." + str(lid)
+                elif model == 'drv':
+                    logfile = model + ".log." + str(lid)
                 else:
                     logfile = model + inst_string + ".log." + str(lid)
                 nmlgen.set_value("logfile", logfile)


### PR DESCRIPTION
### Description of changes
Correct the name of the drv log file in nuopc.runconfig

### Specific notes

Contributors other than yourself, if any:

CMEPS Issues Fixed (include github issue #):

Are changes expected to change answers? (specify if bfb, different at roundoff, more substantial) 

Any User Interface Changes (namelist or namelist defaults changes)?

### Testing performed

Testing performed if application target is CESM:
- [ ] (recommended) CIME_DRIVER=nuopc scripts_regression_tests.py
   - machines:
   - details (e.g. failed tests):
- [ ] (recommended) CESM testlist_drv.xml
   - machines and compilers:
   - details (e.g. failed tests):
- [ ] (optional) CESM prealpha test
   - machines and compilers
   - details (e.g. failed tests):
- [ ] (other) please described in detail
   - machines and compilers
   - details (e.g. failed tests):

Testing performed if application target is UFS-coupled:
- [ ] (recommended) UFS-coupled testing
   - description:
   - details (e.g. failed tests):

Testing performed if application target is UFS-HAFS:
- [ ] (recommended) UFS-HAFS testing
   - description:
   - details (e.g. failed tests):

### Hashes used for testing:

- [ ] CESM:
  - repository to check out: https://github.com/ESCOMP/CESM.git
  - branch/hash:
- [ ] UFS-coupled, then umbrella repostiory to check out and associated hash:
  - repository to check out:
  - branch/hash:
- [ ] UFS-HAFS, then umbrella repostiory to check out and associated hash:
  - repository to check out:
  - branch/hash:
