### PR TITLE
move shr_file_getLogUnit to shr_log_getLogUnit

### DIFF
--- a/cesm/driver/ensemble_driver.F90
+++ b/cesm/driver/ensemble_driver.F90
@@ -8,8 +8,7 @@ module Ensemble_driver
   !-----------------------------------------------------------------------------
 
   use shr_kind_mod  , only : cl=>shr_kind_cl, cs=>shr_kind_cs
-  use shr_log_mod   , only : shrlogunit=> shr_log_unit
-  use shr_file_mod  , only : shr_file_setLogUnit
+  use shr_log_mod   , only : shr_log_setLogUnit
   use esm_utils_mod , only : mastertask, logunit, chkerr
 
   implicit none
@@ -256,10 +255,10 @@ contains
              open (newunit=logunit,file=trim(diro)//"/"//trim(logfile))
              mastertask = .true.
           else
-             logUnit = shrlogunit
+             logUnit = 6
              mastertask = .false.
           endif
-          call shr_file_setLogUnit (logunit)
+          call shr_log_setLogUnit (logunit)
 
           ! Create a clock for each driver instance
           call esm_time_clockInit(ensemble_driver, driver, logunit, mastertask, rc)

--- a/cesm/driver/esm.F90
+++ b/cesm/driver/esm.F90
@@ -8,7 +8,7 @@ module ESM
   use shr_sys_mod  , only : shr_sys_abort
   use shr_mpi_mod  , only : shr_mpi_bcast
   use shr_mem_mod  , only : shr_mem_init
-  use shr_file_mod , only : shr_file_setLogunit
+  use shr_log_mod  , only : shr_log_setLogunit
   use esm_utils_mod, only : logunit, mastertask, dbug_flag, chkerr
   use perf_mod     , only : t_initf, t_setLogUnit
 
@@ -141,10 +141,8 @@ contains
 
     !-------------------------------------------
     ! Set the io logunit to the value defined in ensemble_driver
-    ! TODO: - is this statement still correct?
-    ! it may be corrected below if the med mastertask is not the driver mastertask
     !-------------------------------------------
-    call shr_file_setLogunit(logunit)
+    call shr_log_setLogunit(logunit)
 
     !-------------------------------------------
     ! Get the config and vm objects from the driver

--- a/cesm/nuopc_cap_share/driver_pio_mod.F90
+++ b/cesm/nuopc_cap_share/driver_pio_mod.F90
@@ -2,7 +2,6 @@ module driver_pio_mod
   use pio
   use shr_pio_mod,  only : io_compname, pio_comp_settings, iosystems, io_compid, shr_pio_getindex
   use shr_kind_mod, only : CS=>shr_kind_CS, shr_kind_cl, shr_kind_in
-  use shr_file_mod, only : shr_file_getunit, shr_file_freeunit
   use shr_log_mod,  only : shr_log_unit
   use shr_mpi_mod,  only : shr_mpi_bcast, shr_mpi_chkerr
   use shr_sys_mod,  only : shr_sys_abort

--- a/cesm/nuopc_cap_share/nuopc_shr_methods.F90
+++ b/cesm/nuopc_cap_share/nuopc_shr_methods.F90
@@ -22,7 +22,7 @@ module nuopc_shr_methods
   use NUOPC_Model  , only : NUOPC_ModelGet
   use shr_kind_mod , only : r8 => shr_kind_r8, cl=>shr_kind_cl, cs=>shr_kind_cs
   use shr_sys_mod  , only : shr_sys_abort
-  use shr_file_mod , only : shr_file_setlogunit, shr_file_getLogUnit
+  use shr_log_mod , only : shr_log_setLogUnit
 
   implicit none
   private
@@ -170,7 +170,7 @@ contains
     endif
     shrlogunit = logunit
 
-    call shr_file_setLogUnit (logunit)
+    call shr_log_setLogUnit (logunit)
     
   end subroutine set_component_logging
 

--- a/cesm/nuopc_cap_share/shr_carma_mod.F90
+++ b/cesm/nuopc_cap_share/shr_carma_mod.F90
@@ -7,7 +7,7 @@ module shr_carma_mod
 
   use shr_kind_mod , only : r8 => shr_kind_r8, CX => SHR_KIND_CX
   use shr_sys_mod  , only : shr_sys_abort
-  use shr_log_mod  , only : logunit => shr_log_Unit
+  use shr_log_mod  , only : shr_log_getLogUnit
   use shr_nl_mod   , only : shr_nl_find_group_name
 
   implicit none
@@ -38,9 +38,11 @@ contains
     integer :: ierr             ! error code
     logical :: exists           ! if file exists or not
     integer :: i, tmp(1)
+    integer :: logunit
     character(*),parameter :: F00   = "('(shr_carma_readnl) ',2a)"
 
     namelist /carma_inparm/ carma_fields
+    call shr_log_getLogUnit(logunit)
 
     carma_fields = ' '
     call ESMF_VMGetCurrent(vm, rc=rc)

--- a/cesm/nuopc_cap_share/shr_drydep_mod.F90
+++ b/cesm/nuopc_cap_share/shr_drydep_mod.F90
@@ -13,8 +13,7 @@ module shr_drydep_mod
   use shr_kind_mod   , only : r8 => shr_kind_r8, CS => SHR_KIND_CS, CX => SHR_KIND_CX
   use shr_const_mod  , only : SHR_CONST_MWWV
   use shr_nl_mod     , only : shr_nl_find_group_name
-  use shr_log_mod    , only : s_logunit => shr_log_Unit
-  use shr_file_mod   , only : shr_file_getLogUnit
+  use shr_log_mod    , only : shr_log_getLogUnit
   use shr_infnan_mod , only : shr_infnan_posinf, assignment(=)
   use nuopc_shr_methods, only : chkerr
 
@@ -254,6 +253,7 @@ CONTAINS
     type(ESMF_VM) :: vm
     integer       :: localPet
     integer       :: mpicom
+    integer       :: s_logunit
     integer       :: rc
     character(*),parameter :: F00   = "('(shr_drydep_read) ',8a)"
     character(*),parameter :: FI1   = "('(shr_drydep_init) ',a,I2)"
@@ -281,8 +281,8 @@ CONTAINS
     call ESMF_VMGet(vm, localPet=localPet, rc=rc)
     if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) return
 
+    call shr_log_getLogUnit(s_logunit)
     if (localPet==0) then
-       call shr_file_getLogUnit(s_logunit)
        inquire( file=trim(NLFileName), exist=exists)
        if ( exists ) then
           open(newunit=unitn, file=trim(NLFilename), status='old' )
@@ -348,6 +348,7 @@ CONTAINS
     integer       :: mpicom
     integer       :: bint(2)
     real(kind=r8), pointer :: dptr(:)
+    integer       :: s_logunit
     integer       :: rc
     logical, save :: drydep_initialized=.false.
     character(len=256) :: msg
@@ -357,6 +358,7 @@ CONTAINS
     character(*),parameter :: F00   = "('(shr_drydep_init) ',8a)"
 
     call ESMF_LogWrite(subname//' start', ESMF_LOGMSG_INFO)
+    call shr_log_getLogUnit(s_logunit)
 
     if (dep_data_file=='NONE' .or. len_trim(dep_data_file)==0) return
 
@@ -615,7 +617,7 @@ CONTAINS
     real(r8) :: dk1s(ncol)     ! DK Work array 1
     real(r8) :: dk2s(ncol)     ! DK Work array 2
     real(r8) :: wrk(ncol)      ! Work array
-
+    integer  :: s_logunit
     !----- formats -----
     character(*),parameter :: subName = '(shr_drydep_set_hcoeff) '
     character(*),parameter :: F00   = "('(shr_drydep_set_hcoeff) ',8a)"
@@ -624,6 +626,7 @@ CONTAINS
     ! notes:
     !-------------------------------------------------------------------------------
 
+    call shr_log_getLogUnit(s_logunit)
     wrk(:) = (t0 - sfc_temp(:))/(t0*sfc_temp(:))
     do m = 1,n_drydep
        l    = mapping(m)

--- a/cesm/nuopc_cap_share/shr_megan_mod.F90
+++ b/cesm/nuopc_cap_share/shr_megan_mod.F90
@@ -16,7 +16,7 @@ module shr_megan_mod
   use ESMF                , only : ESMF_LogFoundError, ESMF_LOGERR_PASSTHRU, ESMF_SUCCESS
   use shr_kind_mod        , only : r8 => shr_kind_r8, cl=>shr_kind_cl, cx=>shr_kind_cx, cs=>shr_kind_cs
   use shr_sys_mod         , only : shr_sys_abort
-  use shr_log_mod         , only : logunit => shr_log_Unit
+  use shr_log_mod         , only : shr_log_getLogUnit
   use shr_mpi_mod         , only : shr_mpi_bcast
   use shr_nl_mod          , only : shr_nl_find_group_name
   use shr_expr_parser_mod , only : shr_exp_parse, shr_exp_item_t, shr_exp_list_destroy
@@ -126,6 +126,7 @@ contains
     logical             :: megan_mapped_emisfctrs = .false.
     character(len=CL)   :: megan_factors_file = ' '
     integer             :: rc
+    integer             :: logunit
     integer             :: i, tmp(1)
     character(*), parameter :: F00   = "('(shr_megan_readnl) ',2a)"
     character(len=*), parameter :: subname='(shr_megan_readnl)'
@@ -143,7 +144,7 @@ contains
 
     call ESMF_VMGet(vm, localPet=localPet, mpiCommunicator=mpicom, rc=rc)
     if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) return 
-
+    call shr_log_getLogUnit(logunit)
     ! Note the following still needs to be called on all processors since the mpi_bcast is a collective 
     ! call on all the pes of mpicom
     if (localPet==0) then

--- a/cesm/nuopc_cap_share/shr_ndep_mod.F90
+++ b/cesm/nuopc_cap_share/shr_ndep_mod.F90
@@ -9,7 +9,7 @@ module shr_ndep_mod
   use ESMF         , only : ESMF_VMGetCurrent, ESMF_VM, ESMF_VMGet
   use ESMF         , only : ESMF_LogFoundError, ESMF_LOGERR_PASSTHRU, ESMF_SUCCESS
   use shr_sys_mod  , only : shr_sys_abort
-  use shr_log_mod  , only : s_logunit => shr_log_Unit
+  use shr_log_mod  , only : shr_log_getLogUnit
   use shr_kind_mod , only : r8 => shr_kind_r8
   use shr_nl_mod   , only : shr_nl_find_group_name
   use shr_mpi_mod  , only : shr_mpi_bcast
@@ -49,7 +49,7 @@ CONTAINS
     character(len=32)  :: ndep_list(maxspc) = '' ! List of ndep species
     integer            :: localpet
     integer            :: mpicom
-    
+    integer            :: logunit
     character(*),parameter :: subName = '(shr_ndep_readnl) '
     character(*),parameter :: F00   = "('(shr_ndep_readnl) ',8a)"
     ! ------------------------------------------------------------------
@@ -67,7 +67,7 @@ CONTAINS
     if ( len_trim(NLFilename) == 0 ) then
        call shr_sys_abort( subName//'ERROR: nlfilename not set' )
     end if
-
+    call shr_log_getLogUnit(logunit)
     call ESMF_VMGetCurrent(vm, rc=rc)
     if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) return 
 
@@ -80,7 +80,7 @@ CONTAINS
        inquire( file=trim(NLFileName), exist=exists)
        if ( exists ) then
           open(newunit=unitn, file=trim(NLFilename), status='old' )
-          write(s_logunit,F00) 'Read in ndep_inparm namelist from: ', trim(NLFilename)
+          write(logunit,F00) 'Read in ndep_inparm namelist from: ', trim(NLFilename)
           call shr_nl_find_group_name(unitn, 'ndep_inparm', ierr)
           if (ierr == 0) then
              ! Note that ierr /= 0, no namelist is present.

--- a/cesm/nuopc_cap_share/shr_ozone_coupling_mod.F90
+++ b/cesm/nuopc_cap_share/shr_ozone_coupling_mod.F90
@@ -7,7 +7,7 @@ module shr_ozone_coupling_mod
   use ESMF         , only : ESMF_VMGetCurrent, ESMF_VM, ESMF_VMGet
   use ESMF         , only : ESMF_LogFoundError, ESMF_LOGERR_PASSTHRU, ESMF_SUCCESS
   use shr_sys_mod  , only : shr_sys_abort
-  use shr_log_mod  , only : s_logunit => shr_log_Unit
+  use shr_log_mod  , only : shr_log_getLogUnit
   use shr_nl_mod   , only : shr_nl_find_group_name
   use shr_mpi_mod  , only : shr_mpi_bcast
 
@@ -52,7 +52,7 @@ CONTAINS
     integer           :: rc
     integer           :: localpet
     integer           :: mpicom
-
+    integer           :: s_logunit
     character(len=*), parameter :: atm_ozone_frequency_not_present = 'NOT_PRESENT'
     character(len=*), parameter :: subname = '(shr_ozone_coupling_readnl) '
     ! ------------------------------------------------------------------
@@ -65,7 +65,7 @@ CONTAINS
     if ( len_trim(NLFilename) == 0 ) then
        call shr_sys_abort( subname//'ERROR: nlfilename not set' )
     end if
-
+    call shr_log_getLogUnit(s_logunit)
     call ESMF_VMGetCurrent(vm, rc=rc)
     if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) return
 

--- a/cime_config/namelist_definition_drv.xml
+++ b/cime_config/namelist_definition_drv.xml
@@ -891,7 +891,7 @@
       default: ocn
     </desc>
     <values>
-      <value>ogrid</value>
+      <value>xgrid</value>
     </values>
   </entry>
   <entry id="ocn_surface_flux_scheme">

--- a/cime_config/namelist_definition_drv.xml
+++ b/cime_config/namelist_definition_drv.xml
@@ -891,7 +891,7 @@
       default: ocn
     </desc>
     <values>
-      <value>xgrid</value>
+      <value>ogrid</value>
     </values>
   </entry>
   <entry id="ocn_surface_flux_scheme">


### PR DESCRIPTION
### Description of changes
Clean up usage of log files

### Specific notes
Depricated shr_file_getLogUnit and added shr_log_getLogUnit
Depends on https://github.com/ESCOMP/CESM_share/pull/36
Contributors other than yourself, if any:

CMEPS Issues Fixed (include github issue #):

Are changes expected to change answers? (specify if bfb, different at roundoff, more substantial) 

Any User Interface Changes (namelist or namelist defaults changes)?

### Testing performed

Testing performed if application target is CESM:
- [ ] (recommended) CIME_DRIVER=nuopc scripts_regression_tests.py
   - machines:
   - details (e.g. failed tests):
- [ ] (recommended) CESM testlist_drv.xml
   - machines and compilers:
   - details (e.g. failed tests):
- [X] (optional) CESM prealpha test
   - machines and compilers cheyenne intel
   - details (e.g. failed tests): all consistant with baselines. 
- [ ] (other) please described in detail
   - machines and compilers
   - details (e.g. failed tests):

Testing performed if application target is UFS-coupled:
- [ ] (recommended) UFS-coupled testing
   - description:
   - details (e.g. failed tests):

Testing performed if application target is UFS-HAFS:
- [ ] (recommended) UFS-HAFS testing
   - description:
   - details (e.g. failed tests):

### Hashes used for testing:

- [ ] CESM:
  - repository to check out: https://github.com/ESCOMP/CESM.git
  - branch/hash:
- [ ] UFS-coupled, then umbrella repostiory to check out and associated hash:
  - repository to check out:
  - branch/hash:
- [ ] UFS-HAFS, then umbrella repostiory to check out and associated hash:
  - repository to check out:
  - branch/hash:
