### PR TITLE
was not working when atm and lnd did not share all tasks

### DIFF
--- a/cesm/driver/esm_time_mod.F90
+++ b/cesm/driver/esm_time_mod.F90
@@ -522,7 +522,7 @@ contains
       if (ChkErr(rc,__LINE__,u_FILE_u)) return
       update_nextalarm  = .true.
 
-   case (optNYears)
+   case (optNYears, trim(optNYears)//'s')
       call ESMF_TimeIntervalSet(AlarmInterval, yy=1, rc=rc)
       if (ChkErr(rc,__LINE__,u_FILE_u)) return
       AlarmInterval = AlarmInterval * opt_n

--- a/cesm/nuopc_cap_share/shr_drydep_mod.F90
+++ b/cesm/nuopc_cap_share/shr_drydep_mod.F90
@@ -6,15 +6,17 @@ module shr_drydep_mod
   ! dry deposition of tracers
   !========================================================================
 
-  use ESMF           , only : ESMF_VMGetCurrent, ESMF_VM, ESMF_VMGet
+  use ESMF           , only : ESMF_VMGetCurrent, ESMF_VM, ESMF_VMGet, ESMF_LOGMSG_INFO
   use ESMF           , only : ESMF_LogFoundError, ESMF_LOGERR_PASSTHRU, ESMF_SUCCESS
+  use ESMF           , only : ESMF_LogWrite, ESMF_VMBroadCast
   use shr_sys_mod    , only : shr_sys_abort
   use shr_kind_mod   , only : r8 => shr_kind_r8, CS => SHR_KIND_CS, CX => SHR_KIND_CX
   use shr_const_mod  , only : SHR_CONST_MWWV
-  use shr_mpi_mod    , only : shr_mpi_bcast
   use shr_nl_mod     , only : shr_nl_find_group_name
   use shr_log_mod    , only : s_logunit => shr_log_Unit
+  use shr_file_mod   , only : shr_file_getLogUnit
   use shr_infnan_mod , only : shr_infnan_posinf, assignment(=)
+  use nuopc_shr_methods, only : chkerr
 
   implicit none
   private
@@ -31,8 +33,6 @@ module shr_drydep_mod
   integer, private, parameter :: NSeas = 5                 ! Number of seasons
   integer, public,  parameter :: NLUse = 11                ! Number of land-use types
   integer, private, protected :: NHen
-
-  logical, private :: drydep_initialized = .false.
 
   ! public data members:
 
@@ -222,12 +222,15 @@ module shr_drydep_mod
   character(len=16), public, protected, allocatable :: species_name_table(:)
 
   !--- data for effective Henry's Law coefficient ---
-  real(r8), public, protected, allocatable :: dheff(:,:)
+  real(r8), public, protected, allocatable, target :: dheff(:,:)
 
   real(r8), private, parameter :: wh2o = SHR_CONST_MWWV
   real(r8), allocatable :: mol_wgts(:)
 
   character(len=500) :: dep_data_file = 'NONE' ! complete file path
+  character(len=*), parameter :: u_FILE_u = &
+       __FILE__
+
 
 !===============================================================================
 CONTAINS
@@ -263,6 +266,7 @@ CONTAINS
     ! Read namelist and figure out the drydep field list to pass
     ! First check if file exists and if not, n_drydep will be zero
     !-----------------------------------------------------------------------------
+    call ESMF_LogWrite(subname//' start', ESMF_LOGMSG_INFO)
 
     rc = ESMF_SUCCESS
 
@@ -274,10 +278,11 @@ CONTAINS
     call ESMF_VMGetCurrent(vm, rc=rc)
     if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) return
 
-    call ESMF_VMGet(vm, localPet=localPet, mpiCommunicator=mpicom, rc=rc)
+    call ESMF_VMGet(vm, localPet=localPet, rc=rc)
     if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) return
 
     if (localPet==0) then
+       call shr_file_getLogUnit(s_logunit)
        inquire( file=trim(NLFileName), exist=exists)
        if ( exists ) then
           open(newunit=unitn, file=trim(NLFilename), status='old' )
@@ -293,8 +298,10 @@ CONTAINS
           close( unitn )
        end if
     end if
