### PR TITLE
fix the multi instance initialization

### DIFF
--- a/cesm/driver/esm.F90
+++ b/cesm/driver/esm.F90
@@ -610,14 +610,14 @@ contains
     character(len=*)    , intent(in)    :: inst_suffix
     integer             , intent(in)    :: nthrds
     integer             , intent(inout) :: rc
-
     ! local variables
     integer                        :: inst_index
+    logical                        :: computetask
     character(len=CL)              :: cvalue
     character(len=CS)              :: attribute
     character(len=*), parameter    :: subname = "(esm.F90:AddAttributes)"
     !-------------------------------------------
-
+    computetask = .false.
     rc = ESMF_Success
     call ESMF_LogWrite(trim(subname)//": called", ESMF_LOGMSG_INFO)
     call shr_log_setLogunit(logunit)
@@ -635,6 +635,10 @@ contains
     ! Add driver restart flag to gcomp attributes
     !------
     attribute = 'read_restart'
+    call NUOPC_CompAttributeGet(driver, name=trim(attribute), isPresent=computetask, rc=rc)
+    if (chkerr(rc,__LINE__,u_FILE_u)) return
+    if(.not. computetask) return
+
     call NUOPC_CompAttributeGet(driver, name=trim(attribute), value=cvalue, rc=rc)
     if (chkerr(rc,__LINE__,u_FILE_u)) return
     call NUOPC_CompAttributeAdd(gcomp, (/trim(attribute)/), rc=rc)
@@ -649,6 +653,9 @@ contains
     if (chkerr(rc,__LINE__,u_FILE_u)) return
     call ReadAttributes(gcomp, config, "ALLCOMP_attributes::", rc=rc)
     if (chkerr(rc,__LINE__,u_FILE_u)) return
+
+    call ESMF_LogWrite(trim(subname)//": call Readattributes for"//trim(compname), ESMF_LOGMSG_INFO)
+
     call ReadAttributes(gcomp, config, trim(compname)//"_modelio::", rc=rc)
     if (chkerr(rc,__LINE__,u_FILE_u)) then
        print *,__FILE__,__LINE__,"ERROR reading ",trim(compname)," modelio from runconfig"


### PR DESCRIPTION
### Description of changes
The aysncio pr accidently regressed the recent fix for multiinstance cases, this fixes it.  
 
### Specific notes
Depends on cime #4359

Contributors other than yourself, if any:

CMEPS Issues Fixed (include github issue #):

Are changes expected to change answers? (specify if bfb, different at roundoff, more substantial) 

Any User Interface Changes (namelist or namelist defaults changes)?

### Testing performed

Testing performed if application target is CESM:
- [ ] (recommended) CIME_DRIVER=nuopc scripts_regression_tests.py
   - machines:
   - details (e.g. failed tests):
- [ ] (recommended) CESM testlist_drv.xml
   - machines and compilers:
   - details (e.g. failed tests):
- [ ] (optional) CESM prealpha test
   - machines and compilers
   - details (e.g. failed tests):
- [x] (other) please described in detail
   - machines and compilers SMS_C80_P108x1_Lh1_Vnuopc.f09_f09_mg17.FHIST_DARTC6.cheyenne_intel.cam-dartcambigens ERS_C3_Vnuopc.f19_g17.A.cheyenne_intel.drv-asyncio1pernode, ERS_Ln9.f19_f19_mg17.FHIST.cheyenne_intel.drv-asyncio1pernode--cam-outfrq9s
   - details (e.g. failed tests):

Testing performed if application target is UFS-coupled:
- [ ] (recommended) UFS-coupled testing
   - description:
   - details (e.g. failed tests):

Testing performed if application target is UFS-HAFS:
- [ ] (recommended) UFS-HAFS testing
   - description:
   - details (e.g. failed tests):

### Hashes used for testing:

- [ ] CESM:
  - repository to check out: https://github.com/ESCOMP/CESM.git
  - branch/hash:
- [ ] UFS-coupled, then umbrella repostiory to check out and associated hash:
  - repository to check out:
  - branch/hash:
- [ ] UFS-HAFS, then umbrella repostiory to check out and associated hash:
  - repository to check out:
  - branch/hash:
