### PR TITLE
turn off HierarchyProtocol

### DIFF
--- a/cesm/driver/ensemble_driver.F90
+++ b/cesm/driver/ensemble_driver.F90
@@ -340,6 +340,9 @@ contains
           else
              inst_suffix = ''
           endif
+          # CESM does not use this ESMF feature and at large processor counts it can be expensive to have it on.
+          call NUOPC_CompAttributeSet(driver, name="HierarchyProtocol", value="off", rc=rc)
+          if (chkerr(rc,__LINE__,u_FILE_u)) return
           
           ! Set the driver instance attributes
           call NUOPC_CompAttributeAdd(driver, attrList=(/'read_restart'/), rc=rc)

--- a/cesm/driver/ensemble_driver.F90
+++ b/cesm/driver/ensemble_driver.F90
@@ -340,7 +340,7 @@ contains
           else
              inst_suffix = ''
           endif
-          # CESM does not use this ESMF feature and at large processor counts it can be expensive to have it on.
+          ! CESM does not use this ESMF feature and at large processor counts it can be expensive to have it on.
           call NUOPC_CompAttributeSet(driver, name="HierarchyProtocol", value="off", rc=rc)
           if (chkerr(rc,__LINE__,u_FILE_u)) return
           


### PR DESCRIPTION
, not used in cesm this is a memory and intialization time saver

### Description of changes
Turn off the initialization Hierarchy protocol used in esmf. This decreases memory usage and initialization time and is particularly noticeable at scale.

### Specific notes

Contributors other than yourself, if any:

CMEPS Issues Fixed (include github issue #):

Are changes expected to change answers? (specify if bfb, different at roundoff, more substantial) 

Any User Interface Changes (namelist or namelist defaults changes)?

### Testing performed

Testing performed if application target is CESM:
- [ ] (recommended) CIME_DRIVER=nuopc scripts_regression_tests.py
   - machines:
   - details (e.g. failed tests):
- [ ] (recommended) CESM testlist_drv.xml
   - machines and compilers:
   - details (e.g. failed tests):
- [ ] (optional) CESM prealpha test
   - machines and compilers
   - details (e.g. failed tests):
- [ ] (other) please described in detail
   - machines and compilers
   - details (e.g. failed tests):

Testing performed if application target is UFS-coupled:
- [ ] (recommended) UFS-coupled testing
   - description:
   - details (e.g. failed tests):

Testing performed if application target is UFS-HAFS:
- [ ] (recommended) UFS-HAFS testing
   - description:
   - details (e.g. failed tests):

### Hashes used for testing:

- [ ] CESM:
  - repository to check out: https://github.com/ESCOMP/CESM.git
  - branch/hash:
- [ ] UFS-coupled, then umbrella repostiory to check out and associated hash:
  - repository to check out:
  - branch/hash:
- [ ] UFS-HAFS, then umbrella repostiory to check out and associated hash:
  - repository to check out:
  - branch/hash:
