### PR TITLE
CESM specific - activated atm/ocn flux scheme2

### DIFF
--- a/cesm/flux_atmocn/shr_flux_mod.F90
+++ b/cesm/flux_atmocn/shr_flux_mod.F90
@@ -569,7 +569,7 @@ contains
 
     else
 
-       call shr_sys_abort(subName//" subroutine flux_atmOcn requires ocn_surface_flux_scheme = 0 or 1")
+       call shr_sys_abort(subName//" subroutine flux_atmOcn requires ocn_surface_flux_scheme = 0, 1 or 2")
 
     endif  !! ocn_surface_flux_scheme
 

--- a/cesm/flux_atmocn/shr_flux_mod.F90
+++ b/cesm/flux_atmocn/shr_flux_mod.F90
@@ -133,8 +133,8 @@ contains
   !                   Thomas Toniazzo (Bjerknes Centre, Bergen) ”
   !===============================================================================
   SUBROUTINE flux_atmOcn(logunit, nMax  ,zbot  ,ubot  ,vbot  ,thbot ,   &
-       &               qbot  ,s16O  ,sHDO  ,s18O  ,rbot  ,   &
-       &               tbot  ,us    ,vs    ,   &
+       &               qbot  ,s16O  ,sHDO  ,s18O  ,rbot,  &
+       &               tbot  ,us    ,vs,  pslv,  &
        &               ts    ,mask  , seq_flux_atmocn_minwind, &
        &               sen   ,lat   ,lwup  ,   &
        &               r16O, rhdo, r18O, &
@@ -169,6 +169,7 @@ contains
     real(R8)   ,intent(in) :: r18O (nMax) ! ocn H218O tracer ratio/Rstd
     real(R8)   ,intent(in) :: rbot (nMax) ! atm air density       (kg/m^3)
     real(R8)   ,intent(in) :: tbot (nMax) ! atm T                 (K)
+    real(R8)   ,intent(in) :: pslv (nMax) ! atm sea level pressure(Pa)
     real(R8)   ,intent(in) :: us   (nMax) ! ocn u-velocity        (m/s)
     real(R8)   ,intent(in) :: vs   (nMax) ! ocn v-velocity        (m/s)
     real(R8)   ,intent(in) :: ts   (nMax) ! ocn temperature       (K)
@@ -552,6 +553,19 @@ contains
              if (present(ssq_sv  )) ssq_sv  (n) = spval
           endif
        ENDDO
+
+    else if (ocn_surface_flux_scheme .eq. 2) then
+
+       call flux_atmOcn_UA(logunit,&
+                          nMax, zbot, ubot, vbot, thbot, &
+                          qbot, s16O, sHDO, s18O, rbot, &
+                          tbot, pslv, us, vs, &
+                          ts, mask, sen, lat, lwup, &
+                          r16O, rhdo, r18O, &
+                          evap, evap_16O, evap_HDO, evap_18O, &
+                          taux, tauy, tref, qref, &
+                          duu10n, ustar_sv, re_sv, ssq_sv, &
+                          missval)
 
     else
 

--- a/cime_config/namelist_definition_drv.xml
+++ b/cime_config/namelist_definition_drv.xml
@@ -894,7 +894,17 @@
       <value>ogrid</value>
     </values>
   </entry>
-
+  <entry id="ocn_surface_flux_scheme">
+    <type>integer</type>
+    <category>control</category>
+    <group>MED_attributes</group>
+    <desc>
+      atm/ocn flux calculation scheme
+    </desc>
+    <values>
+      <value>0</value>
+    </values>
+  </entry>
   <entry id="gust_fac">
     <type>real</type>
     <category>control</category>

--- a/mediator/esmFldsExchange_cesm_mod.F90
+++ b/mediator/esmFldsExchange_cesm_mod.F90
@@ -291,6 +291,7 @@ contains
           call addmap(fldListFr(compatm)%flds, 'Sa_shum', compocn, mapbilnr, 'one', atm2ocn_map)
           call addmap(fldListFr(compatm)%flds, 'Sa_ptem', compocn, mapbilnr, 'one', atm2ocn_map)
           call addmap(fldListFr(compatm)%flds, 'Sa_dens', compocn, mapbilnr, 'one', atm2ocn_map)
+          call addmap(fldListFr(compatm)%flds, 'Sa_pslv', compocn, mapbilnr, 'one', atm2ocn_map)
           if (fldchk(is_local%wrap%FBImp(compatm,compatm), 'Sa_shum_wiso', rc=rc)) then
              call addmap(fldListFr(compatm)%flds, 'Sa_shum_wiso', compocn, mapbilnr, 'one', atm2ocn_map)
           end if

--- a/mediator/med_phases_aofluxes_mod.F90
+++ b/mediator/med_phases_aofluxes_mod.F90
@@ -108,6 +108,7 @@ module med_phases_aofluxes_mod
      real(R8) , pointer :: thbot       (:) => null() ! atm potential T
      real(R8) , pointer :: shum        (:) => null() ! atm specific humidity
      real(R8) , pointer :: pbot        (:) => null() ! atm bottom pressure
+     real(R8) , pointer :: pslv        (:) => null() ! atm sea level pressure
      real(R8) , pointer :: dens        (:) => null() ! atm bottom density
      real(R8) , pointer :: tbot        (:) => null() ! atm bottom surface T
      real(R8) , pointer :: shum_16O    (:) => null() ! atm H2O tracer
@@ -931,7 +932,7 @@ contains
          nMax=aoflux_in%lsize, &
          zbot=aoflux_in%zbot, ubot=aoflux_in%ubot, vbot=aoflux_in%vbot, thbot=aoflux_in%thbot, qbot=aoflux_in%shum, &
          s16O=aoflux_in%shum_16O, sHDO=aoflux_in%shum_HDO, s18O=aoflux_in%shum_18O, rbot=aoflux_in%dens, &
-         tbot=aoflux_in%tbot, us=aoflux_in%uocn, vs=aoflux_in%vocn, ts=aoflux_in%tocn, &
+         tbot=aoflux_in%tbot, us=aoflux_in%uocn, vs=aoflux_in%vocn, pslv=aoflux_in%pslv, ts=aoflux_in%tocn, &
          mask=aoflux_in%mask, seq_flux_atmocn_minwind=0.5_r8, &
          sen=aoflux_out%sen, lat=aoflux_out%lat, lwup=aoflux_out%lwup, &
          r16O=aoflux_in%roce_16O, rhdo=aoflux_in%roce_HDO, r18O=aoflux_in%roce_18O, &
@@ -1360,6 +1361,8 @@ end subroutine med_aofluxes_map_ogrid2xgrid_input
     ! Set pointers for aoflux_in attributes
     ! Note that if computation is on the xgrid, fldbun_a and fldbun_o are both fldbun_x
 
+    use med_methods_mod , only : FB_fldchk    => med_methods_FB_FldChk
+
     ! input/output variables
     type(ESMF_FieldBundle)     , intent(inout) :: fldbun_a
     type(ESMF_FieldBundle)     , intent(inout) :: fldbun_o
@@ -1415,6 +1418,11 @@ end subroutine med_aofluxes_map_ogrid2xgrid_input
        allocate(aoflux_in%dens(lsize))
     else
        call fldbun_getfldptr(fldbun_a, 'Sa_dens', aoflux_in%dens, xgrid=xgrid, rc=rc)
+       if (chkerr(rc,__LINE__,u_FILE_u)) return
+    end if
+
+    if (FB_fldchk(fldbun_a, 'Sa_pslv', rc=rc)) then
+       call fldbun_getfldptr(fldbun_a, 'Sa_pslv', aoflux_in%pslv, xgrid=xgrid, rc=rc)
        if (chkerr(rc,__LINE__,u_FILE_u)) return
     end if
 

--- a/mediator/med_phases_aofluxes_mod.F90
+++ b/mediator/med_phases_aofluxes_mod.F90
@@ -384,6 +384,12 @@ contains
     else
        ocn_surface_flux_scheme = 0
     end if
+#ifdef CESMCOUPLED
+    if (mastertask) then
+       write(logunit,*)
+       write(logunit,'(a)') trim(subname)//' ocn_surface_flux_scheme is '//trim(cvalue)
+    end if
+#endif
 
     ! bottom level potential temperature and/or botom level density
     ! will need to be computed if not received from the atm


### PR DESCRIPTION
### Description of changes
CESM specific - activated atm/ocn flux scheme2

### Specific notes
Previously, the atm/ocn flux scheme2 did not have a hook for activation. This PR creates that hook. 
Meg Fowler carried out a one year run with scheme2 active, but I think things are looking reasonable.

Contributors other than yourself, if any: Meg Fowler

CMEPS Issues Fixed: None

Are changes expected to change answers? bfb

Any User Interface Changes (namelist or namelist defaults changes)? Yes - for CESM a new namelist flag for the atm/ocn flux scheme was introduced-  `ocn_surface_flux_scheme`. By default this is set to 0.

### Testing performed

Testing performed if application target is CESM:
- ran ERS_Ld7.f19_g17.B1850.cheyenne_intel.allactive-defaultio and verified that it was bfb with cesm2_3_alpha09c

Testing performed if application target is UFS-coupled:
- [ ] (recommended) UFS-coupled testing
   - description:
   - details (e.g. failed tests):

Testing performed if application target is UFS-HAFS:
- [ ] (recommended) UFS-HAFS testing
   - description:
   - details (e.g. failed tests):

### Hashes used for testing: 

- [x] CESM:
   - cesm2_3_alpha09c
- [ ] UFS-coupled, then umbrella repostiory to check out and associated hash:
  - repository to check out:
  - branch/hash:
- [ ] UFS-HAFS, then umbrella repostiory to check out and associated hash:
  - repository to check out:
  - branch/hash:
