### PR TITLE
Revert default aoflux_grid to ogrid

### DIFF
--- a/cime_config/namelist_definition_drv.xml
+++ b/cime_config/namelist_definition_drv.xml
@@ -924,10 +924,10 @@
     <valid_values>ogrid,agrid,xgrid</valid_values>
     <desc>
       Grid for atm ocn flux calc
-      default: xgrid 
+      default: ogrid
     </desc>
     <values>
-      <value>xgrid</value>
+      <value>ogrid</value>
     </values>
   </entry>
   <entry id="ocn_surface_flux_scheme">


### PR DESCRIPTION
### Description of changes

xgrid was causing restart problems; revert this until we can solve those problems

### Specific notes

Contributors other than yourself, if any: Testing from @fischer-ncar , consultation with @jedwards4b 

CMEPS Issues Fixed (include github issue #):

Are changes expected to change answers? (specify if bfb, different at roundoff, more substantial) Yes - answer changes for cases that compute atm-ocn fluxes

Any User Interface Changes (namelist or namelist defaults changes)? No

### Testing performed

**No testing done exactly on this branch, but @fischer-ncar did testing with both cmeps0.14.16 and cmeps0.14.14 (note that cmeps0.14.14 was the tag that appeared before cmeps0.14.16 due to an oddity in tag ordering); this tag is a blend of those two.

Testing performed if application target is CESM:
- [ ] (recommended) CIME_DRIVER=nuopc scripts_regression_tests.py
   - machines:
   - details (e.g. failed tests):
- [ ] (recommended) CESM testlist_drv.xml
   - machines and compilers:
   - details (e.g. failed tests):
- [ ] (optional) CESM prealpha test
   - machines and compilers
   - details (e.g. failed tests):
- [ ] (other) please described in detail
   - machines and compilers
   - details (e.g. failed tests):

Testing performed if application target is UFS-coupled:
- [ ] (recommended) UFS-coupled testing
   - description:
   - details (e.g. failed tests):

Testing performed if application target is UFS-HAFS:
- [ ] (recommended) UFS-HAFS testing
   - description:
   - details (e.g. failed tests):

### Hashes used for testing:

- [ ] CESM:
  - repository to check out: https://github.com/ESCOMP/CESM.git
  - branch/hash:
- [ ] UFS-coupled, then umbrella repostiory to check out and associated hash:
  - repository to check out:
  - branch/hash:
- [ ] UFS-HAFS, then umbrella repostiory to check out and associated hash:
  - repository to check out:
  - branch/hash:
