### PR TITLE
remove this unused variable

### DIFF
--- a/cime_config/config_component.xml
+++ b/cime_config/config_component.xml
@@ -1035,23 +1035,6 @@
     this to work.</desc>
   </entry>
 
-  <entry id="ESMF_LOGFILE_KIND">
-    <type>char</type>
-    <valid_values>ESMF_LOGKIND_SINGLE,ESMF_LOGKIND_MULTI,ESMF_LOGKIND_NONE</valid_values>
-    <default_value>ESMF_LOGKIND_NONE</default_value>
-    <group>run_flags</group>
-    <file>env_run.xml</file>
-    <desc>
-      Determines what ESMF log files (if any) are generated when
-          USE_ESMF_LIB is TRUE.
-      ESMF_LOGKIND_SINGLE: Use a single log file, combining messages from
-          all of the PETs. Not supported on some platforms.
-      ESMF_LOGKIND_MULTI: Use multiple log files -- one per PET.
-      ESMF_LOGKIND_NONE: Do not issue messages to a log file.
-      By default, no ESMF log files are generated.
-    </desc>
-  </entry>
-
   <entry id="ESMF_VERBOSITY_LEVEL">
     <type>char</type>
     <valid_values>off,low,high,max</valid_values>

--- a/cime_config/namelist_definition_drv.xml
+++ b/cime_config/namelist_definition_drv.xml
@@ -18,24 +18,6 @@
     </values>
   </entry>
 
-  <entry id="esmf_logging" modify_via_xml="ESMF_LOGFILE_KIND">
-    <type>char</type>
-    <category>cime_pes</category>
-    <group>PELAYOUT_attributes</group>
-    <desc>
-      Determines what ESMF log files (if any) are generated when
-          USE_ESMF_LIB is TRUE.
-      ESMF_LOGKIND_SINGLE: Use a single log file, combining messages from
-          all of the PETs. Not supported on some platforms.
-      ESMF_LOGKIND_MULTI: Use multiple log files — one per PET.
-      ESMF_LOGKIND_NONE: Do not issue messages to a log file.
-      By default, no ESMF log files are generated.
-    </desc>
-    <values>
-      <value>$ESMF_LOGFILE_KIND</value>
-    </values>
-  </entry>
-
   <entry id="pio_asyncio_ntasks" modify_via_xml="PIO_ASYNCIO_NTASKS">
     <type>integer</type>
     <category>pio</category>


### PR DESCRIPTION
### Description of changes
Remove unused ESMF_LOGFILE_KIND variable.

### Specific notes
This variable is not used, control for esmf logfiles is through variable
CREATE_ESMF_PET_FILES
Contributors other than yourself, if any: Ufuk

CMEPS Issues Fixed #416 

Are changes expected to change answers? (specify if bfb, different at roundoff, more substantial)  bfbSMS.f19_g17.X.frontera_intel

Any User Interface Changes (namelist or namelist defaults changes)?

### Testing performed
Please describe the tests along with the target model and machine(s) 
If possible, please also added hashes that were used in the testing
SMS.f19_g17.X.frontera_intel 
