### PR TITLE
Add length to logic format descriptor, needed for nag.

### DIFF
--- a/mediator/med_phases_ocnalb_mod.F90
+++ b/mediator/med_phases_ocnalb_mod.F90
@@ -242,7 +242,7 @@ contains
           call ESMF_LogWrite(trim(msg), ESMF_LOGMSG_INFO)
        end if
     end if
-    write(msg,'(A,l)') trim(subname)//': use_nextswcday setting is ',use_nextswcday
+    write(msg,'(A,l1)') trim(subname)//': use_nextswcday setting is ',use_nextswcday
     call ESMF_LogWrite(trim(msg), ESMF_LOGMSG_INFO)
 
     if (dbug_flag > 5) then


### PR DESCRIPTION
### Description of changes
Added a field length to the L field descriptor.

### Specific notes
The nag compiler didn't like have a naked L field descriptor.

Contributors other than yourself, if any:

CMEPS Issues Fixed (include github issue #):

Are changes expected to change answers? (specify if bfb, different at roundoff, more substantial) 
BFB

Any User Interface Changes (namelist or namelist defaults changes)?
None

### Testing performed
Please describe the tests along with the target model and machine(s) 
If possible, please also added hashes that were used in the testing

ERR.f45_g37_rx1.A.izumi_nag build