-    call shr_mpi_bcast( drydep_list, mpicom )
-    call shr_mpi_bcast( dep_data_file, mpicom )
+    call ESMF_LogWrite(subname//' bcast drydep_list', ESMF_LOGMSG_INFO)
+    call ESMF_VMBroadcast(vm,  drydep_list, maxspc*32, 0)
+    call ESMF_LogWrite(subname//' bcast dep_data_file', ESMF_LOGMSG_INFO)
+    call ESMF_VMBroadcast(vm,  dep_data_file, 500, 0)
 
     drydep_nflds = 0
 
@@ -314,25 +321,22 @@ CONTAINS
           write(s_logunit,FI1) 'Number of dry deposition fields transfered is ', drydep_nflds
        end if
     end if
-
-    if (.not. drydep_initialized) then
-       call shr_drydep_init()
-    end if
+    call shr_drydep_init()
+    call ESMF_LogWrite(subname//' done', ESMF_LOGMSG_INFO)
 
   end subroutine shr_drydep_readnl
 
 !====================================================================================
 
   subroutine shr_drydep_init( )
-
-    use shr_pio_mod,  only: shr_pio_getiosys, shr_pio_getiotype
-    use pio
     use netcdf
 
     !========================================================================
     ! Initialization of dry deposition fields
     ! reads drydep_inparm namelist and sets up CCSM driver list of fields for
     ! land-atmosphere communications.
+    ! This is called by both lnd and atm - we need to do this in order to 
+    ! allow for these components to run on disjoint sets of tasks 
     !========================================================================
 
     !----- local -----
@@ -342,26 +346,27 @@ CONTAINS
     type(ESMF_VM) :: vm
     integer       :: localPet
     integer       :: mpicom
+    integer       :: bint(2)
+    real(kind=r8), pointer :: dptr(:)
     integer       :: rc
+    logical, save :: drydep_initialized=.false.
+    character(len=256) :: msg
 
     !----- formats -----
     character(*),parameter :: subName = '(shr_drydep_init) '
     character(*),parameter :: F00   = "('(shr_drydep_init) ',8a)"
 
-    !-----------------------------------------------------------------------------
-    ! Return if this routine has already been called (e.g. cam and clm both call this)
-    !-----------------------------------------------------------------------------
-    if(allocated(foxd)) return
+    call ESMF_LogWrite(subname//' start', ESMF_LOGMSG_INFO)
 
     if (dep_data_file=='NONE' .or. len_trim(dep_data_file)==0) return
 
     rc = ESMF_SUCCESS
 
     call ESMF_VMGetCurrent(vm, rc=rc)
-    if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) return
+    if (chkerr(rc,__LINE__,u_FILE_u)) return
 
     call ESMF_VMGet(vm, localPet=localPet, mpiCommunicator=mpicom, rc=rc)
-    if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) return
+    if (chkerr(rc,__LINE__,u_FILE_u)) return
 
     rc = nf90_noerr
 
@@ -372,23 +377,29 @@ CONTAINS
        rc = nf90_inq_dimid(fileid,'n_species_table',dimid)
        if (rc/=nf90_noerr) call shr_sys_abort(subName//' ERROR: nf90_inq_dimid n_species_table')
 
-       rc = nf90_inquire_dimension(fileid,dimid,len=n_species_table)
+       rc = nf90_inquire_dimension(fileid,dimid,len=bint(1))
        if (rc/=nf90_noerr) call shr_sys_abort(subName//' ERROR: nf90_inquire_dimension n_species_table')
 
        rc = nf90_inq_dimid(fileid,'NHen',dimid)
        if (rc/=nf90_noerr) call shr_sys_abort(subName//' ERROR: nf90_inq_dimid NHen')
 
-       rc = nf90_inquire_dimension(fileid,dimid,len=nHen)
+       rc = nf90_inquire_dimension(fileid,dimid,len=bint(2))
        if (rc/=nf90_noerr) call shr_sys_abort(subName//' ERROR: nf90_inquire_dimension nHen')
     endif
-    call shr_mpi_bcast( n_species_table, mpicom )
-    call shr_mpi_bcast( nHen, mpicom )
-
-    allocate( mol_wgts(n_species_table) )
-    allocate( dfoxd(n_species_table) )
-    allocate( species_name_table(n_species_table) )
-    allocate( dheff(nhen,n_species_table))
-
+    write(msg,*) subname//' bcast n_species_table', localPet, bint
+    call ESMF_LogWrite(msg, ESMF_LOGMSG_INFO)
+    call ESMF_VMBroadcast(vm,  bint, 2, 0, rc=rc )
+    if (chkerr(rc,__LINE__,u_FILE_u)) return
+    n_species_table = bint(1)
+    nHen = bint(2)
+    write(msg,*) subname//' after bcast n_species_table', n_species_table, nhen
+    call ESMF_LogWrite(msg, ESMF_LOGMSG_INFO)
+    if(.not. allocated(mol_wgts))           allocate( mol_wgts(n_species_table) )
+    if(.not. allocated(dfoxd))              allocate( dfoxd(n_species_table) )
+    if(.not. allocated(species_name_table)) allocate( species_name_table(n_species_table) )
+    if(.not. allocated(dheff))              allocate( dheff(nhen,n_species_table))
+    ! This pointer is needed for ESMF_VMBroadcast
+    dptr => dheff(:,1)
     if (localPet==0) then
        rc = nf90_inq_varid(fileid,'mol_wghts',varid)
        if (rc/=nf90_noerr) call shr_sys_abort(subName//' ERROR: nf90_inq_varid mol_wghts')
@@ -413,141 +424,147 @@ CONTAINS
        rc = nf90_close(fileid)
        if (rc/=nf90_noerr) call shr_sys_abort(subName//' ERROR: nf90_close')
     end if
-    call shr_mpi_bcast( mol_wgts, mpicom )
-    call shr_mpi_bcast( dfoxd, mpicom )
-    call shr_mpi_bcast( species_name_table, mpicom )
-    call shr_mpi_bcast( dheff, mpicom )
+    call ESMF_LogWrite(subname//' bcast mol_wgts', ESMF_LOGMSG_INFO)
+    call ESMF_VMBroadcast(vm,  mol_wgts, n_species_table, 0, rc=rc )
+    if (chkerr(rc,__LINE__,u_FILE_u)) return
+    call ESMF_LogWrite(subname//' bcast dfoxd', ESMF_LOGMSG_INFO)
+    call ESMF_VMBroadcast(vm,  dfoxd, n_species_table, 0, rc=rc )
+    if (chkerr(rc,__LINE__,u_FILE_u)) return
+    call ESMF_LogWrite(subname//' bcast species_name_table', ESMF_LOGMSG_INFO)
+    call ESMF_VMBroadcast(vm,  species_name_table, 16*n_species_table, 0, rc=rc )
+    if (chkerr(rc,__LINE__,u_FILE_u)) return
+    call ESMF_LogWrite(subname//' bcast dheff', ESMF_LOGMSG_INFO)
+    call ESMF_VMBroadcast(vm,  dptr, nhen*n_species_table, 0, rc=rc )
+    if (chkerr(rc,__LINE__,u_FILE_u)) return
 
     !-----------------------------------------------------------------------------
     ! Allocate and fill foxd, drat and mapping as well as species indices
     !-----------------------------------------------------------------------------
 
-    if ( n_drydep > 0 ) then
-
-       allocate( foxd(n_drydep) )
-       allocate( drat(n_drydep) )
-       allocate( mapping(n_drydep) )
-
-       ! This initializes these variables to infinity.
-       foxd = shr_infnan_posinf
-       drat = shr_infnan_posinf
-
-       mapping(:) = 0
-
-    end if
-
-    h2_ndx=-1; ch4_ndx=-1; co_ndx=-1; mpan_ndx = -1; pan_ndx = -1; so2_ndx=-1; o3_ndx=-1; xpan_ndx=-1
-
-    !--- Loop over drydep species that need to be worked with ---
-    do i=1,n_drydep
-       if ( len_trim(drydep_list(i))==0 ) exit
-
-       test_name = drydep_list(i)
-
-       if( trim(test_name) == 'O3' ) then
-          test_name = 'OX'
-       end if
-
-       !--- Figure out if species maps to a species in the species table ---
-       do l = 1,n_species_table
-          if(  trim( test_name ) == trim( species_name_table(l) ) ) then
-             mapping(i)  = l
-             exit
-          end if
-       end do
-
-       !--- If it doesn't map to a species in the species table find species close enough ---
-       if( mapping(i) < 1 ) then
-          select case( trim(test_name) )
-          case( 'O3S', 'O3INERT' )
-             test_name = 'OX'
-          case( 'Pb' )
-             test_name = 'HNO3'
-          case( 'SOGM','SOGI','SOGT','SOGB','SOGX' )
-             test_name = 'CH3OOH'
-          case( 'SOA', 'SO4', 'CB1', 'CB2', 'OC1', 'OC2', 'NH4', 'SA1', 'SA2', 'SA3', 'SA4' )
-             test_name = 'OX'  ! this is just a place holder. values are explicitly set below
-          case( 'SOAM', 'SOAI', 'SOAT', 'SOAB', 'SOAX' )
-             test_name = 'OX'  ! this is just a place holder. values are explicitly set below
-          case( 'SOAGbb0' )
-             test_name = 'SOAGff0'
-          case( 'SOAGbb1' )
-             test_name = 'SOAGff1'
-          case( 'SOAGbb2' )
-             test_name = 'SOAGff2'
-          case( 'SOAGbb3' )
-             test_name = 'SOAGff3'
-          case( 'SOAGbb4' )
-             test_name = 'SOAGff4'
-          case( 'O3A' )
-             test_name = 'OX'
-          case( 'XMPAN' )
-             test_name = 'MPAN'
-          case( 'XPAN' )
-             test_name = 'PAN'
-          case( 'XNO' )
-             test_name = 'NO'
-          case( 'XNO2' )
-             test_name = 'NO2'
-          case( 'XHNO3' )
-             test_name = 'HNO3'
-          case( 'XONIT' )
-             test_name = 'ONIT'
-          case( 'XONITR' )
-             test_name = 'ONITR'
-          case( 'XHO2NO2')
-             test_name = 'HO2NO2'
-          case( 'XNH4NO3' )
-             test_name = 'HNO3'
-          case( 'NH4NO3' )
-             test_name = 'HNO3'
-          case default
-             test_name = 'blank'
-          end select
-
-          !--- If found a match check the species table again ---
-          if( trim(test_name) /= 'blank' ) then
-             do l = 1,n_species_table
-                if( trim( test_name ) == trim( species_name_table(l) ) ) then
-                   mapping(i)  = l
-                   exit
-                end if
-             end do
-          else
-             write(s_logunit,F00) trim(drydep_list(i)),' not in tables; will have dep vel = 0'
-             call shr_sys_abort( subName//': '//trim(drydep_list(i))//' is not in tables' )
-          end if
-       end if
-
-       !--- Figure out the specific species indices ---
-       if ( trim(drydep_list(i)) == 'H2' )   h2_ndx   = i
-       if ( trim(drydep_list(i)) == 'CO' )   co_ndx   = i
-       if ( trim(drydep_list(i)) == 'CH4' )  ch4_ndx  = i
-       if ( trim(drydep_list(i)) == 'MPAN' ) mpan_ndx = i
-       if ( trim(drydep_list(i)) == 'PAN' )  pan_ndx  = i
-       if ( trim(drydep_list(i)) == 'SO2' )  so2_ndx  = i
-       if ( trim(drydep_list(i)) == 'OX' .or. trim(drydep_list(i)) == 'O3' ) o3_ndx  = i
-       if ( trim(drydep_list(i)) == 'O3A' ) o3a_ndx  = i
-       if ( trim(drydep_list(i)) == 'XPAN' ) xpan_ndx = i
-
-       if( mapping(i) > 0) then
-         l = mapping(i)
-         foxd(i) = dfoxd(l)
-         drat(i) = sqrt(mol_wgts(l)/wh2o)
+    if ( .not. drydep_initialized ) then
+       if (n_drydep > 0) then
+          allocate( foxd(n_drydep) )
+          allocate( drat(n_drydep) )
+          allocate( mapping(n_drydep) )
+          
+          ! This initializes these variables to infinity.
+          foxd = shr_infnan_posinf
+          drat = shr_infnan_posinf
+          
+          mapping(:) = 0
        endif
 
-    enddo
+       h2_ndx=-1; ch4_ndx=-1; co_ndx=-1; mpan_ndx = -1; pan_ndx = -1; so2_ndx=-1; o3_ndx=-1; xpan_ndx=-1
 
-    where( rgss < 1._r8 )
-       rgss = 1._r8
-    endwhere
+       !--- Loop over drydep species that need to be worked with ---
+       do i=1,n_drydep
+          if ( len_trim(drydep_list(i))==0 ) exit
+          
+          test_name = drydep_list(i)
+          
+          if( trim(test_name) == 'O3' ) then
+             test_name = 'OX'
+          end if
+          
+          !--- Figure out if species maps to a species in the species table ---
+          do l = 1,n_species_table
+             if(  trim( test_name ) == trim( species_name_table(l) ) ) then
+                mapping(i)  = l
+                exit
+             end if
+          end do
+          
+          !--- If it doesn't map to a species in the species table find species close enough ---
+          if( mapping(i) < 1 ) then
+             select case( trim(test_name) )
+             case( 'O3S', 'O3INERT' )
+                test_name = 'OX'
+             case( 'Pb' )
+                test_name = 'HNO3'
+             case( 'SOGM','SOGI','SOGT','SOGB','SOGX' )
+                test_name = 'CH3OOH'
+             case( 'SOA', 'SO4', 'CB1', 'CB2', 'OC1', 'OC2', 'NH4', 'SA1', 'SA2', 'SA3', 'SA4' )
+                test_name = 'OX'  ! this is just a place holder. values are explicitly set below
+             case( 'SOAM', 'SOAI', 'SOAT', 'SOAB', 'SOAX' )
+                test_name = 'OX'  ! this is just a place holder. values are explicitly set below
+             case( 'SOAGbb0' )
+                test_name = 'SOAGff0'
+             case( 'SOAGbb1' )
+                test_name = 'SOAGff1'
+             case( 'SOAGbb2' )
+                test_name = 'SOAGff2'
+             case( 'SOAGbb3' )
+                test_name = 'SOAGff3'
+             case( 'SOAGbb4' )
+                test_name = 'SOAGff4'
+             case( 'O3A' )
+                test_name = 'OX'
+             case( 'XMPAN' )
+                test_name = 'MPAN'
+             case( 'XPAN' )
+                test_name = 'PAN'
+             case( 'XNO' )
+                test_name = 'NO'
+             case( 'XNO2' )
+                test_name = 'NO2'
+             case( 'XHNO3' )
+                test_name = 'HNO3'
+             case( 'XONIT' )
+                test_name = 'ONIT'
+             case( 'XONITR' )
+                test_name = 'ONITR'
+             case( 'XHO2NO2')
+                test_name = 'HO2NO2'
+             case( 'XNH4NO3' )
+                test_name = 'HNO3'
+             case( 'NH4NO3' )
+                test_name = 'HNO3'
+             case default
+                test_name = 'blank'
+             end select
+             
+             !--- If found a match check the species table again ---
+             if( trim(test_name) /= 'blank' ) then
+                do l = 1,n_species_table
+                   if( trim( test_name ) == trim( species_name_table(l) ) ) then
+                      mapping(i)  = l
+                      exit
+                   end if
+                end do
+             else
+                write(s_logunit,F00) trim(drydep_list(i)),' not in tables; will have dep vel = 0'
+                call shr_sys_abort( subName//': '//trim(drydep_list(i))//' is not in tables' )
+             end if
+          end if
 
-    where( rac < small_value)
-       rac = small_value
-    endwhere
+          !--- Figure out the specific species indices ---
+          if ( trim(drydep_list(i)) == 'H2' )   h2_ndx   = i
+          if ( trim(drydep_list(i)) == 'CO' )   co_ndx   = i
+          if ( trim(drydep_list(i)) == 'CH4' )  ch4_ndx  = i
+          if ( trim(drydep_list(i)) == 'MPAN' ) mpan_ndx = i
+          if ( trim(drydep_list(i)) == 'PAN' )  pan_ndx  = i
+          if ( trim(drydep_list(i)) == 'SO2' )  so2_ndx  = i
+          if ( trim(drydep_list(i)) == 'OX' .or. trim(drydep_list(i)) == 'O3' ) o3_ndx  = i
+          if ( trim(drydep_list(i)) == 'O3A' ) o3a_ndx  = i
+          if ( trim(drydep_list(i)) == 'XPAN' ) xpan_ndx = i
+          
+          if( mapping(i) > 0) then
+             l = mapping(i)
+             foxd(i) = dfoxd(l)
+             drat(i) = sqrt(mol_wgts(l)/wh2o)
+          endif
+          
+       enddo
 
+       where( rgss < 1._r8 )
+          rgss = 1._r8
+       endwhere
+
+       where( rac < small_value)
+          rac = small_value
+       endwhere
+    end if
     drydep_initialized = .true.
-
   end subroutine shr_drydep_init
 
 !====================================================================================

--- a/mediator/med_time_mod.F90
+++ b/mediator/med_time_mod.F90
@@ -28,13 +28,13 @@ module med_time_mod
   character(len=*), private, parameter :: &
        optNONE           = "none"      , &
        optNever          = "never"     , &
-       optNSteps         = "nsteps"    , &
-       optNSeconds       = "nseconds"  , &
-       optNMinutes       = "nminutes"  , &
-       optNHours         = "nhours"    , &
-       optNDays          = "ndays"     , &
-       optNMonths        = "nmonths"   , &
-       optNYears         = "nyears"    , &
+       optNSteps         = "nstep"    , &
+       optNSeconds       = "nsecond"  , &
+       optNMinutes       = "nminute"  , &
+       optNHours         = "nhour"    , &
+       optNDays          = "nday"     , &
+       optNMonths        = "nmonth"   , &
+       optNYears         = "nyear"    , &
        optMonthly        = "monthly"   , &
        optYearly         = "yearly"    , &
        optDate           = "date"      , &
@@ -127,13 +127,14 @@ contains
           rc = ESMF_FAILURE
           return
        end if
-    else if (trim(option) == optNSteps   .or. &
-             trim(option) == optNSeconds .or. &
-             trim(option) == optNMinutes .or. &
-             trim(option) == optNHours   .or. &
-             trim(option) == optNDays    .or. &
-             trim(option) == optNMonths  .or. &
-             trim(option) == optNYears) then
+    else if (&
+         trim(option) == optNSteps   .or. trim(option) == trim(optNSteps)//'s'   .or. &
+         trim(option) == optNSeconds .or. trim(option) == trim(optNSeconds)//'s' .or. &
+         trim(option) == optNMinutes .or. trim(option) == trim(optNMinutes)//'s' .or. &
+         trim(option) == optNHours   .or. trim(option) == trim(optNHours)//'s'   .or. &
+         trim(option) == optNDays    .or. trim(option) == trim(optNDays)//'s'    .or. &
+         trim(option) == optNMonths  .or. trim(option) == trim(optNMonths)//'s'  .or. &
+         trim(option) == optNYears   .or. trim(option) == trim(optNYears)//'s' ) then
        if (.not.present(opt_n)) then
           call ESMF_LogWrite(subname//trim(option)//' requires opt_n', ESMF_LOGMSG_ERROR)
           rc = ESMF_FAILURE
@@ -179,40 +180,40 @@ contains
       if (ChkErr(rc,__LINE__,u_FILE_u)) return
       update_nextalarm  = .false.
 
-    case (optNSteps)
-       call ESMF_ClockGet(clock, TimeStep=AlarmInterval, rc=rc)
-       if (ChkErr(rc,__LINE__,u_FILE_u)) return
-       AlarmInterval = AlarmInterval * opt_n
-       update_nextalarm  = .true.
+   case (optNSteps,trim(optNSteps)//'s')
+      call ESMF_ClockGet(clock, TimeStep=AlarmInterval, rc=rc)
+      if (ChkErr(rc,__LINE__,u_FILE_u)) return
+      AlarmInterval = AlarmInterval * opt_n
+      update_nextalarm  = .true.
 
-    case (optNSeconds)
-       call ESMF_TimeIntervalSet(AlarmInterval, s=1, rc=rc)
-       if (ChkErr(rc,__LINE__,u_FILE_u)) return
-       AlarmInterval = AlarmInterval * opt_n
-       update_nextalarm  = .true.
+   case (optNSeconds,trim(optNSeconds)//'s')
+      call ESMF_TimeIntervalSet(AlarmInterval, s=1, rc=rc)
+      if (ChkErr(rc,__LINE__,u_FILE_u)) return
+      AlarmInterval = AlarmInterval * opt_n
+      update_nextalarm  = .true.
 
-    case (optNMinutes)
-       call ESMF_TimeIntervalSet(AlarmInterval, s=60, rc=rc)
-       AlarmInterval = AlarmInterval * opt_n
-       update_nextalarm  = .true.
+   case (optNMinutes,trim(optNMinutes)//'s')
+      call ESMF_TimeIntervalSet(AlarmInterval, s=60, rc=rc)
+      AlarmInterval = AlarmInterval * opt_n
+      update_nextalarm  = .true.
 
-    case (optNHours)
-       call ESMF_TimeIntervalSet(AlarmInterval, s=3600, rc=rc)
-       if (ChkErr(rc,__LINE__,u_FILE_u)) return
-       AlarmInterval = AlarmInterval * opt_n
-       update_nextalarm  = .true.
+   case (optNHours,trim(optNHours)//'s')
+      call ESMF_TimeIntervalSet(AlarmInterval, s=3600, rc=rc)
+      if (ChkErr(rc,__LINE__,u_FILE_u)) return
+      AlarmInterval = AlarmInterval * opt_n
+      update_nextalarm  = .true.
 
-    case (optNDays)
-       call ESMF_TimeIntervalSet(AlarmInterval, d=1, rc=rc)
-       if (ChkErr(rc,__LINE__,u_FILE_u)) return
-       AlarmInterval = AlarmInterval * opt_n
-       update_nextalarm  = .true.
+   case (optNDays,trim(optNDays)//'s')
+      call ESMF_TimeIntervalSet(AlarmInterval, d=1, rc=rc)
+      if (ChkErr(rc,__LINE__,u_FILE_u)) return
+      AlarmInterval = AlarmInterval * opt_n
+      update_nextalarm  = .true.
 
-    case (optNMonths)
-       call ESMF_TimeIntervalSet(AlarmInterval, mm=1, rc=rc)
-       if (ChkErr(rc,__LINE__,u_FILE_u)) return
-       AlarmInterval = AlarmInterval * opt_n
-       update_nextalarm  = .true.
+   case (optNMonths,trim(optNMonths)//'s')
+      call ESMF_TimeIntervalSet(AlarmInterval, mm=1, rc=rc)
+      if (ChkErr(rc,__LINE__,u_FILE_u)) return
+      AlarmInterval = AlarmInterval * opt_n
+      update_nextalarm  = .true.
 
     case (optMonthly)
        call ESMF_TimeIntervalSet(AlarmInterval, mm=1, rc=rc)
@@ -221,7 +222,7 @@ contains
        if (ChkErr(rc,__LINE__,u_FILE_u)) return
        update_nextalarm  = .true.
 
-    case (optNYears)
+    case (optNYears, trim(optNYears)//'s')
        call ESMF_TimeIntervalSet(AlarmInterval, yy=1, rc=rc)
        if (ChkErr(rc,__LINE__,u_FILE_u)) return
        AlarmInterval = AlarmInterval * opt_n


### PR DESCRIPTION
### Description of changes
Replace shr_mpi_bcast with ESMF_VMBroadcast.   Was not working when lndroot .ne. atmroot.

### Specific notes
This change affects cesm only.

Contributors other than yourself, if any: Mariana

CMEPS Issues Fixed (include github issue #):

Are changes expected to change answers?  bfb

Any User Interface Changes (namelist or namelist defaults changes)?

### Testing performed
   
Testing performed if application target is CESM:
- [ ] (recommended) CIME_DRIVER=nuopc scripts_regression_tests.py
   - machines:
   - details (e.g. failed tests):
- [X] (recommended) CESM testlist_drv.xml
   - machines and compilers: cheyenne, intel 
   - details (e.g. failed tests):
- [ ] (optional) CESM prealpha test
   - machines and compilers
   - details (e.g. failed tests):
- [ ] (other) please described in detail
   - machines and compilers Testnames: ['ERS.ne30_g17.B1850.cheyenne_intel',   'ERS_Ln9.f19_f19_mg17.FHIST.cheyenne_intel.cam-outfrq9s']
   - details (e.g. failed tests): ALL PASS

Testing performed if application target is UFS-coupled:
- [ ] (recommended) UFS-coupled testing
   - description:
   - details (e.g. failed tests):

Testing performed if application target is UFS-HAFS:
- [ ] (recommended) UFS-HAFS testing
   - description:
   - details (e.g. failed tests):

### Hashes used for testing:

- [ ] CESM:
  - repository to check out: https://github.com/ESCOMP/CESM.git
  - branch/hash: alpha10b candidate
- [ ] UFS-coupled, then umbrella repostiory to check out and associated hash:
  - repository to check out:
  - branch/hash:
- [ ] UFS-HAFS, then umbrella repostiory to check out and associated hash:
  - repository to check out:
  - branch/hash:
