### PR TITLE
fix hard-wiring of wavice_coupling config (applies only to CESM)

### DIFF
--- a/cime_config/buildnml
+++ b/cime_config/buildnml
@@ -107,11 +107,10 @@ def _create_drv_namelists(case, infile, confdir, nmlgen, files):
     nmlgen.init_defaults(infile, config, skip_default_for_groups=["modelio"])
 
     #--------------------------------
-    # Overwrite: wav-ice coupling (assumes cice6 as the ice component
+    # Set default wav-ice coupling (assumes cice6 as the ice component
     #--------------------------------
-    ## commenting out wavice_coupling for now because it causes instabilities. -aa
-    ##if (case.get_value("COMP_WAV") == 'ww3dev' and case.get_value("COMP_ICE") == 'cice'):
-    ##    nmlgen.set_value('wavice_coupling', value='.true.')
+    if (case.get_value("COMP_WAV") == 'ww3dev' and case.get_value("COMP_ICE") == 'cice'):
+        nmlgen.add_default('wavice_coupling', value='.true.')
 
     #--------------------------------
     # Overwrite: set brnch_retain_casename


### PR DESCRIPTION
### Description of changes
fix hard-wiring of wavice_coupling config (applies only to CESM)

### Specific notes
This PR has a simple fix (changes nmlgen.set_value to nmlgen.add_default) in order to permit the 
setting of wavice_coupling to be changed in user_nl_cpl.

Contributors other than yourself, if any: None

CMEPS Issues Fixed:

Are changes expected to change answers? bfb

Any User Interface Changes (namelist or namelist defaults changes)? No

### Testing performed

Testing performed if application target is CESM:
Verified that wavice_coupling could be changed in nuopc.runconfig my changing user_nl_cpl.

Testing performed if application target is UFS-coupled:
- [ ] (recommended) UFS-coupled testing
   - description:
   - details (e.g. failed tests):

Testing performed if application target is UFS-HAFS:
- [ ] (recommended) UFS-HAFS testing
   - description:
   - details (e.g. failed tests):

### Hashes used for testing:

- [x] CESM:
  - repository to check out: https://github.com/ESCOMP/CESM.git
  - tag: cesm2_3_beta09
- [ ] UFS-coupled, then umbrella repostiory to check out and associated hash:
  - repository to check out:
  - branch/hash:
- [ ] UFS-HAFS, then umbrella repostiory to check out and associated hash:
  - repository to check out:
  - branch/hash:
