### PR TITLE
checking of nans in export field bundles

### DIFF
--- a/mediator/med_diag_mod.F90
+++ b/mediator/med_diag_mod.F90
@@ -95,6 +95,8 @@ module med_diag_mod
   character(*), parameter :: FA1  = "('    ',a12,6f15.8)"
   character(*), parameter :: FA0r = "('    ',12x,8(6x,a8,1x))"
   character(*), parameter :: FA1r = "('    ',a12,8f15.8)"
+  character(*), parameter :: FA0s = "('    ',12x,8(7x,a8,2x))"
+  character(*), parameter :: FA1s = "('    ',a12,8g18.8)"
 
   ! ---------------------------------
   ! C for component
@@ -2683,7 +2685,7 @@ contains
        write(diagunit,*) ' '
        write(diagunit,FAH) subname,'NET SALT BUDGET (kg/m2s): period = ',&
             trim(budget_diags%periods(ip)%name), ': date = ',date,tod
-       write(diagunit,FA0r) '     atm','     lnd','     rof','     ocn','  ice nh','  ice sh','     glc',' *SUM*  '
+       write(diagunit,FA0s) '     atm','     lnd','     rof','     ocn','  ice nh','  ice sh','     glc',' *SUM*  '
        do nf = f_salt_beg, f_salt_end
           net_salt_atm    = data(nf, c_atm_recv, ip) + data(nf, c_atm_send, ip)
           net_salt_lnd    = data(nf, c_lnd_recv, ip) + data(nf, c_lnd_send, ip)
@@ -2695,7 +2697,7 @@ contains
           net_salt_tot    = net_salt_atm + net_salt_lnd + net_salt_rof + net_salt_ocn + &
                net_salt_ice_nh + net_salt_ice_sh + net_salt_glc
 
-          write(diagunit,FA1r) budget_diags%fields(nf)%name,&
+          write(diagunit,FA1s) budget_diags%fields(nf)%name,&
                net_salt_atm, net_salt_lnd, net_salt_rof, net_salt_ocn, &
                net_salt_ice_nh, net_salt_ice_sh, net_salt_glc, net_salt_tot
        enddo
@@ -2718,7 +2720,7 @@ contains
        sum_net_salt_tot    = sum_net_salt_atm + sum_net_salt_lnd + sum_net_salt_rof + sum_net_salt_ocn + &
             sum_net_salt_ice_nh + sum_net_salt_ice_sh + sum_net_salt_glc
 
-       write(diagunit,FA1r)'   *SUM*',&
+       write(diagunit,FA1s)'   *SUM*',&
             sum_net_salt_atm, sum_net_salt_lnd, sum_net_salt_rof, sum_net_salt_ocn, &
             sum_net_salt_ice_nh, sum_net_salt_ice_sh, sum_net_salt_glc, sum_net_salt_tot
     end if

--- a/mediator/med_methods_mod.F90
+++ b/mediator/med_methods_mod.F90
@@ -2567,7 +2567,8 @@ contains
 
   !-----------------------------------------------------------------------------
   subroutine med_methods_check_for_nans_1d(dataptr, nancount)
-   use shr_infnan_mod, only: nan => shr_infnan_nan, inf => shr_infnan_inf, assignment(=)
+    use shr_infnan_mod, only: nan => isnan
+
     ! input/output variables
     real(r8) , intent(in)  :: dataptr(:)
     integer  , intent(out) :: nancount
@@ -2584,7 +2585,8 @@ contains
   end subroutine med_methods_check_for_nans_1d
 
   subroutine med_methods_check_for_nans_2d(dataptr, nancount)
-    use shr_infnan_mod, only: nan => shr_infnan_nan, inf => shr_infnan_inf, assignment(=)
+    use shr_infnan_mod, only: isnan
+
     ! input/output variables
     real(r8) , intent(in)  :: dataptr(:,:)
     integer  , intent(out) :: nancount

--- a/mediator/med_methods_mod.F90
+++ b/mediator/med_methods_mod.F90
@@ -2530,6 +2530,11 @@ contains
     ! ----------------------------------------------
     rc = ESMF_SUCCESS
 
+#ifndef CESM_COUPLED
+    ! For now only CESM uses shr_infnan_isnan - so until other models provide this
+    RETURN
+#endif
+
     call ESMF_FieldBundleGet(FB, fieldCount=fieldCount, rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
 
@@ -2566,42 +2571,62 @@ contains
   end subroutine med_methods_FB_check_for_nans
 
   !-----------------------------------------------------------------------------
-  subroutine med_methods_check_for_nans_1d(dataptr, nancount)
-    use shr_infnan_mod, only: nan => isnan
+#ifdef CESM_COUPLED
 
+  subroutine med_methods_check_for_nans_1d(dataptr, nancount)
+    use shr_infnan_mod, only: shr_infnan_isnan
     ! input/output variables
     real(r8) , intent(in)  :: dataptr(:)
     integer  , intent(out) :: nancount
-
     ! local variables
     integer :: n
-    ! ----------------------------------------------
+
     nancount = 0
     do n = 1,size(dataptr)
-       if (isnan(dataptr(n))) then
+       if (shr_infnan_isnan(dataptr(n))) then
           nancount = nancount + 1
        end if
     end do
   end subroutine med_methods_check_for_nans_1d
 
   subroutine med_methods_check_for_nans_2d(dataptr, nancount)
-    use shr_infnan_mod, only: isnan
-
+    use shr_infnan_mod, only: shr_infan_isnan
     ! input/output variables
     real(r8) , intent(in)  :: dataptr(:,:)
     integer  , intent(out) :: nancount
-
     ! local variables
     integer :: n,k
-    ! ----------------------------------------------
+
     nancount = 0
     do k = 1,size(dataptr, dim=1)
        do n = 1,size(dataptr, dim=2)
-          if (isnan(dataptr(k,n))) then
+          if (shr_infan_isnan(dataptr(k,n))) then
              nancount = nancount + 1
           end if
        end do
     end do
   end subroutine med_methods_check_for_nans_2d
+
+#else
+
+  ! For now only CESM uses shr_infnan_isnan - so until other models provide this
+  ! nancount will just be set to zero
+
+  subroutine med_methods_check_for_nans_1d(dataptr, nancount)
+    ! input/output variables
+    real(r8) , intent(in)  :: dataptr(:)
+    integer  , intent(out) :: nancount
+
+    nancount = 0
+  end subroutine med_methods_check_for_nans_1d
+
+  subroutine med_methods_check_for_nans_2d(dataptr, nancount)
+    ! input/output variables
+    real(r8) , intent(in)  :: dataptr(:,:)
+    integer  , intent(out) :: nancount
+
+    nancount = 0
+  end subroutine med_methods_check_for_nans_2d
+#endif
 
 end module med_methods_mod

--- a/mediator/med_phases_prep_atm_mod.F90
+++ b/mediator/med_phases_prep_atm_mod.F90
@@ -14,6 +14,7 @@ module med_phases_prep_atm_mod
   use med_methods_mod       , only : FB_diagnose => med_methods_FB_diagnose
   use med_methods_mod       , only : FB_fldchk   => med_methods_FB_FldChk
   use med_methods_mod       , only : FB_getfldptr=> med_methods_FB_GetFldPtr
+  use med_methods_mod       , only : FB_check_for_nans => med_methods_FB_check_for_nans
   use med_merge_mod         , only : med_merge_auto
   use med_map_mod           , only : med_map_field_packed
   use med_internalstate_mod , only : InternalState, maintask
@@ -242,6 +243,10 @@ contains
           dataptr1(n) = dataptr1(n) + global_htot_corr(1)
        end do
     end if
+
+    ! Check for nans in fields export to atm
+    call FB_check_for_nans(is_local%wrap%FBExp(compatm), rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
 
     if (dbug_flag > 5) then
        call ESMF_LogWrite(trim(subname)//": done", ESMF_LOGMSG_INFO)

--- a/mediator/med_phases_prep_glc_mod.F90
+++ b/mediator/med_phases_prep_glc_mod.F90
@@ -34,6 +34,7 @@ module med_phases_prep_glc_mod
   use med_methods_mod       , only : fldbun_diagnose  => med_methods_FB_diagnose
   use med_methods_mod       , only : fldbun_reset     => med_methods_FB_reset
   use med_methods_mod       , only : fldbun_init      => med_methods_FB_init
+  use med_methods_mod       , only : fldbun_check_for_nans => med_methods_FB_check_for_nans
   use med_methods_mod       , only : field_getdata2d  => med_methods_Field_getdata2d
   use med_methods_mod       , only : field_getdata1d  => med_methods_Field_getdata1d
   use med_utils_mod         , only : chkerr           => med_utils_ChkErr
@@ -705,6 +706,12 @@ contains
           end do
        endif
     end if
+
+    ! Check for nans in fields export to atm
+    do ns = 1,is_local%wrap%num_icesheets
+       call fldbun_check_for_nans(is_local%wrap%FBExp(compglc(ns)), rc=rc)
+       if (ChkErr(rc,__LINE__,u_FILE_u)) return
+    end do
 
     if (dbug_flag > 5) then
        call ESMF_LogWrite(trim(subname)//": done", ESMF_LOGMSG_INFO)

--- a/mediator/med_phases_prep_glc_mod.F90
+++ b/mediator/med_phases_prep_glc_mod.F90
@@ -34,7 +34,7 @@ module med_phases_prep_glc_mod
   use med_methods_mod       , only : fldbun_diagnose  => med_methods_FB_diagnose
   use med_methods_mod       , only : fldbun_reset     => med_methods_FB_reset
   use med_methods_mod       , only : fldbun_init      => med_methods_FB_init
-  use med_methods_mod       , only : fldbun_check_for_nans => med_methods_FB_check_for_nans
+  use med_methods_mod       , only : FB_check_for_nans => med_methods_FB_check_for_nans
   use med_methods_mod       , only : field_getdata2d  => med_methods_Field_getdata2d
   use med_methods_mod       , only : field_getdata1d  => med_methods_Field_getdata1d
   use med_utils_mod         , only : chkerr           => med_utils_ChkErr
@@ -709,7 +709,7 @@ contains
 
     ! Check for nans in fields export to atm
     do ns = 1,is_local%wrap%num_icesheets
-       call fldbun_check_for_nans(is_local%wrap%FBExp(compglc(ns)), rc=rc)
+       call FB_check_for_nans(is_local%wrap%FBExp(compglc(ns)), rc=rc)
        if (ChkErr(rc,__LINE__,u_FILE_u)) return
     end do
 

--- a/mediator/med_phases_prep_ice_mod.F90
+++ b/mediator/med_phases_prep_ice_mod.F90
@@ -34,6 +34,7 @@ contains
     use med_methods_mod       , only : FB_fldchk    => med_methods_FB_FldChk
     use med_methods_mod       , only : FB_diagnose  => med_methods_FB_diagnose
     use med_methods_mod       , only : FB_GetFldPtr => med_methods_FB_GetFldPtr
+    use med_methods_mod       , only : FB_check_for_nans => med_methods_FB_check_for_nans
     use med_constants_mod     , only : dbug_flag    => med_constants_dbug_flag
     use med_merge_mod         , only : med_merge_auto
     use med_internalstate_mod , only : InternalState, logunit, maintask
@@ -148,6 +149,10 @@ contains
        call FB_diagnose(is_local%wrap%FBExp(compice), string=trim(subname)//' FBexp(compice) ', rc=rc)
        if (chkerr(rc,__LINE__,u_FILE_u)) return
     end if
+
+    ! Check for nans in fields export to atm
+    call FB_check_for_nans(is_local%wrap%FBExp(compice), rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
 
     if (dbug_flag > 5) then
        call ESMF_LogWrite(trim(subname)//": done", ESMF_LOGMSG_INFO)

--- a/mediator/med_phases_prep_lnd_mod.F90
+++ b/mediator/med_phases_prep_lnd_mod.F90
@@ -29,7 +29,7 @@ contains
     use ESMF                  , only : ESMF_StateGet, ESMF_StateItem_Flag, ESMF_STATEITEM_NOTFOUND
     use esmFlds               , only : med_fldList_GetFldListTo, med_fldList_type
     use med_methods_mod       , only : fldbun_diagnose  => med_methods_FB_diagnose
-    use med_methods_mod       , only : fldbun_check_for_nans => med_methods_FB_check_for_nans
+    use med_methods_mod       , only : FB_check_for_nans => med_methods_FB_check_for_nans
     use med_utils_mod         , only : chkerr           => med_utils_ChkErr
     use med_constants_mod     , only : dbug_flag        => med_constants_dbug_flag
     use med_internalstate_mod , only : complnd, compatm
@@ -129,7 +129,7 @@ contains
     first_call = .false.
 
     ! Check for nans in fields export to atm
-    call fldbun_check_for_nans(is_local%wrap%FBExp(complnd), rc=rc)
+    call FB_check_for_nans(is_local%wrap%FBExp(complnd), rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
 
     if (dbug_flag > 5) then

--- a/mediator/med_phases_prep_lnd_mod.F90
+++ b/mediator/med_phases_prep_lnd_mod.F90
@@ -29,6 +29,7 @@ contains
     use ESMF                  , only : ESMF_StateGet, ESMF_StateItem_Flag, ESMF_STATEITEM_NOTFOUND
     use esmFlds               , only : med_fldList_GetFldListTo, med_fldList_type
     use med_methods_mod       , only : fldbun_diagnose  => med_methods_FB_diagnose
+    use med_methods_mod       , only : fldbun_check_for_nans => med_methods_FB_check_for_nans
     use med_utils_mod         , only : chkerr           => med_utils_ChkErr
     use med_constants_mod     , only : dbug_flag        => med_constants_dbug_flag
     use med_internalstate_mod , only : complnd, compatm
@@ -126,6 +127,10 @@ contains
 
     ! Set first call logical to false
     first_call = .false.
+
+    ! Check for nans in fields export to atm
+    call fldbun_check_for_nans(is_local%wrap%FBExp(complnd), rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
 
     if (dbug_flag > 5) then
        call ESMF_LogWrite(trim(subname)//": done", ESMF_LOGMSG_INFO)

--- a/mediator/med_phases_prep_ocn_mod.F90
+++ b/mediator/med_phases_prep_ocn_mod.F90
@@ -19,6 +19,7 @@ module med_phases_prep_ocn_mod
   use med_methods_mod       , only : FB_average    => med_methods_FB_average
   use med_methods_mod       , only : FB_copy       => med_methods_FB_copy
   use med_methods_mod       , only : FB_reset      => med_methods_FB_reset
+  use med_methods_mod       , only : FB_check_for_nans => med_methods_FB_check_for_nans
   use esmFlds               , only : med_fldList_GetfldListTo, med_fldlist_type
   use med_internalstate_mod , only : compocn, compatm, compice, coupling_mode
   use perf_mod              , only : t_startf, t_stopf
@@ -293,6 +294,10 @@ contains
 
        ! copy to FBExp(compocn)
        call FB_copy(is_local%wrap%FBExp(compocn), is_local%wrap%FBExpAccumOcn, rc=rc)
+       if (ChkErr(rc,__LINE__,u_FILE_u)) return
+
+       ! Check for nans in fields export to atm
+       call FB_check_for_nans(is_local%wrap%FBExp(compocn), rc=rc)
        if (ChkErr(rc,__LINE__,u_FILE_u)) return
 
        ! zero accumulator

--- a/mediator/med_phases_prep_rof_mod.F90
+++ b/mediator/med_phases_prep_rof_mod.F90
@@ -23,7 +23,7 @@ module med_phases_prep_rof_mod
   use med_methods_mod       , only : fldbun_reset     => med_methods_FB_reset
   use med_methods_mod       , only : fldbun_average   => med_methods_FB_average
   use med_methods_mod       , only : field_getdata1d  => med_methods_Field_getdata1d
-  use med_methods_mod       , only : fldbun_check_for_nans => med_methods_FB_check_for_nans
+  use med_methods_mod       , only : FB_check_for_nans => med_methods_FB_check_for_nans
   use perf_mod              , only : t_startf, t_stopf
 
   implicit none
@@ -378,7 +378,7 @@ contains
     if (chkerr(rc,__LINE__,u_FILE_u)) return
 
     ! Check for nans in fields export to atm
-    call fldbun_check_for_nans(is_local%wrap%FBExp(comprof), rc=rc)
+    call FB_check_for_nans(is_local%wrap%FBExp(comprof), rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
 
     if (dbug_flag > 1) then

--- a/mediator/med_phases_prep_rof_mod.F90
+++ b/mediator/med_phases_prep_rof_mod.F90
@@ -23,6 +23,7 @@ module med_phases_prep_rof_mod
   use med_methods_mod       , only : fldbun_reset     => med_methods_FB_reset
   use med_methods_mod       , only : fldbun_average   => med_methods_FB_average
   use med_methods_mod       , only : field_getdata1d  => med_methods_Field_getdata1d
+  use med_methods_mod       , only : fldbun_check_for_nans => med_methods_FB_check_for_nans
   use perf_mod              , only : t_startf, t_stopf
 
   implicit none
@@ -375,6 +376,10 @@ contains
     call med_merge_auto(compsrc=complnd, FBout=is_local%wrap%FBExp(comprof), &
          FBfrac=is_local%wrap%FBFrac(comprof), FBin=FBlndAccum2rof_r, fldListTo=fldList, rc=rc)
     if (chkerr(rc,__LINE__,u_FILE_u)) return
+
+    ! Check for nans in fields export to atm
+    call fldbun_check_for_nans(is_local%wrap%FBExp(comprof), rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
 
     if (dbug_flag > 1) then
        call fldbun_diagnose(is_local%wrap%FBExp(comprof), &

--- a/mediator/med_phases_prep_wav_mod.F90
+++ b/mediator/med_phases_prep_wav_mod.F90
@@ -17,6 +17,7 @@ module med_phases_prep_wav_mod
   use med_methods_mod       , only : FB_average    => med_methods_FB_average
   use med_methods_mod       , only : FB_copy       => med_methods_FB_copy
   use med_methods_mod       , only : FB_reset      => med_methods_FB_reset
+  use med_methods_mod       , only : FB_check_for_nans => med_methods_FB_check_for_nans
   use esmFlds               , only : med_fldList_GetfldListTo
   use med_internalstate_mod , only : compwav
   use perf_mod              , only : t_startf, t_stopf
@@ -174,6 +175,10 @@ contains
 
        ! copy to FBExp(compwav)
        call FB_copy(is_local%wrap%FBExp(compwav), is_local%wrap%FBExpAccumWav, rc=rc)
+       if (ChkErr(rc,__LINE__,u_FILE_u)) return
+
+       ! Check for nans in fields export to atm
+       call FB_check_for_nans(is_local%wrap%FBExp(compwav), rc=rc)
        if (ChkErr(rc,__LINE__,u_FILE_u)) return
 
        ! zero accumulator


### PR DESCRIPTION
### Description of changes
checking of nans in export field bundles #377

### Specific notes
Introduced a new method med_methods_FB_check_for_nans in med_methods_mod and has all of the med_phases_prep_xxx_mod.F90 files call this method. If Nans are found in any field the model will abort, but it will first print out the number of nans found for each field and on each processor.

Contributors other than yourself, if any: @jedwards4b 

CMEPS Issues Fixed: #370 

Are changes expected to change answers?  bfb

Any User Interface Changes (namelist or namelist defaults changes)? None

### Testing performed
Verified that if nans were set in the 1d and 2d field in the call to med_phases_prep_atm, then PET files were written with the right statistics and the model aborted.
