### PR TITLE
Turn off wavice_coupling (temporary)

### DIFF
--- a/cime_config/buildnml
+++ b/cime_config/buildnml
@@ -109,8 +109,9 @@ def _create_drv_namelists(case, infile, confdir, nmlgen, files):
     #--------------------------------
     # Overwrite: wav-ice coupling (assumes cice6 as the ice component
     #--------------------------------
-    if (case.get_value("COMP_WAV") == 'ww3dev' and case.get_value("COMP_ICE") == 'cice'):
-        nmlgen.set_value('wavice_coupling', value='.true.')
+    ## commenting out wavice_coupling for now because it causes instabilities. -aa
+    ##if (case.get_value("COMP_WAV") == 'ww3dev' and case.get_value("COMP_ICE") == 'cice'):
+    ##    nmlgen.set_value('wavice_coupling', value='.true.')
 
     #--------------------------------
     # Overwrite: set brnch_retain_casename


### PR DESCRIPTION
### Description of changes

Setting wavice_coupling flag to true causes instabilities in WW3DEV in ERS_D tests. This PR sets this flag to false by default. (It may still be set to true manually). It will be set to true by default again when the underlying issue is identified and resolved.

### Specific notes

Are changes expected to change answers? bfb

Any User Interface Changes (namelist or namelist defaults changes)? none

### Testing performed

ERS_D.TL319_t061_wt061.GMOM_JRA_WD.cheyenne_intel
ERS_D.TL319_t061_wt061.GMOM_JRA_WD.cheyenne_gnu

Testing performed if application target is CESM:
- [ ] (recommended) CIME_DRIVER=nuopc scripts_regression_tests.py
   - machines:
   - details (e.g. failed tests):
- [ ] (recommended) CESM testlist_drv.xml
   - machines and compilers:
   - details (e.g. failed tests):
- [ ] (optional) CESM prealpha test
   - machines and compilers
   - details (e.g. failed tests):
- [ ] (other) please described in detail
   - machines and compilers
   - details (e.g. failed tests):

### Hashes used for testing:

- [ ] CESM:
2.3 alpha09c