### PR TITLE
Extract non-initialization parts of shr_pio_mod to a module in share

### DIFF
--- a/cesm/driver/esm.F90
+++ b/cesm/driver/esm.F90
@@ -808,7 +808,7 @@ contains
     use mpi          , only : MPI_COMM_NULL, mpi_comm_size
 #endif
     use mct_mod      , only : mct_world_init
-    use shr_pio_mod  , only : shr_pio_init, shr_pio_component_init
+    use init_pio_mod , only : init_pio_init, init_pio_component_init
 
 #ifdef MED_PRESENT
     use med_internalstate_mod , only : med_id
@@ -934,7 +934,7 @@ contains
 
     ! Initialize PIO
     ! This reads in the pio parameters that are independent of component
-    call shr_pio_init(driver, rc=rc)
+    call init_pio_init(driver, rc=rc)
     if (chkerr(rc,__LINE__,u_FILE_u)) return
 
     allocate(comms(componentCount+1), comps(componentCount+1))
@@ -1182,7 +1182,7 @@ contains
     enddo
     ! Read in component dependent PIO parameters and initialize
     ! IO systems
-    call shr_pio_component_init(driver, size(comps), rc)
+    call init_pio_component_init(driver, size(comps), rc)
     if (chkerr(rc,__LINE__,u_FILE_u)) return
 
     ! Initialize MCT (this is needed for data models and cice prescribed capability)

--- a/cesm/driver/esm.F90
+++ b/cesm/driver/esm.F90
@@ -808,7 +808,7 @@ contains
     use mpi          , only : MPI_COMM_NULL, mpi_comm_size
 #endif
     use mct_mod      , only : mct_world_init
-    use init_pio_mod , only : init_pio_init, init_pio_component_init
+    use driver_pio_mod , only : driver_pio_init, driver_pio_component_init
 
 #ifdef MED_PRESENT
     use med_internalstate_mod , only : med_id
@@ -934,7 +934,7 @@ contains
 
     ! Initialize PIO
     ! This reads in the pio parameters that are independent of component
-    call init_pio_init(driver, rc=rc)
+    call driver_pio_init(driver, rc=rc)
     if (chkerr(rc,__LINE__,u_FILE_u)) return
 
     allocate(comms(componentCount+1), comps(componentCount+1))
@@ -1182,7 +1182,7 @@ contains
     enddo
     ! Read in component dependent PIO parameters and initialize
     ! IO systems
-    call init_pio_component_init(driver, size(comps), rc)
+    call driver_pio_component_init(driver, size(comps), rc)
     if (chkerr(rc,__LINE__,u_FILE_u)) return
 
     ! Initialize MCT (this is needed for data models and cice prescribed capability)

--- a/cesm/nuopc_cap_share/driver_pio_mod.F90
+++ b/cesm/nuopc_cap_share/driver_pio_mod.F90
@@ -1,4 +1,4 @@
-module init_pio_mod
+module driver_pio_mod
   use pio
   use shr_pio_mod,  only : io_compname, pio_comp_settings, iosystems, io_compid, shr_pio_getindex
   use shr_kind_mod, only : CS=>shr_kind_CS, shr_kind_cl, shr_kind_in
@@ -15,10 +15,10 @@ module init_pio_mod
 #include <mpif.h>
 #endif
   private
-  public :: init_pio_init
-  public :: init_pio_component_init
-  public :: init_pio_finalize
-  public :: init_pio_log_comp_settings
+  public :: driver_pio_init
+  public :: driver_pio_component_init
+  public :: driver_pio_finalize
+  public :: driver_pio_log_comp_settings
 
   integer :: io_comm
   integer :: pio_debug_level=0, pio_blocksize=0
@@ -50,7 +50,7 @@ contains
 !!
 !<
 
-  subroutine init_pio_init(driver, rc)
+  subroutine driver_pio_init(driver, rc)
     use ESMF, only : ESMF_GridComp, ESMF_VM, ESMF_Config, ESMF_GridCompGet
     use ESMF, only : ESMF_VMGet, ESMF_RC_NOT_VALID, ESMF_LogSetError
     use NUOPC, only: NUOPC_CompAttributeGet
@@ -66,7 +66,7 @@ contains
     character(len=CS) :: pio_rearr_comm_type, pio_rearr_comm_fcd
     character(CS) :: msgstr
 
-    character(*), parameter :: subName = '(init_pio_init) '
+    character(*), parameter :: subName = '(driver_pio_init) '
 
     call ESMF_GridCompGet(driver, vm=vm, rc=rc)
     if (chkerr(rc,__LINE__,u_FILE_u)) return
@@ -167,9 +167,9 @@ contains
        write(shr_log_unit, *) "  enable_isend (io2comp)  = ", pio_rearr_opts%comm_fc_opts_io2comp%enable_isend
     end if
 
-  end subroutine init_pio_init
+  end subroutine driver_pio_init
 
-  subroutine init_pio_component_init(driver, ncomps, rc)
+  subroutine driver_pio_component_init(driver, ncomps, rc)
     use ESMF, only : ESMF_GridComp, ESMF_LogSetError, ESMF_RC_NOT_VALID, ESMF_GridCompIsCreated, ESMF_VM, ESMF_VMGet
     use ESMF, only : ESMF_GridCompGet, ESMF_GridCompIsPetLocal, ESMF_VMIsCreated
     use NUOPC, only : NUOPC_CompAttributeGet, NUOPC_CompAttributeSet, NUOPC_CompAttributeAdd
@@ -278,7 +278,7 @@ contains
           
           call NUOPC_CompAttributeGet(gcomp(i), name="pio_netcdf_format", value=cval, rc=rc)
           if (chkerr(rc,__LINE__,u_FILE_u)) return
-          call init_pio_getioformatfromname(cval, pio_comp_settings(i)%pio_netcdf_ioformat, PIO_64BIT_DATA)
+          call driver_pio_getioformatfromname(cval, pio_comp_settings(i)%pio_netcdf_ioformat, PIO_64BIT_DATA)
           
           if (pio_async_interface(i)) then
              do_async_init = do_async_init + 1
@@ -308,9 +308,9 @@ contains
     endif
 
     deallocate(gcomp)
-  end subroutine init_pio_component_init
+  end subroutine driver_pio_component_init
 
-  subroutine init_pio_log_comp_settings(gcomp, logunit)
+  subroutine driver_pio_log_comp_settings(gcomp, logunit)
     use ESMF, only : ESMF_GridComp, ESMF_GridCompGet
     use NUOPC, only: NUOPC_CompAttributeGet
 
@@ -341,21 +341,21 @@ contains
 
     write(logunit, *) trim(name),': PIO root=',pio_comp_settings(i)%pio_root
         
-  end subroutine init_pio_log_comp_settings
+  end subroutine driver_pio_log_comp_settings
 
 !===============================================================================
-  subroutine init_pio_finalize(  )
+  subroutine driver_pio_finalize(  )
     integer :: ierr
     integer :: i
     do i=1,total_comps
        call pio_finalize(iosystems(i), ierr)
     end do
 
-  end subroutine init_pio_finalize
+  end subroutine driver_pio_finalize
 
 !===============================================================================
 
-  subroutine init_pio_getioformatfromname(pio_netcdf_format, pio_netcdf_ioformat, pio_default_netcdf_ioformat)
+  subroutine driver_pio_getioformatfromname(pio_netcdf_format, pio_netcdf_ioformat, pio_default_netcdf_ioformat)
     use shr_string_mod, only : shr_string_toupper
     character(len=*), intent(inout) :: pio_netcdf_format
     integer, intent(out) :: pio_netcdf_ioformat
@@ -372,10 +372,10 @@ contains
        pio_netcdf_ioformat = pio_default_netcdf_ioformat
     endif
 
-  end subroutine init_pio_getioformatfromname
+  end subroutine driver_pio_getioformatfromname
 
 
-  subroutine init_pio_getiotypefromname(typename, iotype, defaulttype)
+  subroutine driver_pio_getiotypefromname(typename, iotype, defaulttype)
     use shr_string_mod, only : shr_string_toupper
     character(len=*), intent(inout) :: typename
     integer, intent(out) :: iotype
@@ -395,12 +395,12 @@ contains
     else if ( typename .eq. 'DEFAULT') then
        iotype = defaulttype
     else
-       write(shr_log_unit,*) 'init_pio_mod: WARNING Bad io_type argument - using iotype_netcdf'
+       write(shr_log_unit,*) 'driver_pio_mod: WARNING Bad io_type argument - using iotype_netcdf'
        iotype=pio_iotype_netcdf
     end if
 
-  end subroutine init_pio_getiotypefromname
+  end subroutine driver_pio_getiotypefromname
 
 !===============================================================================
 
-end module init_pio_mod
+end module driver_pio_mod

--- a/cesm/nuopc_cap_share/init_pio_mod.F90
+++ b/cesm/nuopc_cap_share/init_pio_mod.F90
@@ -25,6 +25,7 @@ module init_pio_mod
   integer(kind=pio_offset_kind) :: pio_buffer_size_limit=-1
 
   type(pio_rearr_opt_t) :: pio_rearr_opts
+  logical, allocatable :: pio_async_interface(:)
 
   integer :: total_comps
   logical :: mastertask
@@ -187,7 +188,6 @@ contains
     character(CS) :: msgstr
     integer :: do_async_init
     type(iosystem_desc_t), allocatable :: async_iosystems(:)
-    logical, allocatable :: pio_async_interface(:)
 
     allocate(pio_comp_settings(ncomps))
     allocate(gcomp(ncomps))

--- a/cesm/nuopc_cap_share/nuopc_shr_methods.F90
+++ b/cesm/nuopc_cap_share/nuopc_shr_methods.F90
@@ -132,7 +132,7 @@ contains
 !===============================================================================
 
   subroutine set_component_logging(gcomp, mastertask, logunit, shrlogunit, rc)
-    use init_pio_mod, only : init_pio_log_comp_settings
+    use driver_pio_mod, only : driver_pio_log_comp_settings
     ! input/output variables
     type(ESMF_GridComp)  :: gcomp
     logical, intent(in)  :: mastertask
@@ -165,7 +165,7 @@ contains
 
        open(newunit=logunit,file=trim(diro)//"/"//trim(logfile))
        ! Write the PIO settings to the beggining of each component log
-       call init_pio_log_comp_settings(gcomp, logunit)
+       call driver_pio_log_comp_settings(gcomp, logunit)
 
     else
        logUnit = 6

--- a/cesm/nuopc_cap_share/nuopc_shr_methods.F90
+++ b/cesm/nuopc_cap_share/nuopc_shr_methods.F90
@@ -132,7 +132,7 @@ contains
 !===============================================================================
 
   subroutine set_component_logging(gcomp, mastertask, logunit, shrlogunit, rc)
-    use shr_pio_mod, only : shr_pio_log_comp_settings
+    use init_pio_mod, only : init_pio_log_comp_settings
     ! input/output variables
     type(ESMF_GridComp)  :: gcomp
     logical, intent(in)  :: mastertask
@@ -165,7 +165,7 @@ contains
 
        open(newunit=logunit,file=trim(diro)//"/"//trim(logfile))
        ! Write the PIO settings to the beggining of each component log
-       call shr_pio_log_comp_settings(gcomp, logunit)
+       call init_pio_log_comp_settings(gcomp, logunit)
 
     else
        logUnit = 6


### PR DESCRIPTION
### Description of changes

Extract the non-initialization parts of shr_pio_mod to a module in the
share repository, just keeping the initialization parts here.

This is part of a set of changes where I am splitting shr_pio_mod into two pieces: 

(1) Reading configuration files and initializing PIO appropriately

(2) Storing information about PIO (io system descriptors, io types, io formats) and providing an interface to query this information

Piece (2) lives in the share code and is used regardless of the driver. Piece (1) is driver-specific, so for now we have three versions of that piece: one in CMEPS (created by extracting the initialization pieces from `cmeps/cesm/nuopc_cap_share/shr_pio_mod.F90`), one in the cpl7 repo (created by extracting the initialization pieces from `share/src/shr_pio_mod.F90`), and one in CTSM's LILAC directory (which is essentially identical to the one in the cpl7 repo). Piece (2) – the actual share code piece – is used by components (their use statements stay exactly as they are now) as well as by piece (1) (which is responsible for setting the module-level variables in piece (2)).

See https://github.com/ESCOMP/CTSM/issues/1759#issuecomment-1171779485 for more context.

Needs to be coordinated with https://github.com/ESCOMP/CESM_share/pull/34

### Specific notes

Contributors other than yourself, if any: Discussions with @jedwards4b @mvertens 

CMEPS Issues Fixed (include github issue #): none

Are changes expected to change answers? no

Any User Interface Changes (namelist or namelist defaults changes)? no

### Testing performed

**Only limited testing performed so far; I plan to run CESM prealpha testing. Please let me know if you'd like more than that (I'm uncertain about whether scripts_regression_tests and testlist_drv give additional value if I'm already running prealpha testing).**

Testing performed if application target is CESM:
- [ ] (recommended) CIME_DRIVER=nuopc scripts_regression_tests.py
   - machines:
   - details (e.g. failed tests):
- [ ] (recommended) CESM testlist_drv.xml
   - machines and compilers:
   - details (e.g. failed tests):
- [x] (optional) CESM prealpha test
   - machines and compilers: cheyenne intel & gnu
   - details (e.g. failed tests): tests pass and are bit-for-bit
- [x] (other) please described in detail: the following tests pass
```
ERP_D_Ld10_P36x2_Vmct.f10_f10_mg37.IHistClm51BgcCrop.cheyenne_intel.clm-ciso_decStart
ERP_D_P36x2_Ld3.f10_f10_mg37.I1850Clm50BgcCrop.cheyenne_intel.clm-default
LILACSMOKE_D_Ld2.f10_f10_mg37.I2000Ctsm50NwpSpAsRs.cheyenne_intel.clm-lilac   
```

Testing performed if application target is UFS-coupled:
- [ ] (recommended) UFS-coupled testing
   - description:
   - details (e.g. failed tests):

Testing performed if application target is UFS-HAFS:
- [ ] (recommended) UFS-HAFS testing
   - description:
   - details (e.g. failed tests):

### Hashes used for testing:

- [x] CESM prealpha tests:
  - repository to check out: https://github.com/ESCOMP/CESM.git
  - branch/hash: cesm2_3_alpha09c, but with: cmeps at 1f8ce1304a7c0939cbc4584e1b5afa5165821fb6, cpl7 at 15c5d5ce45a9db320b1448e5c29d9892fc57e046 and share at d7c43983b8d84abfc357fa112870bc50b3b60d60 (all from billsacks forks)
- [x] For the other tests described above:
  - repository to check out: https://github.com/billsacks/CTSM.git
  - branch/hash: branch fix_lilac_pio2, hash 2ead6826d
- [ ] UFS-coupled, then umbrella repostiory to check out and associated hash:
  - repository to check out:
  - branch/hash:
- [ ] UFS-HAFS, then umbrella repostiory to check out and associated hash:
  - repository to check out:
  - branch/hash:
