### PR TITLE
make xgrid default, handle main task for multidriver cases in esm_tim…

### DIFF
--- a/cesm/driver/ensemble_driver.F90
+++ b/cesm/driver/ensemble_driver.F90
@@ -375,7 +375,7 @@ contains
        call shr_log_setLogUnit (logunit)
        ! Create a clock for each driver instance
 
-       call esm_time_clockInit(ensemble_driver, driver, logunit, maintask, rc)
+       call esm_time_clockInit(ensemble_driver, driver, logunit, localpet==petList(1), rc)
        if (chkerr(rc,__LINE__,u_FILE_u)) return
 
     enddo

--- a/cime_config/namelist_definition_drv.xml
+++ b/cime_config/namelist_definition_drv.xml
@@ -927,7 +927,7 @@
       default: xgrid 
     </desc>
     <values>
-      <value>ogrid</value>
+      <value>xgrid</value>
     </values>
   </entry>
   <entry id="ocn_surface_flux_scheme">


### PR DESCRIPTION
…e_clockinit

### Description of changes
Make xgrid default, fix an issue with maintask in multidriver cases. 

### Specific notes

Contributors other than yourself, if any:

CMEPS Issues Fixed (include github issue #):

Are changes expected to change answers? (specify if bfb, different at roundoff, more substantial) 

Any User Interface Changes (namelist or namelist defaults changes)?

### Testing performed

Testing performed if application target is CESM:
- [ ] (recommended) CIME_DRIVER=nuopc scripts_regression_tests.py
   - machines:
   - details (e.g. failed tests):
- [ ] (recommended) CESM testlist_drv.xml
   - machines and compilers:
   - details (e.g. failed tests):
- [ ] (optional) CESM prealpha test
   - machines and compilers
   - details (e.g. failed tests):
- [ ] (other) please described in detail
   - machines and compilers
   - details (e.g. failed tests):

Testing performed if application target is UFS-coupled:
- [ ] (recommended) UFS-coupled testing
   - description:
   - details (e.g. failed tests):

Testing performed if application target is UFS-HAFS:
- [ ] (recommended) UFS-HAFS testing
   - description:
   - details (e.g. failed tests):

### Hashes used for testing:

- [ ] CESM:
  - repository to check out: https://github.com/ESCOMP/CESM.git
  - branch/hash:
- [ ] UFS-coupled, then umbrella repostiory to check out and associated hash:
  - repository to check out:
  - branch/hash:
- [ ] UFS-HAFS, then umbrella repostiory to check out and associated hash:
  - repository to check out:
  - branch/hash:
