### PR TITLE
Remove unnecessary deallocate

### DIFF
--- a/mediator/med_io_mod.F90
+++ b/mediator/med_io_mod.F90
@@ -1140,7 +1140,6 @@ contains
        call pio_syncfile(io_file(lfile_ind))
        call pio_freedecomp(io_file(lfile_ind), iodesc)
     endif
-    deallocate(fieldNameList)
     deallocate(ownedElemCoords, ownedElemCoords_x, ownedElemCoords_y)
 
     if (dbug_flag > 5) then


### PR DESCRIPTION
### Description of changes

fieldNameList is not always allocated, so this deallocate caused problems in some circumstances. We could wrap the deallocate in a conditional, but since allocatable arrays are automatically deallocated upon leaving a subroutine, this deallocate statement is unnecessary.

### Specific notes

Contributors other than yourself, if any: @olyson found this issue

CMEPS Issues Fixed (include github issue #): none

Are changes expected to change answers? (specify if bfb, different at roundoff, more substantial) NO

Any User Interface Changes (namelist or namelist defaults changes)? none

### Testing performed

NONE

Testing performed if application target is CESM:
- [ ] (recommended) CIME_DRIVER=nuopc scripts_regression_tests.py
   - machines:
   - details (e.g. failed tests):
- [ ] (recommended) CESM testlist_drv.xml
   - machines and compilers:
   - details (e.g. failed tests):
- [ ] (optional) CESM prealpha test
   - machines and compilers
   - details (e.g. failed tests):
- [ ] (other) please described in detail
   - machines and compilers
   - details (e.g. failed tests):

Testing performed if application target is UFS-coupled:
- [ ] (recommended) UFS-coupled testing
   - description:
   - details (e.g. failed tests):

Testing performed if application target is UFS-HAFS:
- [ ] (recommended) UFS-HAFS testing
   - description:
   - details (e.g. failed tests):

### Hashes used for testing:

- [ ] CESM:
  - repository to check out: https://github.com/ESCOMP/CESM.git
  - branch/hash:
- [ ] UFS-coupled, then umbrella repostiory to check out and associated hash:
  - repository to check out:
  - branch/hash:
- [ ] UFS-HAFS, then umbrella repostiory to check out and associated hash:
  - repository to check out:
  - branch/hash:
