### PR TITLE
update the minimum esmf version requirement

### DIFF
--- a/cime_config/buildnml
+++ b/cime_config/buildnml
@@ -620,14 +620,7 @@ def buildnml(case, caseroot, component):
                 major = line[-2] if "MAJOR" in line else major
                 minor = line[-2] if "MINOR" in line else minor
         logger.debug("ESMF version major {} minor {}".format(major, minor))
-        expect(int(major) >= 8, "ESMF version should be 8.1 or newer")
-        if esmf_aware_threading:
-            expect(
-                int(minor) >= 2,
-                "ESMF version should be 8.2.0 or newer when using ESMF_AWARE_THREADING",
-            )
-        else:
-            expect(int(minor) >= 1, "ESMF version should be 8.1.0 or newer")
+        expect(int(major) >= 8 and int(minor) >=4, "ESMF version should be 8.4.1 or newer")
 
     confdir = os.path.join(case.get_value("CASEBUILD"), "cplconf")
     if not os.path.isdir(confdir):


### PR DESCRIPTION
### Description of changes
update minimum esmf version to 8.4

### Specific notes
Fixes: #360 

Contributors other than yourself, if any:

CMEPS Issues Fixed (include github issue #):

Are changes expected to change answers? (specify if bfb, different at roundoff, more substantial) 

Any User Interface Changes (namelist or namelist defaults changes)?

### Testing performed
Tested on cheyenne by running preview-namelist with versions of esmf newer and older than 8.4


Testing performed if application target is CESM:
- [ ] (recommended) CIME_DRIVER=nuopc scripts_regression_tests.py
   - machines:
   - details (e.g. failed tests):
- [ ] (recommended) CESM testlist_drv.xml
   - machines and compilers:
   - details (e.g. failed tests):
- [ ] (optional) CESM prealpha test
   - machines and compilers
   - details (e.g. failed tests):
- [ ] (other) please described in detail
   - machines and compilers
   - details (e.g. failed tests):

Testing performed if application target is UFS-coupled:
- [ ] (recommended) UFS-coupled testing
   - description:
   - details (e.g. failed tests):

Testing performed if application target is UFS-HAFS:
- [ ] (recommended) UFS-HAFS testing
   - description:
   - details (e.g. failed tests):

### Hashes used for testing:

- [ ] CESM:
  - repository to check out: https://github.com/ESCOMP/CESM.git
  - branch/hash:
- [ ] UFS-coupled, then umbrella repostiory to check out and associated hash:
  - repository to check out:
  - branch/hash:
- [ ] UFS-HAFS, then umbrella repostiory to check out and associated hash:
  - repository to check out:
  - branch/hash:
