### PR TITLE
Fix documentation of DOUT_S_SAVE_INTERIM_RESTART_FILES

### DIFF
--- a/cime_config/config_component_cesm.xml
+++ b/cime_config/config_component_cesm.xml
@@ -92,7 +92,7 @@
     <file>env_run.xml</file>
     <desc>Logical to archive all interim restart files, not just those at eor
     If TRUE, perform short term archiving on all interim restart files,
-    not just those at the end of the run. By default, this value is TRUE.
+    not just those at the end of the run. By default, this value is FALSE.
     The restart files are saved under the specific component directory
     ($DOUT_S_ROOT/$CASE/$COMPONENT/rest rather than the top-level $DOUT_S_ROOT/$CASE/rest directory).
     Interim restart files are created using the REST_N and REST_OPTION variables.


### PR DESCRIPTION
### Description of changes

Fix documentation of default value of DOUT_S_SAVE_INTERIM_RESTART_FILES, as pointed out in https://bb.cgd.ucar.edu/cesm/threads/restart-files-were-deleted-when-archiving-after-the-run-was-completed.7885/

### Specific notes

Contributors other than yourself, if any: none

CMEPS Issues Fixed (include github issue #): none

Are changes expected to change answers? (specify if bfb, different at roundoff, more substantial)  NO

Any User Interface Changes (namelist or namelist defaults changes)? no

### Testing performed

No testing performed.

Testing performed if application target is CESM:
- [ ] (recommended) CIME_DRIVER=nuopc scripts_regression_tests.py
   - machines:
   - details (e.g. failed tests):
- [ ] (recommended) CESM testlist_drv.xml
   - machines and compilers:
   - details (e.g. failed tests):
- [ ] (optional) CESM prealpha test
   - machines and compilers
   - details (e.g. failed tests):
- [ ] (other) please described in detail
   - machines and compilers
   - details (e.g. failed tests):

Testing performed if application target is UFS-coupled:
- [ ] (recommended) UFS-coupled testing
   - description:
   - details (e.g. failed tests):

Testing performed if application target is UFS-HAFS:
- [ ] (recommended) UFS-HAFS testing
   - description:
   - details (e.g. failed tests):

### Hashes used for testing:

- [ ] CESM:
  - repository to check out: https://github.com/ESCOMP/CESM.git
  - branch/hash:
- [ ] UFS-coupled, then umbrella repostiory to check out and associated hash:
  - repository to check out:
  - branch/hash:
- [ ] UFS-HAFS, then umbrella repostiory to check out and associated hash:
  - repository to check out:
  - branch/hash:
