### PR TITLE
add CAM linked lbs to exe build

### DIFF
--- a/cime_config/buildexe
+++ b/cime_config/buildexe
@@ -38,6 +38,7 @@ def _main_func():
         num_esp   = case.get_value("NUM_COMP_INST_ESP")
         ocn_model = case.get_value("COMP_OCN")
         gmake_args = get_standard_makefile_args(case)
+        link_libs = case.get_value("CAM_LINKED_LIBS", subgroup="build_component_cam")
         esmf_aware_threading = case.get_value("ESMF_AWARE_THREADING")
 
     # Determine valid components
@@ -64,6 +65,9 @@ def _main_func():
 
     if ocn_model == 'mom':
         gmake_args += "USE_FMS=TRUE"
+
+    if link_libs is not None:
+        gmake_args += 'USER_SLIBS="{}"'.format(link_libs)
 
     comp_classes = case.get_values("COMP_CLASSES")
     for comp in comp_classes:


### PR DESCRIPTION
### Description of changes

Addition of an option to pass flags needed to link external libraries for use in CAM.

### Specific notes

Contributors other than yourself, if any:

none (This is my first PR to this repo, so apologies if this is not the right way to suggest this change)

CMEPS Issues Fixed (include github issue #):

#355

Are changes expected to change answers? (specify if bfb, different at roundoff, more substantial) 

No (bfb)

Any User Interface Changes (namelist or namelist defaults changes)?

No

### Testing performed

Testing performed if application target is CESM:
- [ ] (recommended) CIME_DRIVER=nuopc scripts_regression_tests.py
   - machines:
   - details (e.g. failed tests):
- [ ] (recommended) CESM testlist_drv.xml
   - machines and compilers:
   - details (e.g. failed tests):
- [ ] (optional) CESM prealpha test
   - machines and compilers
   - details (e.g. failed tests):
- [ ] (other) please described in detail
   - machines and compilers
   - details (e.g. failed tests):

Testing performed if application target is UFS-coupled:
- [ ] (recommended) UFS-coupled testing
   - description:
   - details (e.g. failed tests):

Testing performed if application target is UFS-HAFS:
- [ ] (recommended) UFS-HAFS testing
   - description:
   - details (e.g. failed tests):

### Hashes used for testing:

- [ ] CESM:
  - repository to check out: https://github.com/ESCOMP/CESM.git
  - branch/hash:
- [ ] UFS-coupled, then umbrella repostiory to check out and associated hash:
  - repository to check out:
  - branch/hash:
- [ ] UFS-HAFS, then umbrella repostiory to check out and associated hash:
  - repository to check out:
  - branch/hash:
