### PR TITLE
fix issue with scaling over instances

### DIFF
--- a/cesm/driver/ensemble_driver.F90
+++ b/cesm/driver/ensemble_driver.F90
@@ -133,7 +133,7 @@ contains
     call ReadAttributes(ensemble_driver, config, "CLOCK_attributes::", rc=rc)
     if (chkerr(rc,__LINE__,u_FILE_u)) return
 
-    call NUOPC_CompAttributeGet(ensemble_driver, 'calendar', calendar, rc=rc) 
+    call NUOPC_CompAttributeGet(ensemble_driver, 'calendar', calendar, rc=rc)
     if (chkerr(rc,__LINE__,u_FILE_u)) return
     if (calendar == 'NO_LEAP') then
        call ESMF_CalendarSetDefault(ESMF_CALKIND_NOLEAP, rc=rc)
@@ -203,6 +203,7 @@ contains
     !-------------------------------------------
 
     allocate(petList(ntasks_per_member))
+    ! which driver instance is this?
     inst = localPet/ntasks_per_member + 1
 
     ! Determine pet list for driver instance
@@ -215,9 +216,9 @@ contains
     write(drvrinst,'(a,i4.4)') "ESM",inst
     call NUOPC_DriverAddComp(ensemble_driver, drvrinst, ESMSetServices, petList=petList, comp=gridcomptmp, rc=rc)
     if (chkerr(rc,__LINE__,u_FILE_u)) return
-    
+
     if (localpet >= petlist(1) .and. localpet <= petlist(ntasks_per_member)) then
-       
+
        driver = gridcomptmp
 
        if(number_of_members > 1) then
@@ -235,17 +236,17 @@ contains
        if (chkerr(rc,__LINE__,u_FILE_u)) return
        call NUOPC_CompAttributeSet(driver, name='read_restart', value=trim(read_restart_string), rc=rc)
        if (chkerr(rc,__LINE__,u_FILE_u)) return
-       
+
        call ReadAttributes(driver, config, "CLOCK_attributes::", rc=rc)
        if (chkerr(rc,__LINE__,u_FILE_u)) return
-       
+
        call ReadAttributes(driver, config, "DRIVER_attributes::", rc=rc)
        if (chkerr(rc,__LINE__,u_FILE_u)) return
 
        call ReadAttributes(driver, config, "DRV_modelio::", rc=rc)
        if (chkerr(rc,__LINE__,u_FILE_u)) return
-       
-       ! Set the driver log to the driver task 0 
+
+       ! Set the driver log to the driver task 0
        if (mod(localPet, ntasks_per_member) == 0) then
           call NUOPC_CompAttributeGet(driver, name="diro", value=diro, rc=rc)
           if (chkerr(rc,__LINE__,u_FILE_u)) return
@@ -262,7 +263,7 @@ contains
        ! Create a clock for each driver instance
        call esm_time_clockInit(ensemble_driver, driver, logunit, mastertask, rc)
        if (chkerr(rc,__LINE__,u_FILE_u)) return
-       
+
     endif
 
     deallocate(petList)


### PR DESCRIPTION
### Description of changes
Remove a performance funnel in ensemble_driver which caused linear scaling with number of members

### Specific notes

Contributors other than yourself, if any:

CMEPS Issues Fixed (include github issue #): Fixes #326

Are changes expected to change answers? (specify if bfb, different at roundoff, more substantial) 

Any User Interface Changes (namelist or namelist defaults changes)?

### Testing performed

Testing performed if application target is CESM:
- [ ] (recommended) CIME_DRIVER=nuopc scripts_regression_tests.py
   - machines:
   - details (e.g. failed tests):
- [ ] (recommended) CESM testlist_drv.xml
   - machines and compilers:
   - details (e.g. failed tests):
- [ ] (optional) CESM prealpha test
   - machines and compilers
   - details (e.g. failed tests):
- [ ] (other) please described in detail
   - machines and compilers
   - details (e.g. failed tests):

Testing performed if application target is UFS-coupled:
- [ ] (recommended) UFS-coupled testing
   - description:
   - details (e.g. failed tests):

Testing performed if application target is UFS-HAFS:
- [ ] (recommended) UFS-HAFS testing
   - description:
   - details (e.g. failed tests):

### Hashes used for testing:

- [ ] CESM:
  - repository to check out: https://github.com/ESCOMP/CESM.git
  - branch/hash:
- [ ] UFS-coupled, then umbrella repostiory to check out and associated hash:
  - repository to check out:
  - branch/hash:
- [ ] UFS-HAFS, then umbrella repostiory to check out and associated hash:
  - repository to check out:
  - branch/hash:
