### PR TITLE
A fix for #346 so that LND2ROF_FMAPNAME will be used

### DIFF
--- a/cime_config/namelist_definition_drv.xml
+++ b/cime_config/namelist_definition_drv.xml
@@ -2055,25 +2055,25 @@
       <value samegrid_atm_lnd='true'>idmap</value>
     </values>
   </entry>
-  <entry id="lnd2rof_map">
+  <entry id="lnd2rof_map" modify_via_xml="LND2ROF_FMAPNAME">
     <type>char</type>
     <category>mapping</category>
     <input_pathname>abs</input_pathname>
     <group>MED_attributes</group>
-    <desc>lnd to rof mapping, 'unset' or 'idmap' are normal possible values</desc>
+    <desc>lnd to rof mapping, 'unset' or 'idmap' are normal possible values (mapping file given for mizuRoute grids)</desc>
     <values>
-      <value>unset</value>
+      <value>$LND2ROF_FMAPNAME</value>
       <value samegrid_lnd_rof='true'>idmap</value>
     </values>
   </entry>
-  <entry id="rof2lnd_map">
+  <entry id="rof2lnd_map" modify_via_xml="ROF2LND_FMAPNAME">
     <type>char</type>
     <category>mapping</category>
     <input_pathname>abs</input_pathname>
     <group>MED_attributes</group>
-    <desc>rof to lnd mapping, 'unset' or 'idmap' are normal possible values</desc>
+    <desc>rof to lnd mapping, 'unset' or 'idmap' are normal possible values (mapping file given for mizuRoute grids)</desc>
     <values>
-      <value>unset</value>
+      <value>$ROF2LND_FMAPNAME</value>
       <value samegrid_lnd_rof='true'>idmap</value>
     </values>
   </entry>


### PR DESCRIPTION
### Description of changes

Simple changes so that LND2ROF_FMAPNAME and ROF2LND_FMAPNAME will be used to fix the mapping for mizuRoute.

### Specific notes

Contributors other than yourself, if any:

CMEPS Issues Fixed (include github issue #):
  Fixes #346

Are changes expected to change answers? b4b (unless you use mapping files)

Any User Interface Changes (namelist or namelist defaults changes)?
  XML variables LND2ROF_FMAPNAME and ROF2LND_FMAPNAME are now used

### Testing performed

Testing performed if application target is CESM:

- [x] (other) please described in detail
   - machines and compilers: cheyenne_intel

with CTSM add_mizuRoute branch. ctsm5.1.dev114-40-g3c288c96c
ccs_config_cesm0.0.52
cime6.0.75

This resolves the mizuRoute issue: https://github.com/ESCOMP/mizuRoute/issues/339

