### PR TITLE
simplify specification of stop_option, rest_option and history_option (cesm only)

### DIFF
--- a/cesm/driver/esm_time_mod.F90
+++ b/cesm/driver/esm_time_mod.F90
@@ -29,18 +29,18 @@ module esm_time_mod
 
   ! Clock and alarm options
   character(len=*), private, parameter :: &
-       optNONE           = "none"      , &
-       optNever          = "never"     , &
-       optNSteps         = "nsteps"    , &
-       optNSeconds       = "nseconds"  , &
-       optNMinutes       = "nminutes"  , &
-       optNHours         = "nhours"    , &
-       optNDays          = "ndays"     , &
-       optNMonths        = "nmonths"   , &
-       optNYears         = "nyears"    , &
-       optMonthly        = "monthly"   , &
-       optYearly         = "yearly"    , &
-       optDate           = "date"      , &
+       optNONE           = "none"    , &
+       optNever          = "never"   , &
+       optNSteps         = "nstep"   , &
+       optNSeconds       = "nsecond" , &
+       optNMinutes       = "nminute" , &
+       optNHours         = "nhour"   , &
+       optNDays          = "nday"    , &
+       optNMonths        = "nmonth"  , &
+       optNYears         = "nyear"   , &
+       optMonthly        = "monthly" , &
+       optYearly         = "yearly"  , &
+       optDate           = "date"    , &
        optGLCCouplingPeriod = "glc_coupling_period"
 
   ! Module data
@@ -434,13 +434,14 @@ contains
          rc = ESMF_FAILURE
          return
       end if
-   else if (trim(option) == optNSteps   .or. &
-        trim(option) == optNSeconds .or. &
-        trim(option) == optNMinutes .or. &
-        trim(option) == optNHours   .or. &
-        trim(option) == optNDays    .or. &
-        trim(option) == optNMonths  .or. &
-        trim(option) == optNYears) then
+   else if (&
+        trim(option) == optNSteps   .or. trim(option) == optNSteps//'s'   .or. &
+        trim(option) == optNSeconds .or. trim(option) == optNSeconds//'s' .or. &
+        trim(option) == optNMinutes .or. trim(option) == optNMinutes//'s' .or. &
+        trim(option) == optNHours   .or. trim(option) == optNHours//'s'   .or. &
+        trim(option) == optNDays    .or. trim(option) == optNDays//'s'    .or. &
+        trim(option) == optNMonths  .or. trim(option) == optNMonths//'s'  .or. &
+        trim(option) == optNYears   .or. trim(option) == optNYears//'s' ) then
       if (.not.present(opt_n)) then
          call ESMF_LogWrite(subname//trim(option)//' requires opt_n', ESMF_LOGMSG_ERROR)
          rc = ESMF_FAILURE

--- a/cesm/driver/esm_time_mod.F90
+++ b/cesm/driver/esm_time_mod.F90
@@ -434,14 +434,14 @@ contains
          rc = ESMF_FAILURE
          return
       end if
-   else if (&
-        trim(option) == optNSteps   .or. trim(option) == optNSteps//'s'   .or. &
-        trim(option) == optNSeconds .or. trim(option) == optNSeconds//'s' .or. &
-        trim(option) == optNMinutes .or. trim(option) == optNMinutes//'s' .or. &
-        trim(option) == optNHours   .or. trim(option) == optNHours//'s'   .or. &
-        trim(option) == optNDays    .or. trim(option) == optNDays//'s'    .or. &
-        trim(option) == optNMonths  .or. trim(option) == optNMonths//'s'  .or. &
-        trim(option) == optNYears   .or. trim(option) == optNYears//'s' ) then
+    else if (&
+         trim(option) == optNSteps   .or. trim(option) == trim(optNSteps)//'s'   .or. &
+         trim(option) == optNSeconds .or. trim(option) == trim(optNSeconds)//'s' .or. &
+         trim(option) == optNMinutes .or. trim(option) == trim(optNMinutes)//'s' .or. &
+         trim(option) == optNHours   .or. trim(option) == trim(optNHours)//'s'   .or. &
+         trim(option) == optNDays    .or. trim(option) == trim(optNDays)//'s'    .or. &
+         trim(option) == optNMonths  .or. trim(option) == trim(optNMonths)//'s'  .or. &
+         trim(option) == optNYears   .or. trim(option) == trim(optNYears)//'s' ) then
       if (.not.present(opt_n)) then
          call ESMF_LogWrite(subname//trim(option)//' requires opt_n', ESMF_LOGMSG_ERROR)
          rc = ESMF_FAILURE
@@ -452,7 +452,7 @@ contains
          rc = ESMF_FAILURE
          return
       end if
-   end if
+    end if
 
    ! Determine inputs for call to create alarm
    selectcase (trim(option))
@@ -480,36 +480,36 @@ contains
       if (ChkErr(rc,__LINE__,u_FILE_u)) return
       update_nextalarm  = .false.
 
-   case (optNSteps)
+   case (optNSteps,trim(optNSteps)//'s')
       call ESMF_ClockGet(clock, TimeStep=AlarmInterval, rc=rc)
       if (ChkErr(rc,__LINE__,u_FILE_u)) return
       AlarmInterval = AlarmInterval * opt_n
       update_nextalarm  = .true.
 
-   case (optNSeconds)
+   case (optNSeconds,trim(optNSeconds)//'s')
       call ESMF_TimeIntervalSet(AlarmInterval, s=1, rc=rc)
       if (ChkErr(rc,__LINE__,u_FILE_u)) return
       AlarmInterval = AlarmInterval * opt_n
       update_nextalarm  = .true.
 
-   case (optNMinutes)
+   case (optNMinutes,trim(optNMinutes)//'s')
       call ESMF_TimeIntervalSet(AlarmInterval, s=60, rc=rc)
       AlarmInterval = AlarmInterval * opt_n
       update_nextalarm  = .true.
 
-   case (optNHours)
+   case (optNHours,trim(optNHours)//'s')
       call ESMF_TimeIntervalSet(AlarmInterval, s=3600, rc=rc)
       if (ChkErr(rc,__LINE__,u_FILE_u)) return
       AlarmInterval = AlarmInterval * opt_n
       update_nextalarm  = .true.
 
-   case (optNDays)
+   case (optNDays,trim(optNDays)//'s')
       call ESMF_TimeIntervalSet(AlarmInterval, d=1, rc=rc)
       if (ChkErr(rc,__LINE__,u_FILE_u)) return
       AlarmInterval = AlarmInterval * opt_n
       update_nextalarm  = .true.
 
-   case (optNMonths)
+   case (optNMonths,trim(optNMonths)//'s')
       call ESMF_TimeIntervalSet(AlarmInterval, mm=1, rc=rc)
       if (ChkErr(rc,__LINE__,u_FILE_u)) return
       AlarmInterval = AlarmInterval * opt_n

--- a/cime_config/buildnml
+++ b/cime_config/buildnml
@@ -107,11 +107,10 @@ def _create_drv_namelists(case, infile, confdir, nmlgen, files):
     nmlgen.init_defaults(infile, config, skip_default_for_groups=["modelio"])
 
     #--------------------------------
-    # Overwrite: wav-ice coupling (assumes cice6 as the ice component
+    # Set default wav-ice coupling (assumes cice6 as the ice component
     #--------------------------------
-    ## commenting out wavice_coupling for now because it causes instabilities. -aa
-    ##if (case.get_value("COMP_WAV") == 'ww3dev' and case.get_value("COMP_ICE") == 'cice'):
-    ##    nmlgen.set_value('wavice_coupling', value='.true.')
+    if (case.get_value("COMP_WAV") == 'ww3dev' and case.get_value("COMP_ICE") == 'cice'):
+        nmlgen.add_default('wavice_coupling', value='.true.')
 
     #--------------------------------
     # Overwrite: set brnch_retain_casename

--- a/cime_config/config_component.xml
+++ b/cime_config/config_component.xml
@@ -340,7 +340,7 @@
 
   <entry id="STOP_OPTION">
     <type>char</type>
-    <valid_values>none,never,nsteps,nstep,nseconds,nsecond,nminutes,nminute,nhours,nhour,ndays,nday,nmonths,nmonth,nyears,nyear,date,end</valid_values>
+    <valid_values>none,never,nsteps,nseconds,nminutes,nhours,ndays,nmonths,nyears,date,end</valid_values>
     <default_value>ndays</default_value>
     <group>run_begin_stop_restart</group>
     <file>env_run.xml</file>
@@ -372,7 +372,7 @@
 
   <entry id="REST_OPTION">
     <type>char</type>
-    <valid_values>none,never,nsteps,nstep,nseconds,nsecond,nminutes,nminute,nhours,nhour,ndays,nday,nmonths,nmonth,nyears,nyear,date,end</valid_values>
+    <valid_values>none,never,nsteps,nseconds,nminutes,nhours,ndays,nmonths,nyears,date,end</valid_values>
     <default_value>$STOP_OPTION</default_value>
     <group>run_begin_stop_restart</group>
     <file>env_run.xml</file>
@@ -404,7 +404,7 @@
 
   <entry id="PAUSE_OPTION">
     <type>char</type>
-    <valid_values>none,never,nsteps,nstep,nseconds,nsecond,nminutes,nminute,nhours,nhour,ndays,nday,nmonths,nmonth,nyears,nyear</valid_values>
+    <valid_values>none,never,nsteps,nseconds,nminutes,nhours,ndays,nmonths,nyears</valid_values>
     <default_value>never</default_value>
     <group>run_begin_stop_restart</group>
     <file>env_run.xml</file>

--- a/cime_config/config_component_cesm.xml
+++ b/cime_config/config_component_cesm.xml
@@ -422,11 +422,11 @@
     <group>run_coupling</group>
     <file>env_run.xml</file>
     <desc>
-      OPTION1 (like RASM_OPTION1 in CPL7) runs prep_ocn_avg, 
+      OPTION1 (like RASM_OPTION1 in CPL7) runs prep_ocn_avg,
       BEFORE the aoflux and ocnalb calculations, thereby reducing
       most of the lags and field inconsistency but still allowing the
       ocean to run concurrently with the ice and atmosphere.
-      OPTION2 (like CESM1_MOD in CPL7) runs prep_ocn_avg, 
+      OPTION2 (like CESM1_MOD in CPL7) runs prep_ocn_avg,
       AFTER the aoflux and ocnalb calculations, thereby permitting maximum
       concurrency
       TIGHT (like CESM1_MOD_TIGHT), is a tight coupling run sequence
@@ -439,7 +439,7 @@
 
   <entry id="HIST_OPTION">
     <type>char</type>
-    <valid_values>none,never,nsteps,nstep,nseconds,nsecond,nminutes,nminute,nhours,nhour,ndays,nday,nmonths,nmonth,nyears,nyear,date,ifdays0,end</valid_values>
+    <valid_values>none,never,nsteps,nseconds,nminutes,nhours,ndays,nmonths,nyears,date,end</valid_values>
     <default_value>never</default_value>
     <group>med_history</group>
     <file>env_run.xml</file>
@@ -468,7 +468,7 @@
 
   <entry id="AVGHIST_OPTION">
     <type>char</type>
-    <valid_values>none,never,nsteps,nstep,nseconds,nsecond,nminutes,nminute,nhours,nhour,ndays,nday,nmonths,nmonth,nyears,nyear,date,ifdays0,end</valid_values>
+    <valid_values>none,never,nsteps,nseconds,nminutes,nhours,ndays,nmonths,nyears,date,end</valid_values>
     <default_value>never</default_value>
     <values match="last">
       <value compset="_DOCN%IAF">nmonths</value>

--- a/cime_config/namelist_definition_drv.xml
+++ b/cime_config/namelist_definition_drv.xml
@@ -1072,23 +1072,22 @@
     <type>char</type>
     <category>time</category>
     <group>ALLCOMP_attributes</group>
-    <valid_values>none,never,nsteps,nstep,nseconds,nsecond,nminutes,nminute,nhours,nhour,ndays,nday,monthly,nmonths,nmonth,nyears,nyear,date,ifdays0,end</valid_values>
+    <valid_values>none,never,nsteps,nseconds,nminutes,nhours,ndays,nmonths,nyears,monthly,yearly,date,end</valid_values>
     <desc>
       mediator history snapshot option (used with history_n and history_ymd)
       set by HIST_OPTION in env_run.xml.
       history_option alarms are:
       [none/never], turns option off
-      [nstep/s]   , history snapshot every history_n nsteps  , relative to current run start time
-      [nsecond/s] , history snapshot every history_n nseconds, relative to current run start time
-      [nminute/s] , history snapshot every history_n nminutes, relative to current run start time
-      [nhour/s]   , history snapshot every history_n nhours  , relative to current run start time
-      [nday/s]    , history snapshot every history_n ndays   , relative to current run start time
-      [monthly/s] , history snapshot every           month   , relative to current run start time
-      [nmonth/s]  , history snapshot every history_n nmonths , relative to current run start time
-      [nyear/s]   , history snapshot every history_n nyears  , relative to current run start time
-      [date]      , history snapshot at history_ymd value
-      [ifdays0]   , history snapshot at history_n calendar day value and seconds equal 0
-      [end]       , history snapshot at end
+      [nsteps]   , history snapshot every history_n nsteps  , relative to current run start time
+      [nseconds] , history snapshot every history_n nseconds, relative to current run start time
+      [nminutes] , history snapshot every history_n nminutes, relative to current run start time
+      [nhours]   , history snapshot every history_n nhours  , relative to current run start time
+      [ndays]    , history snapshot every history_n ndays   , relative to current run start time
+      [monthly]  , history snapshot every           month   , relative to current run start time
+      [nmonths]  , history snapshot every history_n nmonths , relative to current run start time
+      [nyears]   , history snapshot every history_n nyears  , relative to current run start time
+      [date]     , history snapshot at history_ymd value
+      [end]      , history snapshot at end
     </desc>
     <values>
       <value>$HIST_OPTION</value>
@@ -1129,7 +1128,7 @@
     <type>char</type>
     <category>time</category>
     <group>MED_attributes</group>
-    <valid_values>none,never,nsteps,nstep,nseconds,nsecond,nminutes,nminute,nhours,nhour,ndays,nday,monthly,nmonths,nmonth,nyears,nyear,date,ifdays0,end</valid_values>
+    <valid_values>none,never,nsteps,nseconds,nminutes,nhours,ndays,nmonths,nyears,monthly,yearly,date,end</valid_values>
     <desc>
       mediator history for mediator aoflux and oceean albedoes (used with history_n and history_ymd)
     </desc>
@@ -1157,7 +1156,7 @@
     <type>char</type>
     <category>time</category>
     <group>MED_attributes</group>
-    <valid_values>none,never,nsteps,nstep,nseconds,nsecond,nminutes,nminute,nhours,nhour,ndays,nday,monthly,nmonths,nmonth,nyears,nyear,date,ifdays0,end</valid_values>
+    <valid_values>none,never,nsteps,nseconds,nminutes,nhours,ndays,nmonths,nyears,monthly,yearly,date,end</valid_values>
     <desc>
       mediator history for atm import/export/fields snapshot option (used with history_n and history_ymd)
     </desc>
@@ -1180,7 +1179,7 @@
     <type>char</type>
     <category>time</category>
     <group>MED_attributes</group>
-    <valid_values>none,never,nsteps,nstep,nseconds,nsecond,nminutes,nminute,nhours,nhour,ndays,nday,monthly,nmonths,nmonth,nyears,nyear,date,ifdays0,end</valid_values>
+    <valid_values>none,never,nsteps,nseconds,nminutes,nhours,ndays,nmonths,nyears,monthly,yearly,date,end</valid_values>
     <desc>
       mediator time average history option (used with histavg_n and histavg_ymd)
     </desc>
@@ -1539,7 +1538,7 @@
     <type>char</type>
     <category>time</category>
     <group>MED_attributes</group>
-    <valid_values>none,never,nsteps,nstep,nseconds,nsecond,nminutes,nminute,nhours,nhour,ndays,nday,monthly,nmonths,nmonth,nyears,nyear,date,ifdays0,end</valid_values>
+    <valid_values>none,never,nsteps,nseconds,nminutes,nhours,ndays,nmonths,nyears,monthly,yearly,date,end</valid_values>
     <desc>
       mediator history for ice import/export/fields snapshot option (used with history_n and history_ymd)
     </desc>
@@ -1562,7 +1561,7 @@
     <type>char</type>
     <category>time</category>
     <group>MED_attributes</group>
-    <valid_values>none,never,nsteps,nstep,nseconds,nsecond,nminutes,nminute,nhours,nhour,ndays,nday,monthly,nmonths,nmonth,nyears,nyear,date,ifdays0,end</valid_values>
+    <valid_values>none,never,nsteps,nseconds,nminutes,nhours,ndays,nmonths,nyears,monthly,yearly,date,end</valid_values>
     <desc>
       mediator time average history option (used with histavg_n and histavg_ymd)
     </desc>
@@ -1590,7 +1589,7 @@
     <type>char</type>
     <category>time</category>
     <group>MED_attributes</group>
-    <valid_values>none,never,nsteps,nstep,nseconds,nsecond,nminutes,nminute,nhours,nhour,ndays,nday,monthly,nmonths,nmonth,nyears,nyear,date,ifdays0,end</valid_values>
+    <valid_values>none,never,nsteps,nseconds,nminutes,nhours,ndays,nmonths,nyears,monthly,yearly,date,end</valid_values>
     <desc>
       mediator history for glc import/export/fields snapshot option (used with history_n and history_ymd)
     </desc>
@@ -1613,7 +1612,7 @@
     <type>char</type>
     <category>time</category>
     <group>MED_attributes</group>
-    <valid_values>none,never,nsteps,nstep,nseconds,nsecond,nminutes,nminute,nhours,nhour,ndays,nday,monthly,nmonths,nmonth,nyears,nyear,date,ifdays0,end</valid_values>
+    <valid_values>none,never,nsteps,nseconds,nminutes,nhours,ndays,nmonths,nyears,monthly,yearly,date,end</valid_values>
     <desc>
       mediator time average history option (used with histavg_n and histavg_ymd)
     </desc>
@@ -1641,7 +1640,7 @@
     <type>char</type>
     <category>time</category>
     <group>MED_attributes</group>
-    <valid_values>none,never,nsteps,nstep,nseconds,nsecond,nminutes,nminute,nhours,nhour,ndays,nday,monthly,nmonths,nmonth,nyears,nyear,date,ifdays0,end</valid_values>
+    <valid_values>none,never,nsteps,nseconds,nminutes,nhours,ndays,nmonths,nyears,monthly,yearly,date,end</valid_values>
     <desc>
       mediator history for lnd import/export/fields snapshot option (used with history_n and history_ymd)
     </desc>
@@ -1664,7 +1663,7 @@
     <type>char</type>
     <category>time</category>
     <group>MED_attributes</group>
-    <valid_values>none,never,nsteps,nstep,nseconds,nsecond,nminutes,nminute,nhours,nhour,ndays,nday,monthly,nmonths,nmonth,nyears,nyear,date,ifdays0,end</valid_values>
+    <valid_values>none,never,nsteps,nseconds,nminutes,nhours,ndays,nmonths,nyears,monthly,yearly,date,end</valid_values>
     <desc>
       mediator time average history option (used with histavg_n and histavg_ymd)
     </desc>
@@ -1770,7 +1769,7 @@
     <type>char</type>
     <category>time</category>
     <group>MED_attributes</group>
-    <valid_values>none,never,nsteps,nstep,nseconds,nsecond,nminutes,nminute,nhours,nhour,ndays,nday,monthly,nmonths,nmonth,nyears,nyear,date,ifdays0,end</valid_values>
+    <valid_values>none,never,nsteps,nseconds,nminutes,nhours,ndays,nmonths,nyears,monthly,yearly,date,end</valid_values>
     <desc>
       mediator history for ocn import/export/fields snapshot option (used with history_n and history_ymd)
     </desc>
@@ -1793,7 +1792,7 @@
     <type>char</type>
     <category>time</category>
     <group>MED_attributes</group>
-    <valid_values>none,never,nsteps,nstep,nseconds,nsecond,nminutes,nminute,nhours,nhour,ndays,nday,monthly,nmonths,nmonth,nyears,nyear,date,ifdays0,end</valid_values>
+    <valid_values>none,never,nsteps,nseconds,nminutes,nhours,ndays,nmonths,nyears,monthly,yearly,date,end</valid_values>
     <desc>
       mediator time average history option (used with histavg_n and histavg_ymd)
     </desc>
@@ -1821,7 +1820,7 @@
     <type>char</type>
     <category>time</category>
     <group>MED_attributes</group>
-    <valid_values>none,never,nsteps,nstep,nseconds,nsecond,nminutes,nminute,nhours,nhour,ndays,nday,monthly,nmonths,nmonth,nyears,nyear,date,ifdays0,end</valid_values>
+    <valid_values>none,never,nsteps,nseconds,nminutes,nhours,ndays,nmonths,nyears,monthly,yearly,date,end</valid_values>
     <desc>
       mediator history for rof import/export/fields snapshot option (used with history_n and history_ymd)
     </desc>
@@ -1844,7 +1843,7 @@
     <type>char</type>
     <category>time</category>
     <group>MED_attributes</group>
-    <valid_values>none,never,nsteps,nstep,nseconds,nsecond,nminutes,nminute,nhours,nhour,ndays,nday,monthly,nmonths,nmonth,nyears,nyear,date,ifdays0,end</valid_values>
+    <valid_values>none,never,nsteps,nseconds,nminutes,nhours,ndays,nmonths,nyears,monthly,yearly,date,end</valid_values>
     <desc>
       mediator time average history option (used with histavg_n and histavg_ymd)
     </desc>
@@ -1937,7 +1936,7 @@
     <type>char</type>
     <category>time</category>
     <group>MED_attributes</group>
-    <valid_values>none,never,nsteps,nstep,nseconds,nsecond,nminutes,nminute,nhours,nhour,ndays,nday,monthly,nmonths,nmonth,nyears,nyear,date,ifdays0,end</valid_values>
+    <valid_values>none,never,nsteps,nseconds,nminutes,nhours,ndays,nmonths,nyears,monthly,yearly,date,end</valid_values>
     <desc>
       mediator history for wav import/export/fields snapshot option (used with history_n and history_ymd)
     </desc>
@@ -1960,7 +1959,7 @@
     <type>char</type>
     <category>time</category>
     <group>MED_attributes</group>
-    <valid_values>none,never,nsteps,nstep,nseconds,nsecond,nminutes,nminute,nhours,nhour,ndays,nday,monthly,nmonths,nmonth,nyears,nyear,date,ifdays0,end</valid_values>
+    <valid_values>none,never,nsteps,nseconds,nminutes,nhours,ndays,nmonths,nyears,monthly,yearly,date,end</valid_values>
     <desc>
       mediator time average history option (used with histavg_n and histavg_ymd)
     </desc>
@@ -2590,22 +2589,22 @@
     <type>char</type>
     <category>time</category>
     <group>CLOCK_attributes</group>
-    <valid_values>none,never,nsteps,nstep,nseconds,nsecond,nminutes,nminute,nhours,nhour,ndays,nday,monthly,nmonths,nmonth,nyears,nyear,date,ifdays0,end</valid_values>
+    <valid_values>none,never,nsteps,nseconds,nminutes,nhours,ndays,monthly,nmonths,nyears,date,end</valid_values>
     <desc>
       sets the run length with stop_n and stop_ymd
       stop_option alarms are:
-      [none/never], turns option off
-      [nstep/s]   , stops every stop_n nsteps  , relative to current run start time
-      [nsecond/s] , stops every stop_n nseconds, relative to current run start time
-      [nminute/s] , stops every stop_n nminutes, relative to current run start time
-      [nhour/s]   , stops every stop_n nhours  , relative to current run start time
-      [nday/s]    , stops every stop_n ndays   , relative to current run start time
-      [nmonth/s]  , stops every stop_n nmonths , relative to current run start time
-      [monthly/s] , stops every        month   , relative to current run start time
-      [nyear/s]   , stops every stop_n nyears  , relative to current run start time
-      [date]      , stops at stop_ymd value
-      [ifdays0]   , stops at stop_n calendar day value and seconds equal 0
-      [end]       , stops at end
+      [none/never] , turns option off
+      [nsteps]     , stops every stop_n nsteps  , relative to current run start time
+      [nseconds]   , stops every stop_n nseconds, relative to current run start time
+      [nminutes]   , stops every stop_n nminutes, relative to current run start time
+      [nhours]     , stops every stop_n nhours  , relative to current run start time
+      [ndays]      , stops every stop_n ndays   , relative to current run start time
+      [nmonths]    , stops every stop_n nmonths , relative to current run start time
+      [nyears]     , stops every stop_n nyears  , relative to current run start time
+      [monthly]    , stops every        month   , relative to current run start time
+      [yearly]     , stops every        year    , relative to current run start time
+      [end]        , stops at end
+      [date]       , stops at stop_ymd value
     </desc>
     <values>
       <value>$STOP_OPTION</value>
@@ -2654,22 +2653,22 @@
     <type>char</type>
     <category>time</category>
     <group>CLOCK_attributes</group>
-    <valid_values>none,never,nsteps,nstep,nseconds,nsecond,nminutes,nminute,nhours,nhour,ndays,nday,nmonths,monthly,nmonth,nyears,nyear,date,ifdays0,end</valid_values>
+    <valid_values>none,never,nsteps,nseconds,nminutes,nhours,ndays,nmonths,nyears,monthly,yearly,date,end</valid_values>
     <desc>
       sets the restart frequency with restart_n and restart_ymd
       restart_option alarms are:
       [none/never], turns option off
-      [nstep/s]   , restarts every restart_n nsteps  , relative to current run start time
-      [nsecond/s] , restarts every restart_n nseconds, relative to current run start time
-      [nminute/s] , restarts every restart_n nminutes, relative to current run start time
-      [nhour/s]   , restarts every restart_n nhours  , relative to current run start time
-      [nday/s]    , restarts every restart_n ndays   , relative to current run start time
-      [monthly/s] , restarts every           month   , relative to current run start time
-      [nmonth/s]  , restarts every restart_n nmonths , relative to current run start time
-      [nyear/s]   , restarts every restart_n nyears  , relative to current run start time
-      [date]      , restarts at restart_ymd value
-      [ifdays0]   , restarts at restart_n calendar day value and seconds equal 0
-      [end]       , restarts at end
+      [nsteps]   , restarts every restart_n nsteps  , relative to current run start time
+      [nseconds] , restarts every restart_n nseconds, relative to current run start time
+      [nminutes] , restarts every restart_n nminutes, relative to current run start time
+      [nhours]   , restarts every restart_n nhours  , relative to current run start time
+      [ndays]    , restarts every restart_n ndays   , relative to current run start time
+      [nmonths]  , restarts every restart_n nmonths , relative to current run start time
+      [nyears]   , restarts every restart_n nyears  , relative to current run start time
+      [monthly]  , restarts every           month   , relative to current run start time
+      [yearly]   , restarts every           year    , relative to current run start time
+      [date]     , restarts at restart_ymd value
+      [end]      , restarts at end
     </desc>
     <values>
       <value>$REST_OPTION</value>
@@ -2721,22 +2720,22 @@
     <type>char</type>
     <category>time</category>
     <group>CLOCK_attributes</group>
-    <valid_values>none,never,nsteps,nstep,nseconds,nsecond,nminutes,nminute,nhours,nhour,ndays,nday,monthly,nmonths,nmonth,nyears,nyear,date,ifdays0,end</valid_values>
+    <valid_values>none,never,nsteps,nseconds,nminutes,nhours,ndays,nmonths,nyears,monthly,yearly,date,end</valid_values>
     <desc>
       Sets timing output file frequency (like rest_option but relative to run start date)
       tprof_option alarms are:
       [none/never], turns option off
-      [nstep/s]   , every tprof_n nsteps  , relative to current run start time
-      [nsecond/s] , every tprof_n nseconds, relative to current run start time
-      [nminute/s] , every tprof_n nminutes, relative to current run start time
-      [nhour/s]   , every tprof_n nhours  , relative to current run start time
-      [nday/s]    , every tprof_n ndays   , relative to current run start time
-      [monthly/s] , every         month   , relative to current run start time
-      [nmonth/s]  , every tprof_n nmonths , relative to current run start time
-      [nyear/s]   , every tprof_n nyears  , relative to current run start time
-      [date]      , at tprof_ymd value
-      [ifdays0]   , at tprof_n calendar day value and seconds equal 0
-      [end]       , at end
+      [nsteps]   , every tprof_n nsteps  , relative to current run start time
+      [nseconds] , every tprof_n nseconds, relative to current run start time
+      [nminutes] , every tprof_n nminutes, relative to current run start time
+      [nhours]   , every tprof_n nhours  , relative to current run start time
+      [ndays]    , every tprof_n ndays   , relative to current run start time
+      [nmonths]  , every tprof_n nmonths , relative to current run start time
+      [nyears]   , every tprof_n nyears  , relative to current run start time
+      [monthly]  , every         month   , relative to current run start time
+      [yearly]   , every         year    , relative to current run start time
+      [date]     , at tprof_ymd value
+      [end]      , at end
     </desc>
     <values>
       <value>never</value>
@@ -2771,19 +2770,19 @@
   <!--   <type>char</type> -->
   <!--   <category>time</category> -->
   <!--   <group>CLOCK_attributes</group> -->
-  <!--   <valid_values>none,never,nsteps,nstep,nseconds,nsecond,nminutes,nminute,nhours,nhour,ndays,nday,monthly,nmonths,nmonth,nyears,nyear</valid_values> -->
+  <!--   <valid_values>none,never,nsteps,nseconds,nminutes,nhours,ndays,monthly,nmonths,nyears</valid_values> -->
   <!--   <desc> -->
   <!--     sets the pause frequency with pause_n -->
   <!--     pause_option alarms are: -->
   <!--     [none/never], turns option off -->
-  <!--     [nstep/s]   , pauses every pause_n nsteps  , relative to start or last pause time -->
-  <!--     [nsecond/s] , pauses every pause_n nseconds, relative to start or last pause time -->
-  <!--     [nminute/s] , pauses every pause_n nminutes, relative to start or last pause time -->
-  <!--     [nhour/s]   , pauses every pause_n nhours  , relative to start or last pause time -->
-  <!--     [nday/s]    , pauses every pause_n ndays   , relative to start or last pause time -->
-  <!--     [nmonth/s]  , pauses every pause_n nmonths , relative to start or last pause time -->
-  <!--     [monthly/s] , pauses every        month    , relative to start or last pause time -->
-  <!--     [nyear/s]   , pauses every pause_n nyears  , relative to start or last pause time -->
+  <!--     [nsteps]   , pauses every pause_n nsteps  , relative to start or last pause time -->
+  <!--     [nseconds] , pauses every pause_n nseconds, relative to start or last pause time -->
+  <!--     [nminutes] , pauses every pause_n nminutes, relative to start or last pause time -->
+  <!--     [nhours]   , pauses every pause_n nhours  , relative to start or last pause time -->
+  <!--     [ndays]    , pauses every pause_n ndays   , relative to start or last pause time -->
+  <!--     [nmonths]  , pauses every pause_n nmonths , relative to start or last pause time -->
+  <!--     [monthly]  , pauses every        month    , relative to start or last pause time -->
+  <!--     [nyear]    , pauses every pause_n nyears  , relative to start or last pause time -->
   <!--   </desc> -->
   <!--   <values> -->
   <!--     <value>$PAUSE_OPTION</value> -->


### PR DESCRIPTION
### Description of changes
simplify specification of stop_option, rest_option and hist_option

### Specific notes
This PR addresses issue #311 
Only the following values are now allowed
`none,never,nsteps,nseconds,nminutes,nhours,ndays,nmonths,nyears,date,end`

Contributors other than yourself, if any: None

CMEPS Issues Fixed: #311 

Are changes expected to change answers? bfb

Any User Interface Changes (namelist or namelist defaults changes)? None

### Testing performed
Verified that SMS_Ln9.f19_g17.A.cheyenne_intel if HIST_OPTION is 'nstep', preview_namelist_fails

### Hashes used for testing:

- [x] CESM:
  - repository to check out: https://github.com/ESCOMP/CESM.git
  - tag: cesm2_3_beta09

