### PR TITLE
needed for using ESMF_AWARE_THREADING=TRUE

### DIFF
--- a/cesm/nuopc_cap_share/driver_pio_mod.F90
+++ b/cesm/nuopc_cap_share/driver_pio_mod.F90
@@ -226,13 +226,7 @@ contains
           if (chkerr(rc,__LINE__,u_FILE_u)) return
 
           if(comp_comm .ne. MPI_COMM_NULL) then
-             call ESMF_VMGet(vm, petCount=npets, rc=rc)
-             if (chkerr(rc,__LINE__,u_FILE_u)) return
-
-             call ESMF_VMGet(vm, localPet=comp_rank, rc=rc) 
-             if (chkerr(rc,__LINE__,u_FILE_u)) return
-
-             call ESMF_VMGet(vm, ssiLocalPetCount=default_stride, rc=rc)
+             call ESMF_VMGet(vm, petCount=npets, localPet=comp_rank, ssiLocalPetCount=default_stride, rc=rc)
              if (chkerr(rc,__LINE__,u_FILE_u)) return
           
              call NUOPC_CompAttributeGet(gcomp(i), name="pio_stride", value=cval, rc=rc)
@@ -254,7 +248,6 @@ contains
                 pio_comp_settings(i)%pio_numiotasks = max(1,npets/pio_comp_settings(i)%pio_stride)
              endif
 
-
              call NUOPC_CompAttributeGet(gcomp(i), name="pio_root", value=cval, rc=rc)
              if (chkerr(rc,__LINE__,u_FILE_u)) return
              read(cval, *) pio_comp_settings(i)%pio_root
@@ -262,7 +255,6 @@ contains
              if(pio_comp_settings(i)%pio_root < 0 .or. pio_comp_settings(i)%pio_root > npets) then
                 pio_comp_settings(i)%pio_root = 0
              endif
-          
           
              call NUOPC_CompAttributeGet(gcomp(i), name="pio_typename", value=cval, rc=rc)
              if (chkerr(rc,__LINE__,u_FILE_u)) return

--- a/cesm/nuopc_cap_share/driver_pio_mod.F90
+++ b/cesm/nuopc_cap_share/driver_pio_mod.F90
@@ -212,86 +212,97 @@ contains
        if (ESMF_GridCompIsPetLocal(gcomp(i), rc=rc)) then
           call ESMF_GridCompGet(gcomp(i), vm=vm, name=cval, rc=rc)
           if (chkerr(rc,__LINE__,u_FILE_u)) return
+          
           io_compname(i) = trim(cval)
-
+          
           call NUOPC_CompAttributeAdd(gcomp(i), attrList=(/'MCTID'/), rc=rc)
           if (chkerr(rc,__LINE__,u_FILE_u)) return
-
+          
           write(cval, *) io_compid(i)
           call NUOPC_CompAttributeSet(gcomp(i), name="MCTID", value=trim(cval), rc=rc)
           if (chkerr(rc,__LINE__,u_FILE_u)) return
 
-          call ESMF_VMGet(vm, mpiCommunicator=comp_comm, localPet=comp_rank, petCount=npets, &
-               ssiLocalPetCount=default_stride, rc=rc)
+          call ESMF_VMGet(vm, mpiCommunicator=comp_comm, rc=rc)
           if (chkerr(rc,__LINE__,u_FILE_u)) return
-          
-          call NUOPC_CompAttributeGet(gcomp(i), name="pio_stride", value=cval, rc=rc)
-          if (chkerr(rc,__LINE__,u_FILE_u)) return
-          read(cval, *) pio_comp_settings(i)%pio_stride
-          if(pio_comp_settings(i)%pio_stride <= 0 .or. pio_comp_settings(i)%pio_stride > npets) then
-             pio_comp_settings(i)%pio_stride = min(npets, default_stride)
-          endif
-          
-          call NUOPC_CompAttributeGet(gcomp(i), name="pio_rearranger", value=cval, rc=rc)
-          if (chkerr(rc,__LINE__,u_FILE_u)) return
-          read(cval, *) pio_comp_settings(i)%pio_rearranger
-          
-          call NUOPC_CompAttributeGet(gcomp(i), name="pio_numiotasks", value=cval, rc=rc)
-          if (chkerr(rc,__LINE__,u_FILE_u)) return
-          read(cval, *) pio_comp_settings(i)%pio_numiotasks
-          
-          if(pio_comp_settings(i)%pio_numiotasks < 0 .or. pio_comp_settings(i)%pio_numiotasks > npets) then
-             pio_comp_settings(i)%pio_numiotasks = max(1,npets/pio_comp_settings(i)%pio_stride)
-          endif
 
+          if(comp_comm .ne. MPI_COMM_NULL) then
+             call ESMF_VMGet(vm, petCount=npets, rc=rc)
+             if (chkerr(rc,__LINE__,u_FILE_u)) return
 
-          call NUOPC_CompAttributeGet(gcomp(i), name="pio_root", value=cval, rc=rc)
-          if (chkerr(rc,__LINE__,u_FILE_u)) return
-          read(cval, *) pio_comp_settings(i)%pio_root
+             call ESMF_VMGet(vm, localPet=comp_rank, rc=rc) 
+             if (chkerr(rc,__LINE__,u_FILE_u)) return
+
+             call ESMF_VMGet(vm, ssiLocalPetCount=default_stride, rc=rc)
+             if (chkerr(rc,__LINE__,u_FILE_u)) return
           
-          if(pio_comp_settings(i)%pio_root < 0 .or. pio_comp_settings(i)%pio_root > npets) then
-             pio_comp_settings(i)%pio_root = 0
-          endif
-          
-          
-          call NUOPC_CompAttributeGet(gcomp(i), name="pio_typename", value=cval, rc=rc)
-          if (chkerr(rc,__LINE__,u_FILE_u)) return
-          
-          select case (trim(cval))
-          case ('pnetcdf')
-             pio_comp_settings(i)%pio_iotype = PIO_IOTYPE_PNETCDF
-          case ('netcdf')
-             pio_comp_settings(i)%pio_iotype = PIO_IOTYPE_NETCDF
-          case ('netcdf4p')
-             pio_comp_settings(i)%pio_iotype = PIO_IOTYPE_NETCDF4P
-          case ('netcdf4c')
-             pio_comp_settings(i)%pio_iotype = PIO_IOTYPE_NETCDF4C
-          case DEFAULT
-             write (msgstr, *) "Invalid PIO_TYPENAME Setting for component ", trim(cval)
-             call ESMF_LogSetError(ESMF_RC_NOT_VALID, msg=msgstr, line=__LINE__, file=__FILE__, rcToReturn=rc)
-             return
-          end select
+             call NUOPC_CompAttributeGet(gcomp(i), name="pio_stride", value=cval, rc=rc)
+             if (chkerr(rc,__LINE__,u_FILE_u)) return
+             read(cval, *) pio_comp_settings(i)%pio_stride
+             if(pio_comp_settings(i)%pio_stride <= 0 .or. pio_comp_settings(i)%pio_stride > npets) then
+                pio_comp_settings(i)%pio_stride = min(npets, default_stride)
+             endif
              
-          call NUOPC_CompAttributeGet(gcomp(i), name="pio_async_interface", value=cval, rc=rc)
-          if (chkerr(rc,__LINE__,u_FILE_u)) return
-          pio_async_interface(i) = (trim(cval) == '.true.')
+             call NUOPC_CompAttributeGet(gcomp(i), name="pio_rearranger", value=cval, rc=rc)
+             if (chkerr(rc,__LINE__,u_FILE_u)) return
+             read(cval, *) pio_comp_settings(i)%pio_rearranger
+             
+             call NUOPC_CompAttributeGet(gcomp(i), name="pio_numiotasks", value=cval, rc=rc)
+             if (chkerr(rc,__LINE__,u_FILE_u)) return
+             read(cval, *) pio_comp_settings(i)%pio_numiotasks
           
-          call NUOPC_CompAttributeGet(gcomp(i), name="pio_netcdf_format", value=cval, rc=rc)
-          if (chkerr(rc,__LINE__,u_FILE_u)) return
-          call driver_pio_getioformatfromname(cval, pio_comp_settings(i)%pio_netcdf_ioformat, PIO_64BIT_DATA)
+             if(pio_comp_settings(i)%pio_numiotasks < 0 .or. pio_comp_settings(i)%pio_numiotasks > npets) then
+                pio_comp_settings(i)%pio_numiotasks = max(1,npets/pio_comp_settings(i)%pio_stride)
+             endif
+
+
+             call NUOPC_CompAttributeGet(gcomp(i), name="pio_root", value=cval, rc=rc)
+             if (chkerr(rc,__LINE__,u_FILE_u)) return
+             read(cval, *) pio_comp_settings(i)%pio_root
+             
+             if(pio_comp_settings(i)%pio_root < 0 .or. pio_comp_settings(i)%pio_root > npets) then
+                pio_comp_settings(i)%pio_root = 0
+             endif
           
-          if (pio_async_interface(i)) then
-             do_async_init = do_async_init + 1
-          else
-             if(pio_rearr_opts%comm_fc_opts_io2comp%max_pend_req < PIO_REARR_COMM_UNLIMITED_PEND_REQ) then
-                pio_rearr_opts%comm_fc_opts_io2comp%max_pend_req = pio_comp_settings(i)%pio_numiotasks
+          
+             call NUOPC_CompAttributeGet(gcomp(i), name="pio_typename", value=cval, rc=rc)
+             if (chkerr(rc,__LINE__,u_FILE_u)) return
+             
+             select case (trim(cval))
+             case ('pnetcdf')
+                pio_comp_settings(i)%pio_iotype = PIO_IOTYPE_PNETCDF
+             case ('netcdf')
+                pio_comp_settings(i)%pio_iotype = PIO_IOTYPE_NETCDF
+             case ('netcdf4p')
+                pio_comp_settings(i)%pio_iotype = PIO_IOTYPE_NETCDF4P
+             case ('netcdf4c')
+                pio_comp_settings(i)%pio_iotype = PIO_IOTYPE_NETCDF4C
+             case DEFAULT
+                write (msgstr, *) "Invalid PIO_TYPENAME Setting for component ", trim(cval)
+                call ESMF_LogSetError(ESMF_RC_NOT_VALID, msg=msgstr, line=__LINE__, file=__FILE__, rcToReturn=rc)
+                return
+             end select
+             
+             call NUOPC_CompAttributeGet(gcomp(i), name="pio_async_interface", value=cval, rc=rc)
+             if (chkerr(rc,__LINE__,u_FILE_u)) return
+             pio_async_interface(i) = (trim(cval) == '.true.')
+             
+             call NUOPC_CompAttributeGet(gcomp(i), name="pio_netcdf_format", value=cval, rc=rc)
+             if (chkerr(rc,__LINE__,u_FILE_u)) return
+             call driver_pio_getioformatfromname(cval, pio_comp_settings(i)%pio_netcdf_ioformat, PIO_64BIT_DATA)
+             
+             if (pio_async_interface(i)) then
+                do_async_init = do_async_init + 1
+             else
+                if(pio_rearr_opts%comm_fc_opts_io2comp%max_pend_req < PIO_REARR_COMM_UNLIMITED_PEND_REQ) then
+                   pio_rearr_opts%comm_fc_opts_io2comp%max_pend_req = pio_comp_settings(i)%pio_numiotasks
+                endif
+                if(pio_rearr_opts%comm_fc_opts_comp2io%max_pend_req < PIO_REARR_COMM_UNLIMITED_PEND_REQ) then
+                   pio_rearr_opts%comm_fc_opts_comp2io%max_pend_req = pio_comp_settings(i)%pio_numiotasks
+                endif
+                call pio_init(comp_rank ,comp_comm ,pio_comp_settings(i)%pio_numiotasks, 0, pio_comp_settings(i)%pio_stride, &
+                     pio_comp_settings(i)%pio_rearranger, iosystems(i), pio_comp_settings(i)%pio_root, &
+                     pio_rearr_opts)
              endif
-             if(pio_rearr_opts%comm_fc_opts_comp2io%max_pend_req < PIO_REARR_COMM_UNLIMITED_PEND_REQ) then
-                pio_rearr_opts%comm_fc_opts_comp2io%max_pend_req = pio_comp_settings(i)%pio_numiotasks
-             endif
-             call pio_init(comp_rank ,comp_comm ,pio_comp_settings(i)%pio_numiotasks, 0, pio_comp_settings(i)%pio_stride, &
-                  pio_comp_settings(i)%pio_rearranger, iosystems(i), pio_comp_settings(i)%pio_root, &
-                  pio_rearr_opts)
           endif
        endif
     enddo


### PR DESCRIPTION
### Description of changes
With ESMF_AWARE_THREADING=TRUE not all active tasks are using PIO, this causes a deadlock without this change. 

### Specific notes

Contributors other than yourself, if any:

CMEPS Issues Fixed (include github issue #):

Are changes expected to change answers? (specify if bfb, different at roundoff, more substantial) 

Any User Interface Changes (namelist or namelist defaults changes)?

### Testing performed

Testing performed if application target is CESM:
- [ ] (recommended) CIME_DRIVER=nuopc scripts_regression_tests.py
   - machines:
   - details (e.g. failed tests):
- [ ] (recommended) CESM testlist_drv.xml
   - machines and compilers:
   - details (e.g. failed tests):
- [ ] (optional) CESM prealpha test
   - machines and compilers
   - details (e.g. failed tests):
- [ ] (other) please described in detail
   - machines and compilers
   - details (e.g. failed tests):

Testing performed if application target is UFS-coupled:
- [ ] (recommended) UFS-coupled testing
   - description:
   - details (e.g. failed tests):

Testing performed if application target is UFS-HAFS:
- [ ] (recommended) UFS-HAFS testing
   - description:
   - details (e.g. failed tests):

### Hashes used for testing:

- [ ] CESM:
  - repository to check out: https://github.com/ESCOMP/CESM.git
  - branch/hash:
- [ ] UFS-coupled, then umbrella repostiory to check out and associated hash:
  - repository to check out:
  - branch/hash:
- [ ] UFS-HAFS, then umbrella repostiory to check out and associated hash:
  - repository to check out:
  - branch/hash:
