### PR TITLE
CMEPS PR for CDEPS Inline implementation

### DIFF
--- a/.github/workflows/srt.yml
+++ b/.github/workflows/srt.yml
@@ -26,8 +26,8 @@ jobs:
       CPPFLAGS: "-I/usr/include -I/usr/local/include "
       LDFLAGS: "-L/usr/lib/x86_64-linux-gnu -lnetcdf -lnetcdff -lpnetcdf"     
       # Versions of all dependencies can be updated here
-      ESMF_VERSION: v8.4.0
-      PARALLELIO_VERSION: pio2_5_10
+      ESMF_VERSION: v8.5.0
+      PARALLELIO_VERSION: pio2_6_0
       CIME_MODEL: cesm
       CIME_DRIVER: nuopc
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -153,6 +153,7 @@ jobs:
           mkdir -p $HOME/cesm/scratch
           mkdir -p $HOME/cesm/inputdata
           pushd $GITHUB_WORKSPACE/cesm/cime/CIME/tests
+          export SRCROOT=$GITHUB_WORKSPACE/cesm/
           export CIME_TEST_PLATFORM=ubuntu-latest
           export PIO_INCDIR=$HOME/pio/include
           export PIO_LIBDIR=$HOME/pio/lib
@@ -175,6 +176,6 @@ jobs:
           popd
 #     the following can be used by developers to login to the github server in case of errors
 #     see https://github.com/marketplace/actions/debugging-with-tmate for further details
-#      - name: Setup tmate session
-#        if: ${{ failure() }}
-#        uses: mxschmitt/action-tmate@v3
+      - name: Setup tmate session
+        if: ${{ failure() }}
+        uses: mxschmitt/action-tmate@v3

--- a/.github/workflows/srt.yml
+++ b/.github/workflows/srt.yml
@@ -190,6 +190,6 @@ jobs:
           popd
 #     the following can be used by developers to login to the github server in case of errors
 #     see https://github.com/marketplace/actions/debugging-with-tmate for further details
-#      - name: Setup tmate session
-#        if: ${{ failure() }}
-#        uses: mxschmitt/action-tmate@v3
+      - name: Setup tmate session
+        if: ${{ failure() }}
+        uses: mxschmitt/action-tmate@v3

--- a/.github/workflows/srt.yml
+++ b/.github/workflows/srt.yml
@@ -189,6 +189,6 @@ jobs:
           popd
 #     the following can be used by developers to login to the github server in case of errors
 #     see https://github.com/marketplace/actions/debugging-with-tmate for further details
-      - name: Setup tmate session
-        if: ${{ failure() }}
-        uses: mxschmitt/action-tmate@v3
+#      - name: Setup tmate session
+#        if: ${{ failure() }}
+#        uses: mxschmitt/action-tmate@v3

--- a/.github/workflows/srt.yml
+++ b/.github/workflows/srt.yml
@@ -84,9 +84,10 @@ jobs:
           git checkout main 
           cd ../
           git clone https://github.com/ESMCI/cime
+          cd cime
           if [[ ! -e "${PWD}/.gitmodules.bak" ]]
              then
-              echo "Convering git@github.com to https://github.com urls in ${PWD}/.gitmodules"
+              echo "Converting git@github.com to https://github.com urls in ${PWD}/.gitmodules"
 
               sed -i".bak" "s/git@github.com:/https:\/\/github.com\//g" "${PWD}/.gitmodules"
           fi

--- a/.github/workflows/srt.yml
+++ b/.github/workflows/srt.yml
@@ -79,11 +79,11 @@ jobs:
       - name: checkout externals
         run: |
           pushd cesm
-          ./manage_externals/checkout_externals ccs_config cdeps cime share mct cpl7 parallelio
+          ./manage_externals/checkout_externals ccs_config cdeps share mct cpl7 parallelio
           cd ccs_config
-          git checkout main
-          cd ../cime
-          git checkout master
+          git checkout main 
+          cd ../
+          git clone https://github.com/ESMCI/cime
           if [[ ! -e "${PWD}/.gitmodules.bak" ]]
              then
               echo "Convering git@github.com to https://github.com urls in ${PWD}/.gitmodules"

--- a/cime_config/config_component.xml
+++ b/cime_config/config_component.xml
@@ -784,6 +784,34 @@
       If TRUE, the component libraries are always built with OpenMP capability.</desc>
   </entry>
 
+  <entry id="GPU_TYPE">
+    <type>char</type>
+    <valid_values></valid_values>
+    <default_value></default_value>
+    <group>build_def</group>
+    <file>env_build.xml</file>
+    <desc>If set will compile and submit with this gpu type enabled </desc>
+  </entry>
+
+  <entry id="GPU_OFFLOAD">
+    <type>char</type>
+    <valid_values></valid_values>
+    <default_value></default_value>
+    <group>build_def</group>
+    <file>env_build.xml</file>
+    <desc>If set will compile and submit with this gpu offload method enabled </desc>
+  </entry>
+
+  <entry id="MPI_GPU_WRAPPER_SCRIPT">
+    <type>char</type>
+    <valid_values></valid_values>
+    <default_value></default_value>
+    <group>build_def</group>
+    <file>env_build.xml</file>
+    <desc>If set will attach this script to the MPI run command, mapping
+    different MPI ranks to different GPUs within the same compute node</desc>
+  </entry>
+
   <entry id="SMP_PRESENT">
     <type>logical</type>
     <valid_values>TRUE,FALSE</valid_values>
@@ -1798,12 +1826,22 @@
     <desc>pes or cores per node for accounting purposes </desc>
   </entry>
 
+  <entry id="MAX_CPUTASKS_PER_GPU_NODE">
+    <type>integer</type>
+    <default_value>0</default_value>
+    <values>
+      <value compiler="nvhpc">1</value>
+    </values>
+    <group>mach_pes_last</group>
+    <file>env_mach_pes.xml</file>
+    <desc> Number of CPU cores per GPU node used for simulation </desc>
+  </entry>
+
   <entry id="NGPUS_PER_NODE">
     <type>integer</type>
     <default_value>0</default_value>
     <values>
-      <value compiler="pgi-gpu">1</value>
-      <value compiler="nvhpc-gpu">1</value>
+      <value compiler="nvhpc">1</value>
     </values>
     <group>mach_pes</group>
     <file>env_mach_pes.xml</file>

--- a/cime_config/namelist_definition_drv.xml
+++ b/cime_config/namelist_definition_drv.xml
@@ -938,7 +938,7 @@
       default: ogrid
     </desc>
     <values>
-      <value>xgrid</value>
+      <value>ogrid</value>
     </values>
   </entry>
   <entry id="ocn_surface_flux_scheme">

--- a/mediator/esmFldsExchange_cesm_mod.F90
+++ b/mediator/esmFldsExchange_cesm_mod.F90
@@ -2158,7 +2158,7 @@ contains
           ! liquid from river and possibly flood from river to ocean
           if (fldchk(is_local%wrap%FBImp(comprof, comprof), 'Forr_rofl' , rc=rc)) then
              if (trim(rof2ocn_liq_rmap) == 'unset') then
-                call addmap_from(comprof, 'Forr_rofl', compocn, mapconsd, 'none', 'unset')
+                call addmap_from(comprof, 'Forr_rofl', compocn, mapconsd, 'one', 'unset')
              else
                 call addmap_from(comprof, 'Forr_rofl', compocn, map_rof2ocn_liq, 'none', rof2ocn_liq_rmap)
              end if
@@ -2182,7 +2182,7 @@ contains
           ! ice from river to ocean
           if (fldchk(is_local%wrap%FBImp(comprof, comprof), 'Forr_rofi' , rc=rc)) then
              if (trim(rof2ocn_ice_rmap) == 'unset') then
-                call addmap_from(comprof, 'Forr_rofi', compocn, mapconsd, 'none', 'unset')
+                call addmap_from(comprof, 'Forr_rofi', compocn, mapconsd, 'one', 'unset')
              else
                 call addmap_from(comprof, 'Forr_rofi', compocn, map_rof2ocn_ice, 'none', rof2ocn_ice_rmap)
              end if

--- a/mediator/esmFldsExchange_hafs_mod.F90
+++ b/mediator/esmFldsExchange_hafs_mod.F90
@@ -263,7 +263,7 @@ contains
           F_flds(3 ,:) = (/'Faxa_rain     ','Faxa_rain     '/) ! mean_prec_rate
           F_flds(4 ,:) = (/'Faxa_lwnet    ','Foxx_lwnet    '/) ! mean_net_lw_flx
           F_flds(5 ,:) = (/'Faxa_sen      ','Foxx_sen      '/) ! mean_sensi_heat_flx
-          F_flds(6 ,:) = (/'Faxa_lat      ','Foxx_evap     '/) ! mean_laten_heat_flx
+          F_flds(6 ,:) = (/'Faxa_evap     ','Foxx_evap     '/) ! inst_evap_rate
           F_flds(7 ,:) = (/'Faxa_swndr    ','Foxx_swnet_idr'/) ! inst_down_sw_ir_dir_flx
           F_flds(8 ,:) = (/'Faxa_swndf    ','Foxx_swnet_idf'/) ! inst_down_sw_ir_dif_flx
           F_flds(9 ,:) = (/'Faxa_swvdr    ','Foxx_swnet_vdr'/) ! inst_down_sw_vis_dir_flx
@@ -546,7 +546,7 @@ contains
           F_flds(3 ,:) = (/'Faxa_rain     ','Faxa_rain     '/) ! mean_prec_rate
           F_flds(4 ,:) = (/'Faxa_lwnet    ','Foxx_lwnet    '/) ! mean_net_lw_flx
           F_flds(5 ,:) = (/'Faxa_sen      ','Foxx_sen      '/) ! mean_sensi_heat_flx
-          F_flds(6 ,:) = (/'Faxa_lat      ','Foxx_evap     '/) ! mean_laten_heat_flx
+          F_flds(6 ,:) = (/'Faxa_evap     ','Foxx_evap     '/) ! inst_evap_rate
           F_flds(7 ,:) = (/'Faxa_swndr    ','Foxx_swnet_idr'/) ! inst_down_sw_ir_dir_flx
           F_flds(8 ,:) = (/'Faxa_swndf    ','Foxx_swnet_idf'/) ! inst_down_sw_ir_dif_flx
           F_flds(9 ,:) = (/'Faxa_swvdr    ','Foxx_swnet_vdr'/) ! inst_down_sw_vis_dir_flx

--- a/mediator/esmFldsExchange_hafs_mod.F90
+++ b/mediator/esmFldsExchange_hafs_mod.F90
@@ -150,11 +150,13 @@ contains
     !----------------------------------------------------------
     ! from med: ocean albedos (not sent to the ATM in UFS).
     !----------------------------------------------------------
-    if (phase == 'advertise') then
-       call addfld_ocnalb('So_avsdr')
-       call addfld_ocnalb('So_avsdf')
-       call addfld_ocnalb('So_anidr')
-       call addfld_ocnalb('So_anidf')
+    if (trim(coupling_mode) == 'hafs.mom6') then
+       if (phase == 'advertise') then
+          call addfld_ocnalb('So_avsdr')
+          call addfld_ocnalb('So_avsdf')
+          call addfld_ocnalb('So_anidr')
+          call addfld_ocnalb('So_anidf')
+       end if
     end if
 
     !=====================================================================

--- a/mediator/esmFldsExchange_hafs_mod.F90
+++ b/mediator/esmFldsExchange_hafs_mod.F90
@@ -244,13 +244,13 @@ contains
     if (hafs_attr%atm_present .and. hafs_attr%ocn_present) then
        if (trim(coupling_mode) == 'hafs') then
           allocate(F_flds(7,2))
-          F_flds(1,:) = (/'Faxa_taux ','Faxa_taux '/) ! mean_zonal_moment_flx_atm
-          F_flds(2,:) = (/'Faxa_tauy ','Faxa_tauy '/) ! mean_merid_moment_flx_atm
-          F_flds(3,:) = (/'Faxa_rain ','Faxa_rain '/) ! mean_prec_rate
-          F_flds(4,:) = (/'Faxa_swnet','Faxa_swnet'/) ! mean_net_sw_flx
-          F_flds(5,:) = (/'Faxa_lwnet','Faxa_lwnet'/) ! mean_net_lw_flx
-          F_flds(6,:) = (/'Faxa_sen  ','Faxa_sen  '/) ! mean_sensi_heat_flx
-          F_flds(7,:) = (/'Faxa_lat  ','Faxa_lat  '/) ! mean_laten_heat_flx
+          F_flds(1,:) = (/'Faxa_taux ','Faxa_taux '/) ! inst_zonal_moment_flx_atm
+          F_flds(2,:) = (/'Faxa_tauy ','Faxa_tauy '/) ! inst_merid_moment_flx_atm
+          F_flds(3,:) = (/'Faxa_rain ','Faxa_rain '/) ! inst_prec_rate
+          F_flds(4,:) = (/'Faxa_swnet','Faxa_swnet'/) ! inst_net_sw_flx
+          F_flds(5,:) = (/'Faxa_lwnet','Faxa_lwnet'/) ! inst_net_lw_flx
+          F_flds(6,:) = (/'Faxa_sen  ','Faxa_sen  '/) ! inst_sensi_heat_flx
+          F_flds(7,:) = (/'Faxa_lat  ','Faxa_lat  '/) ! inst_laten_heat_flx
           do n = 1,size(F_flds,1)
              fldname1 = trim(F_flds(n,1))
              fldname2 = trim(F_flds(n,2))
@@ -260,11 +260,11 @@ contains
           deallocate(F_flds)
        else
           allocate(F_flds(10,2))
-          F_flds(1 ,:) = (/'Faxa_taux     ','Foxx_taux     '/) ! mean_zonal_moment_flx_atm
-          F_flds(2 ,:) = (/'Faxa_tauy     ','Foxx_tauy     '/) ! mean_merid_moment_flx_atm
-          F_flds(3 ,:) = (/'Faxa_rain     ','Faxa_rain     '/) ! mean_prec_rate
-          F_flds(4 ,:) = (/'Faxa_lwnet    ','Foxx_lwnet    '/) ! mean_net_lw_flx
-          F_flds(5 ,:) = (/'Faxa_sen      ','Foxx_sen      '/) ! mean_sensi_heat_flx
+          F_flds(1 ,:) = (/'Faxa_taux     ','Foxx_taux     '/) ! inst_zonal_moment_flx_atm
+          F_flds(2 ,:) = (/'Faxa_tauy     ','Foxx_tauy     '/) ! inst_merid_moment_flx_atm
+          F_flds(3 ,:) = (/'Faxa_rain     ','Faxa_rain     '/) ! inst_prec_rate
+          F_flds(4 ,:) = (/'Faxa_lwnet    ','Foxx_lwnet    '/) ! inst_net_lw_flx
+          F_flds(5 ,:) = (/'Faxa_sen      ','Foxx_sen      '/) ! inst_sensi_heat_flx
           F_flds(6 ,:) = (/'Faxa_evap     ','Foxx_evap     '/) ! inst_evap_rate
           F_flds(7 ,:) = (/'Faxa_swndr    ','Foxx_swnet_idr'/) ! inst_down_sw_ir_dir_flx
           F_flds(8 ,:) = (/'Faxa_swndf    ','Foxx_swnet_idf'/) ! inst_down_sw_ir_dif_flx
@@ -521,13 +521,13 @@ contains
     if (hafs_attr%atm_present .and. hafs_attr%ocn_present) then
        if (trim(coupling_mode) == 'hafs') then
           allocate(F_flds(7,2))
-          F_flds(1,:) = (/'Faxa_taux ','Faxa_taux '/) ! mean_zonal_moment_flx_atm
-          F_flds(2,:) = (/'Faxa_tauy ','Faxa_tauy '/) ! mean_merid_moment_flx_atm
-          F_flds(3,:) = (/'Faxa_rain ','Faxa_rain '/) ! mean_prec_rate
-          F_flds(4,:) = (/'Faxa_swnet','Faxa_swnet'/) ! mean_net_sw_flx
-          F_flds(5,:) = (/'Faxa_lwnet','Faxa_lwnet'/) ! mean_net_lw_flx
-          F_flds(6,:) = (/'Faxa_sen  ','Faxa_sen  '/) ! mean_sensi_heat_flx
-          F_flds(7,:) = (/'Faxa_lat  ','Faxa_lat  '/) ! mean_laten_heat_flx
+          F_flds(1,:) = (/'Faxa_taux ','Faxa_taux '/) ! inst_zonal_moment_flx_atm
+          F_flds(2,:) = (/'Faxa_tauy ','Faxa_tauy '/) ! inst_merid_moment_flx_atm
+          F_flds(3,:) = (/'Faxa_rain ','Faxa_rain '/) ! inst_prec_rate
+          F_flds(4,:) = (/'Faxa_swnet','Faxa_swnet'/) ! inst_net_sw_flx
+          F_flds(5,:) = (/'Faxa_lwnet','Faxa_lwnet'/) ! inst_net_lw_flx
+          F_flds(6,:) = (/'Faxa_sen  ','Faxa_sen  '/) ! inst_sensi_heat_flx
+          F_flds(7,:) = (/'Faxa_lat  ','Faxa_lat  '/) ! inst_laten_heat_flx
           do n = 1,size(F_flds,1)
              fldname1 = trim(F_flds(n,1))
              fldname2 = trim(F_flds(n,2))
@@ -543,11 +543,11 @@ contains
           deallocate(F_flds)
        else
           allocate(F_flds(10,2))
-          F_flds(1 ,:) = (/'Faxa_taux     ','Foxx_taux     '/) ! mean_zonal_moment_flx_atm
-          F_flds(2 ,:) = (/'Faxa_tauy     ','Foxx_tauy     '/) ! mean_merid_moment_flx_atm
-          F_flds(3 ,:) = (/'Faxa_rain     ','Faxa_rain     '/) ! mean_prec_rate
-          F_flds(4 ,:) = (/'Faxa_lwnet    ','Foxx_lwnet    '/) ! mean_net_lw_flx
-          F_flds(5 ,:) = (/'Faxa_sen      ','Foxx_sen      '/) ! mean_sensi_heat_flx
+          F_flds(1 ,:) = (/'Faxa_taux     ','Foxx_taux     '/) ! inst_zonal_moment_flx_atm
+          F_flds(2 ,:) = (/'Faxa_tauy     ','Foxx_tauy     '/) ! inst_merid_moment_flx_atm
+          F_flds(3 ,:) = (/'Faxa_rain     ','Faxa_rain     '/) ! inst_prec_rate
+          F_flds(4 ,:) = (/'Faxa_lwnet    ','Foxx_lwnet    '/) ! inst_net_lw_flx
+          F_flds(5 ,:) = (/'Faxa_sen      ','Foxx_sen      '/) ! inst_sensi_heat_flx
           F_flds(6 ,:) = (/'Faxa_evap     ','Foxx_evap     '/) ! inst_evap_rate
           F_flds(7 ,:) = (/'Faxa_swndr    ','Foxx_swnet_idr'/) ! inst_down_sw_ir_dir_flx
           F_flds(8 ,:) = (/'Faxa_swndf    ','Foxx_swnet_idf'/) ! inst_down_sw_ir_dif_flx

--- a/mediator/esmFldsExchange_nems_mod.F90
+++ b/mediator/esmFldsExchange_nems_mod.F90
@@ -49,6 +49,7 @@ contains
     ! local variables:
     type(InternalState) :: is_local
     integer             :: n, maptype
+    logical             :: med_aoflux_to_ocn
     character(len=CX)   :: msgString
     character(len=CL)   :: cvalue
     character(len=CS)   :: fldname
@@ -75,6 +76,12 @@ contains
     write(msgString,'(A,i6,A)') trim(subname)//': maptype is ',maptype,', '//mapnames(maptype)
     call ESMF_LogWrite(trim(msgString), ESMF_LOGMSG_INFO)
 
+    if (trim(coupling_mode) == 'nems_orig_data' .or. trim(coupling_mode) == 'nems_frac_aoflux') then
+       med_aoflux_to_ocn = .true.
+    else
+       med_aoflux_to_ocn = .false.
+    end if
+
     !=====================================================================
     ! scalar information
     !=====================================================================
@@ -83,8 +90,8 @@ contains
        call NUOPC_CompAttributeGet(gcomp, name="ScalarFieldName", value=cvalue, rc=rc)
        if (ChkErr(rc,__LINE__,u_FILE_u)) return
        do n = 1,ncomps
-          call addfld_to(n, trim(cvalue))
-          call addfld_from(n, trim(cvalue))
+          call addfld_to(n   , trim(cvalue))
+          call addfld_from(n , trim(cvalue))
        end do
     end if
 
@@ -98,78 +105,45 @@ contains
        if (is_local%wrap%comp_present(compocn)) call addfld_from(compocn, 'So_omask')
        if (is_local%wrap%comp_present(complnd)) call addfld_from(complnd, 'Sl_lfrin')
     else
-       if ( fldchk(is_local%wrap%FBexp(compice)        , trim(fldname), rc=rc) .and. &
-            fldchk(is_local%wrap%FBImp(compocn,compocn), trim(fldname), rc=rc)) then
+       if ( fldchk(is_local%wrap%FBexp(compice)        , 'So_omask', rc=rc) .and. &
+            fldchk(is_local%wrap%FBImp(compocn,compocn), 'So_omask', rc=rc)) then
           call addmap_from(compocn, 'So_omask', compice,  mapfcopy, 'unset', 'unset')
        end if
     end if
 
-    if ( trim(coupling_mode) == 'nems_orig_data') then
-       ! atm fields required for atm/ocn flux calculation
-       allocate(flds(10))
-       flds = (/'Sa_u   ', 'Sa_v   ', 'Sa_z   ', 'Sa_tbot', 'Sa_pbot', &
-                'Sa_shum', 'Sa_u10m', 'Sa_v10m', 'Sa_t2m ', 'Sa_q2m '/)
-       do n = 1,size(flds)
-          fldname = trim(flds(n))
-          if (phase == 'advertise') then
-             if (is_local%wrap%comp_present(compatm) )then
-                call addfld_from(compatm, trim(fldname))
-             end if
-          else
-            if ( fldchk(is_local%wrap%FBImp(compatm,compatm), trim(fldname), rc=rc)) then
-               call addmap_from(compatm, trim(fldname), compocn, maptype, 'one', 'unset')
-            end if
-          end if
-       end do
-       deallocate(flds)
-
-       ! fields returned by the atm/ocn flux computation which are otherwise unadvertised
-       allocate(flds(8))
-       flds = (/'So_tref  ', 'So_qref  ', 'So_ustar ', 'So_re    ','So_ssq   ', &
-                'So_u10   ', 'So_duu10n', 'Faox_lat '/)
-       do n = 1,size(flds)
-          fldname = trim(flds(n))
-          if (phase == 'advertise') then
-             call addfld_aoflux(trim(fldname))
-          end if
-       end do
-       deallocate(flds)
-    end if
-
-    if (trim(coupling_mode) == 'nems_frac_aoflux' .or. trim(coupling_mode) == 'nems_frac_aoflux_sbs') then
-       allocate(flds(12))
-       flds = (/'Sa_u     ', 'Sa_v     ', 'Sa_z     ', 'Sa_tbot  ', 'Sa_pbot  ', &
-                'Sa_pslv  ', 'Sa_shum  ', 'Sa_ptem  ', 'Sa_dens  ', 'Sa_u10m  ', &
-                'Sa_v10m  ', 'Faxa_lwdn'/)
-       do n = 1,size(flds)
-          fldname = trim(flds(n))
-          if (phase == 'advertise') then
-             if (is_local%wrap%comp_present(compatm) )then
-                call addfld_from(compatm, trim(fldname))
-             end if
-          else
-            if ( fldchk(is_local%wrap%FBImp(compatm,compatm), trim(fldname), rc=rc)) then
-               call addmap_from(compatm, trim(fldname), compocn, maptype, 'one', 'unset')
-            end if
-          end if
-       end do
-       deallocate(flds)
-
-       ! fields returned by the atm/ocn flux computation which are otherwise unadvertised
+    ! fields required for atm/ocn flux calculation
+    if (is_local%wrap%comp_present(compocn) .and. is_local%wrap%comp_present(compatm)) then
+       ! from atm: states for fluxes
        allocate(flds(13))
-       flds = (/'So_tref  ', 'So_qref  ','So_u10   ', 'So_ustar ','So_ssq   ', &
-                'So_re    ', 'So_duu10n','Faox_lwup', 'Faox_sen ','Faox_lat ', &
-                'Faox_evap', 'Faox_taux','Faox_tauy'/)
+       flds = (/'Sa_u   ', 'Sa_v   ', 'Sa_z   ', 'Sa_tbot', 'Sa_pbot', 'Sa_pslv', &
+                'Sa_shum', 'Sa_ptem', 'Sa_dens', 'Sa_u10m', 'Sa_v10m', 'Sa_t2m ', &
+                'Sa_q2m '/)
        do n = 1,size(flds)
           fldname = trim(flds(n))
           if (phase == 'advertise') then
-             call addfld_aoflux(trim(fldname))
+             call addfld_from(compatm , fldname)
+          else
+             if ( fldchk(is_local%wrap%FBImp(compatm,compatm), fldname, rc=rc)) then
+                call addmap_from(compatm, fldname, compocn, maptype, 'one', 'unset')
+             end if
+          end if
+       end do
+       deallocate(flds)
+
+       ! from med: fields returned by the atm/ocn flux computation, otherwise unadvertised
+       allocate(flds(8))
+       flds = (/'So_tref  ', 'So_qref  ', 'So_ustar ', 'So_re    ','So_ssq   ', 'So_u10   ', &
+                'So_duu10n', 'Faox_lat '/)
+       do n = 1,size(flds)
+          fldname = trim(flds(n))
+          if (phase == 'advertise') then
+             call addfld_aoflux(fldname)
           end if
        end do
        deallocate(flds)
     end if
 
-    ! Advertise the ocean albedos. These are not sent to the ATM in UFS.
+    ! from med: ocean albedos (not sent to the ATM in UFS).
     if (phase == 'advertise') then
        call addfld_ocnalb('So_avsdr')
        call addfld_ocnalb('So_avsdf')
@@ -184,16 +158,16 @@ contains
     ! to atm: fractions (computed in med_phases_prep_atm)
     if (phase == 'advertise') then
        if (is_local%wrap%comp_present(compice) .and. is_local%wrap%comp_present(compatm)) then
-          call addfld_from(compice, 'Si_ifrac')
-          call addfld_to(compatm, 'Si_ifrac')
+          call addfld_from(compice , 'Si_ifrac')
+          call addfld_to(compatm   , 'Si_ifrac')
        end if
        ! ofrac used by atm
        if (is_local%wrap%comp_present(compocn) .and. is_local%wrap%comp_present(compatm)) then
-          call addfld_from(compatm, 'Sa_ofrac')
+          call addfld_from(compatm , 'Sa_ofrac')
        end if
        ! lfrac used by atm
        if (is_local%wrap%comp_present(complnd) .and. is_local%wrap%comp_present(compatm)) then
-          call addfld_to(compatm, 'Sl_lfrac')
+          call addfld_to(compatm  , 'Sl_lfrac')
        end if
     end if
 
@@ -207,39 +181,40 @@ contains
     ! - mean snow volume per unit area
     ! - surface temperatures
     allocate(flds(9))
-    flds = (/'Faii_taux', 'Faii_tauy', 'Faii_lat ', 'Faii_sen ', 'Faii_lwup', &
-             'Faii_evap', 'Si_vice  ', 'Si_vsno  ', 'Si_t     '/)
+    flds = (/'Faii_taux', 'Faii_tauy', 'Faii_lat ', 'Faii_sen ', 'Faii_lwup', 'Faii_evap', &
+             'Si_vice  ', 'Si_vsno  ', 'Si_t     '/)
     do n = 1,size(flds)
        fldname = trim(flds(n))
        if (phase == 'advertise') then
           if (is_local%wrap%comp_present(compice) .and. is_local%wrap%comp_present(compatm)) then
-             call addfld_from(compice, trim(fldname))
-             call addfld_to(compatm, trim(fldname))
+             call addfld_from(compice , fldname)
+             call addfld_to(compatm   , fldname)
           end if
        else
-          if ( fldchk(is_local%wrap%FBexp(compatm)        , trim(fldname), rc=rc) .and. &
-               fldchk(is_local%wrap%FBImp(compice,compice), trim(fldname), rc=rc)) then
-             call addmap_from(compice, trim(fldname), compatm, maptype, 'ifrac', 'unset')
-             call addmrg_to(compatm, trim(fldname), mrg_from=compice, mrg_fld=trim(fldname), mrg_type='copy')
+          if ( fldchk(is_local%wrap%FBexp(compatm)        , fldname, rc=rc) .and. &
+               fldchk(is_local%wrap%FBImp(compice,compice), fldname, rc=rc)) then
+             call addmap_from(compice, fldname, compatm, maptype, 'ifrac', 'unset')
+             call addmrg_to(compatm, fldname, mrg_from=compice, mrg_fld=fldname, mrg_type='copy')
           end if
        end if
     end do
     deallocate(flds)
 
+    ! to atm: unmerged sea ice albedo, 4 bands
     allocate(flds(4))
     flds = (/'Si_avsdr', 'Si_avsdf', 'Si_anidr', 'Si_anidf'/)
     do n = 1,size(flds)
        fldname = trim(flds(n))
        if (phase == 'advertise') then
           if (is_local%wrap%comp_present(compice) .and. is_local%wrap%comp_present(compatm)) then
-             call addfld_from(compice, trim(fldname))
-             call addfld_to(compatm, trim(fldname))
+             call addfld_from(compice , fldname)
+             call addfld_to(compatm   , fldname)
           end if
        else
-          if ( fldchk(is_local%wrap%FBexp(compatm)        , trim(fldname), rc=rc) .and. &
-               fldchk(is_local%wrap%FBImp(compice,compice), trim(fldname), rc=rc)) then
-             call addmap_from(compice, trim(fldname), compatm, maptype, 'ifrac', 'unset')
-             call addmrg_to(compatm, trim(fldname), mrg_from=compice, mrg_fld=trim(fldname), mrg_type='copy')
+          if ( fldchk(is_local%wrap%FBexp(compatm)        , fldname, rc=rc) .and. &
+               fldchk(is_local%wrap%FBImp(compice,compice), fldname, rc=rc)) then
+             call addmap_from(compice, fldname, compatm, maptype, 'ifrac', 'unset')
+             call addmrg_to(compatm, fldname, mrg_from=compice, mrg_fld=fldname, mrg_type='copy')
           end if
        end if
     end do
@@ -248,8 +223,8 @@ contains
     ! to atm: unmerged surface temperatures from ocn
     if (phase == 'advertise') then
        if (is_local%wrap%comp_present(compocn) .and. is_local%wrap%comp_present(compatm)) then
-          call addfld_from(compocn, 'So_t')
-          call addfld_to(compatm, 'So_t')
+          call addfld_from(compocn , 'So_t')
+          call addfld_to(compatm   , 'So_t')
        end if
     else
        if ( fldchk(is_local%wrap%FBexp(compatm)        , 'So_t', rc=rc) .and. &
@@ -262,8 +237,8 @@ contains
     ! to atm: unmerged surface temperatures from lnd
     if (phase == 'advertise') then
        if (is_local%wrap%comp_present(complnd) .and. is_local%wrap%comp_present(compatm)) then
-          call addfld_from(complnd, 'Sl_t')
-          call addfld_to(compatm, 'Sl_t')
+          call addfld_from(complnd , 'Sl_t')
+          call addfld_to(compatm   , 'Sl_t')
        end if
     else
        if ( fldchk(is_local%wrap%FBexp(compatm)        , 'Sl_t', rc=rc) .and. &
@@ -278,35 +253,31 @@ contains
     ! - surface latent heat flux,
     ! - surface sensible heat flux
     ! - surface upward longwave heat flux
-    ! - evaporation water flux from water, not in the list do we need to send it to atm?
-    if (trim(coupling_mode) == 'nems_frac_aoflux') then
-       if (is_local%wrap%comp_present(compocn) .and. is_local%wrap%comp_present(compatm)) then
-          allocate(flds(5))
-          flds = (/ 'lat ', 'sen ', 'lwup', 'taux', 'tauy' /)
-          if (phase == 'advertise') then
-             do n = 1,size(flds)
-                call addfld_aoflux('Faox_'//trim(flds(n)))
-                call addfld_to(compatm, 'Faox_'//trim(flds(n)))
-             end do
-          else
-             do n = 1,size(flds)
-                if (fldchk(is_local%wrap%FBMed_aoflux_o, 'Faox_'//trim(flds(n)), rc=rc)) then
-                   if (trim(is_local%wrap%aoflux_grid) == 'ogrid') then
-                      call addmap_aoflux('Faox_'//trim(flds(n)), compatm, maptype, 'ofrac', 'unset')
-                   end if
-                   call addmrg_to(compatm, 'Faox_'//trim(flds(n)), mrg_from=compmed, mrg_fld='Faox_'//trim(flds(n)), mrg_type='copy')
-                end if
-             end do
+    allocate(flds(5))
+    flds = (/ 'Faox_lat ', 'Faox_sen ', 'Faox_lwup', 'Faox_taux', 'Faox_tauy' /)
+    do n = 1,size(flds)
+       fldname = trim(flds(n))
+       if (phase == 'advertise') then
+          if (is_local%wrap%comp_present(compatm) .and. is_local%wrap%comp_present(compocn)) then
+             call addfld_aoflux(fldname)
+             call addfld_to(compatm , fldname)
           end if
-          deallocate(flds)
+       else
+          if (fldchk(is_local%wrap%FBMed_aoflux_o, fldname, rc=rc)) then
+             if (trim(is_local%wrap%aoflux_grid) == 'ogrid') then
+                call addmap_aoflux(fldname, compatm, maptype, 'ofrac', 'unset')
+             end if
+             call addmrg_to(compatm, fldname, mrg_from=compmed, mrg_fld=fldname, mrg_type='copy')
+          end if
        end if
-    end if
+    end do
+    deallocate(flds)
 
     ! to atm: surface roughness length from wav
     if (phase == 'advertise') then
        if (is_local%wrap%comp_present(compwav) .and. is_local%wrap%comp_present(compatm)) then
-          call addfld_from(compwav, 'Sw_z0')
-          call addfld_to(compatm, 'Sw_z0')
+          call addfld_from(compwav , 'Sw_z0')
+          call addfld_to(compatm   , 'Sw_z0')
        end if
     else
        if ( fldchk(is_local%wrap%FBexp(compatm)        , 'Sw_z0', rc=rc) .and. &
@@ -323,8 +294,8 @@ contains
     ! to ocn: sea level pressure from atm
     if (phase == 'advertise') then
        if (is_local%wrap%comp_present(compatm) .and. is_local%wrap%comp_present(compocn)) then
-          call addfld_from(compatm, 'Sa_pslv')
-          call addfld_to(compocn, 'Sa_pslv')
+          call addfld_from(compatm , 'Sa_pslv')
+          call addfld_to(compocn   , 'Sa_pslv')
        end if
     else
        if ( fldchk(is_local%wrap%FBexp(compocn)        , 'Sa_pslv', rc=rc) .and. &
@@ -337,14 +308,13 @@ contains
     ! to ocn: swpen thru ice w/o bands
     if (phase == 'advertise') then
        if (is_local%wrap%comp_present(compice) .and. is_local%wrap%comp_present(compocn)) then
-          call addfld_from(compice, 'Fioi_swpen')
+          call addfld_from(compice , 'Fioi_swpen')
        end if
     else
        if (fldchk(is_local%wrap%FBImp(compice,compice), 'Fioi_swpen', rc=rc)) then
           call addmap_from(compice, 'Fioi_swpen', compocn, mapfcopy, 'unset', 'unset')
        end if
     end if
-
     ! to ocn: from sw from atm and sw net from ice (custom merge in med_phases_prep_ocn)
     ! - downward direct  near-infrared ("n" or "i") incident solar radiation
     ! - downward diffuse near-infrared ("n" or "i") incident solar radiation
@@ -359,8 +329,8 @@ contains
     do n = 1,size(oflds)
        if (phase == 'advertise') then
           if (is_local%wrap%comp_present(compatm) .and. is_local%wrap%comp_present(compocn)) then
-             call addfld_from(compatm, trim(aflds(n)))
-             call addfld_to(compocn, trim(oflds(n)))
+             call addfld_from(compatm , trim(aflds(n)))
+             call addfld_to(compocn   , trim(oflds(n)))
           end if
        else
           if ( fldchk(is_local%wrap%FBexp(compocn)        , trim(oflds(n)), rc=rc) .and. &
@@ -373,8 +343,8 @@ contains
     do n = 1,size(oflds)
        if (phase == 'advertise') then
           if (is_local%wrap%comp_present(compice) .and. is_local%wrap%comp_present(compocn)) then
-             call addfld_from(compice, trim(iflds(n)))
-             call addfld_to(compocn, trim(oflds(n)))
+             call addfld_from(compice , trim(iflds(n)))
+             call addfld_to(compocn   , trim(oflds(n)))
           end if
        else
           if ( fldchk(is_local%wrap%FBexp(compocn)        , trim(oflds(n)), rc=rc) .and. &
@@ -394,190 +364,153 @@ contains
        fldname = trim(flds(n))
        if (phase == 'advertise') then
           if (is_local%wrap%comp_present(compatm) .and. is_local%wrap%comp_present(compocn)) then
-             call addfld_from(compatm, trim(fldname))
-             call addfld_to(compocn, trim(fldname))
+             call addfld_from(compatm , fldname)
+             call addfld_to(compocn   , fldname)
           end if
        else
-          if ( fldchk(is_local%wrap%FBexp(compocn)        , trim(fldname), rc=rc) .and. &
-               fldchk(is_local%wrap%FBImp(compatm,compatm), trim(fldname), rc=rc)) then
-             call addmap_from(compatm, trim(fldname), compocn, maptype, 'one', 'unset')
-             call addmrg_to(compocn, trim(fldname), &
-                  mrg_from=compatm, mrg_fld=trim(fldname), mrg_type='copy_with_weights', mrg_fracname='ofrac')
+          if ( fldchk(is_local%wrap%FBexp(compocn)        , fldname, rc=rc) .and. &
+               fldchk(is_local%wrap%FBImp(compatm,compatm), fldname, rc=rc)) then
+             call addmap_from(compatm, fldname, compocn, maptype, 'one', 'unset')
+             call addmrg_to(compocn, fldname, &
+                  mrg_from=compatm, mrg_fld=fldname, mrg_type='copy_with_weights', mrg_fracname='ofrac')
           end if
        end if
     end do
+
+    !to ocn: surface stress from mediator or atm and ice stress via auto merge
+    flds = (/'taux', 'tauy'/)
+    do n = 1,size(flds)
+       fldname = trim(flds(n))
+       if (phase == 'advertise') then
+          if (is_local%wrap%comp_present(compice) .and. is_local%wrap%comp_present(compocn)) then
+             call addfld_aoflux('Faox_'//fldname)
+             call addfld_from(compatm , 'Faxa_'//fldname)
+             call addfld_from(compice , 'Fioi_'//fldname)
+             call addfld_to(compocn   , 'Foxx_'//fldname)
+          end if
+       else
+          if (med_aoflux_to_ocn) then
+             if ( fldchk(is_local%wrap%FBexp(compocn)        , 'Foxx_'//fldname, rc=rc) .and. &
+                  fldchk(is_local%wrap%FBImp(compice,compice), 'Fioi_'//fldname, rc=rc) .and. &
+                  fldchk(is_local%wrap%FBMed_aoflux_o        , 'Faox_'//fldname, rc=rc)) then
+                call addmap_from(compice,  'Fioi_'//fldname, compocn, mapfcopy, 'unset', 'unset')
+                call addmrg_to(compocn,  'Foxx_'//fldname, &
+                     mrg_from=compmed, mrg_fld='Faox_'//fldname, mrg_type='merge', mrg_fracname='ofrac')
+                call addmrg_to(compocn,  'Foxx_'//fldname, &
+                     mrg_from=compice, mrg_fld='Fioi_'//fldname, mrg_type='merge', mrg_fracname='ifrac')
+             end if
+          else
+             if ( fldchk(is_local%wrap%FBexp(compocn)   , 'Foxx_'//fldname, rc=rc) .and. &
+                  fldchk(is_local%wrap%FBImp(compice,compice), 'Fioi_'//fldname, rc=rc) .and. &
+                  fldchk(is_local%wrap%FBImp(compatm,compatm), 'Faxa_'//fldname, rc=rc)) then
+                call addmap_from(compice, 'Fioi_'//fldname, compocn, mapfcopy, 'unset', 'unset')
+                call addmap_from(compatm, 'Faxa_'//fldname, compocn, mapconsf_aofrac, 'aofrac', 'unset')
+                call addmrg_to(compocn, 'Foxx_'//fldname, &
+                     mrg_from=compice, mrg_fld='Fioi_'//fldname, mrg_type='merge', mrg_fracname='ifrac')
+                call addmrg_to(compocn, 'Foxx_'//fldname, &
+                     mrg_from=compatm, mrg_fld='Faxa_'//fldname, mrg_type='merge', mrg_fracname='ofrac')
+             end if
+          end if
+       end if
+       end do
     deallocate(flds)
 
-    if (trim(coupling_mode) == 'nems_orig' .or. trim(coupling_mode) == 'nems_frac' .or. &
-        trim(coupling_mode) == 'nems_frac_aoflux_sbs') then
-       ! to ocn: merge surface stress
-       allocate(oflds(2))
-       allocate(aflds(2))
-       allocate(iflds(2))
-       oflds = (/'Foxx_taux', 'Foxx_tauy'/)
-       aflds = (/'Faxa_taux', 'Faxa_tauy'/)
-       iflds = (/'Fioi_taux', 'Fioi_tauy'/)
-       do n = 1,size(oflds)
-          if (phase == 'advertise') then
-             if (is_local%wrap%comp_present(compice) .and. is_local%wrap%comp_present(compatm) &
-                .and. is_local%wrap%comp_present(compocn)) then
-                   call addfld_from(compice, trim(iflds(n)))
-                   call addfld_from(compatm, trim(aflds(n)))
-                   call addfld_to(compocn, trim(oflds(n)))
-             end if
-          else
-             if ( fldchk(is_local%wrap%FBexp(compocn)        , trim(oflds(n)), rc=rc) .and. &
-                  fldchk(is_local%wrap%FBImp(compice,compice), trim(iflds(n)), rc=rc) .and. &
-                  fldchk(is_local%wrap%FBImp(compatm,compatm), trim(aflds(n)), rc=rc)) then
-                call addmap_from(compice, trim(iflds(n)), compocn, mapfcopy, 'unset', 'unset')
-                call addmap_from(compatm, trim(aflds(n)), compocn, mapconsf_aofrac, 'aofrac', 'unset')
-                call addmrg_to(compocn, trim(oflds(n)), &
-                     mrg_from=compice, mrg_fld=trim(iflds(n)), mrg_type='merge', mrg_fracname='ifrac')
-                call addmrg_to(compocn, trim(oflds(n)), &
-                     mrg_from=compatm, mrg_fld=trim(aflds(n)), mrg_type='merge', mrg_fracname='ofrac')
-             end if
-          end if
-       end do
-       deallocate(oflds)
-       deallocate(aflds)
-       deallocate(iflds)
-
-       ! to ocn: net long wave via auto merge
-       if (phase == 'advertise') then
-          if (is_local%wrap%comp_present(compatm) .and. is_local%wrap%comp_present(compocn)) then
-             call addfld_from(compatm, 'Faxa_lwnet')
-             call addfld_to(compocn, 'Faxa_lwnet')
-          end if
-       else
-          if ( fldchk(is_local%wrap%FBexp(compocn)        , 'Faxa_lwnet', rc=rc) .and. &
-               fldchk(is_local%wrap%FBImp(compatm,compatm), 'Faxa_lwnet', rc=rc)) then
-             call addmap_from(compatm, 'Faxa_lwnet', compocn, mapconsf_aofrac, 'aofrac', 'unset')
-             call addmrg_to(compocn, 'Faxa_lwnet', &
-                  mrg_from=compatm, mrg_fld='Faxa_lwnet', mrg_type='copy_with_weights', mrg_fracname='ofrac')
-          end if
+    ! to ocn: net long wave via auto merge
+    if (phase == 'advertise') then
+       if (is_local%wrap%comp_present(compatm) .and. is_local%wrap%comp_present(compocn)) then
+          call addfld_aoflux('Faox_lwup')
+          call addfld_from(compatm , 'Faxa_lwnet')
+          call addfld_from(compatm , 'Faxa_lwdn')
+          call addfld_to(compocn   , 'Foxx_lwnet')
        end if
-
-       ! to ocn: sensible heat flux
-       if (phase == 'advertise') then
-          if (is_local%wrap%comp_present(compatm) .and. is_local%wrap%comp_present(compocn)) then
-             call addfld_from(compatm, 'Faxa_sen')
-             call addfld_to(compocn, 'Faxa_sen')
-          end if
-       else
-          if ( fldchk(is_local%wrap%FBexp(compocn)        , 'Faxa_sen', rc=rc) .and. &
-               fldchk(is_local%wrap%FBImp(compatm,compatm), 'Faxa_sen', rc=rc)) then
-             call addmap_from(compatm, 'Faxa_sen', compocn, mapconsf_aofrac, 'aofrac', 'unset')
-             call addmrg_to(compocn, 'Faxa_sen', &
-                  mrg_from=compatm, mrg_fld='Faxa_sen', mrg_type='copy_with_weights', mrg_fracname='ofrac')
-          end if
-       end if
-
-       ! to ocn: evaporation water flux
-       if (phase == 'advertise') then
-          if (is_local%wrap%comp_present(compatm) .and. is_local%wrap%comp_present(compocn)) then
-             call addfld_from(compatm, 'Faxa_evap')
-             call addfld_to(compocn, 'Faxa_evap')
-          end if
-       else
-          if ( fldchk(is_local%wrap%FBexp(compocn)        , 'Faxa_evap', rc=rc) .and. &
-               fldchk(is_local%wrap%FBImp(compatm,compatm), 'Faxa_evap' , rc=rc)) then
-             call addmap_from(compatm, 'Faxa_evap', compocn, mapconsf_aofrac, 'aofrac', 'unset')
-             call addmrg_to(compocn, 'Faxa_evap', &
-                  mrg_from=compatm, mrg_fld='Faxa_evap', mrg_type='copy_with_weights', mrg_fracname='ofrac')
-          end if
-       end if
-    else if (trim(coupling_mode) == 'nems_orig_data' .or. trim(coupling_mode) == 'nems_frac_aoflux') then
-       ! nems_orig_data
-       ! to ocn: surface stress from mediator and ice stress via auto merge
-       allocate(flds(2))
-       flds = (/'taux', 'tauy'/)
-       do n = 1,size(flds)
-          if (phase == 'advertise') then
-             if (is_local%wrap%comp_present(compice) .and. is_local%wrap%comp_present(compocn)) then
-                call addfld_aoflux('Faox_'//trim(flds(n)))
-                call addfld_from(compice , 'Fioi_'//trim(flds(n)))
-                call addfld_to(compocn , 'Foxx_'//trim(flds(n)))
-             end if
-          else
-             if ( fldchk(is_local%wrap%FBexp(compocn)        , 'Foxx_'//trim(flds(n)), rc=rc) .and. &
-                  fldchk(is_local%wrap%FBMed_aoflux_o        , 'Faox_'//trim(flds(n)), rc=rc) .and. &
-                  fldchk(is_local%wrap%FBImp(compice,compice), 'Fioi_'//trim(flds(n)), rc=rc)) then
-                call addmap_from(compice,  'Fioi_'//trim(flds(n)), compocn, mapfcopy, 'unset', 'unset')
-                call addmrg_to(compocn,  'Foxx_'//trim(flds(n)), &
-                     mrg_from=compmed, mrg_fld='Faox_'//trim(flds(n)), mrg_type='merge', mrg_fracname='ofrac')
-                call addmrg_to(compocn,  'Foxx_'//trim(flds(n)), &
-                     mrg_from=compice, mrg_fld='Fioi_'//trim(flds(n)), mrg_type='merge', mrg_fracname='ifrac')
-             end if
-          end if
-       end do
-       deallocate(flds)
-
-       ! to ocn: long wave net via auto merge
-       if (phase == 'advertise') then
-          if (is_local%wrap%comp_present(compatm) .and. is_local%wrap%comp_present(compocn)) then
-             call addfld_aoflux('Faox_lwup')
-             call addfld_from(compatm, 'Faxa_lwdn')
-             call addfld_to(compocn, 'Foxx_lwnet')
-          end if
-       else
+    else
+       if (med_aoflux_to_ocn) then
           if ( fldchk(is_local%wrap%FBexp(compocn)        , 'Foxx_lwnet', rc=rc) .and. &
-               fldchk(is_local%wrap%FBMed_aoflux_o        , 'Faox_lwup' , rc=rc) .and. &
-               fldchk(is_local%wrap%FBImp(compatm,compatm), 'Faxa_lwdn' , rc=rc)) then
+               fldchk(is_local%wrap%FBImp(compatm,compatm), 'Faxa_lwdn' , rc=rc) .and. &
+               fldchk(is_local%wrap%FBMed_aoflux_o        , 'Faox_lwup' , rc=rc)) then
              call addmap_from(compatm, 'Faxa_lwdn', compocn, maptype, 'one', 'unset')
              call addmrg_to(compocn, 'Foxx_lwnet', &
                   mrg_from=compmed, mrg_fld='Faox_lwup', mrg_type='merge', mrg_fracname='ofrac')
              call addmrg_to(compocn, 'Foxx_lwnet', &
                   mrg_from=compatm, mrg_fld='Faxa_lwdn', mrg_type='merge', mrg_fracname='ofrac')
           end if
-       end if
-
-       ! to ocn: sensible heat flux from mediator via auto merge
-       if (phase == 'advertise') then
-          if (is_local%wrap%comp_present(compocn)) then
-             call addfld_aoflux('Faox_sen')
-             call addfld_to(compocn, 'Faox_sen')
-          end if
        else
-          if ( fldchk(is_local%wrap%FBexp(compocn)        , 'Faox_sen', rc=rc) .and. &
-               fldchk(is_local%wrap%FBMed_aoflux_o        , 'Faox_sen' , rc=rc)) then
-             call addmrg_to(compocn, 'Faox_sen', &
-                  mrg_from=compmed, mrg_fld='Faox_sen', mrg_type='copy_with_weights', mrg_fracname='ofrac')
-          end if
-       end if
-
-       ! to ocn: evaporation water flux from mediator via auto merge
-       if (phase == 'advertise') then
-          if (is_local%wrap%comp_present(compocn)) then
-             call addfld_aoflux('Faox_evap')
-             call addfld_to(compocn, 'Faox_evap')
-          end if
-       else
-          if ( fldchk(is_local%wrap%FBexp(compocn)        , 'Faox_evap', rc=rc) .and. &
-               fldchk(is_local%wrap%FBMed_aoflux_o        , 'Faox_evap' , rc=rc)) then
-             call addmrg_to(compocn, 'Faox_evap', &
-                  mrg_from=compmed, mrg_fld='Faox_evap', mrg_type='copy_with_weights', mrg_fracname='ofrac')
+          if ( fldchk(is_local%wrap%FBexp(compocn)        , 'Foxx_lwnet', rc=rc) .and. &
+               fldchk(is_local%wrap%FBImp(compatm,compatm), 'Faxa_lwnet', rc=rc)) then
+             call addmap_from(compatm, 'Faxa_lwnet', compocn, mapconsf_aofrac, 'aofrac', 'unset')
+             call addmrg_to(compocn, 'Foxx_lwnet', &
+                  mrg_from=compatm, mrg_fld='Faxa_lwnet', mrg_type='copy_with_weights', mrg_fracname='ofrac')
           end if
        end if
     end if
 
-    ! to ocn: water flux due to melting ice from ice
-    ! to ocn: heat flux from melting ice from ice
-    ! to ocn: salt flux from ice
+    ! to ocn: sensible heat flux
+    if (phase == 'advertise') then
+       if (is_local%wrap%comp_present(compatm) .and. is_local%wrap%comp_present(compocn)) then
+          call addfld_aoflux('Faox_sen')
+          call addfld_from(compatm , 'Faxa_sen')
+          call addfld_to(compocn   , 'Foxx_sen')
+       end if
+    else
+       if (med_aoflux_to_ocn) then
+          if ( fldchk(is_local%wrap%FBexp(compocn)        , 'Foxx_sen', rc=rc) .and. &
+               fldchk(is_local%wrap%FBMed_aoflux_o        , 'Faox_sen' , rc=rc)) then
+             call addmrg_to(compocn, 'Foxx_sen', &
+                  mrg_from=compmed, mrg_fld='Faox_sen', mrg_type='copy_with_weights', mrg_fracname='ofrac')
+          end if
+       else
+          if ( fldchk(is_local%wrap%FBexp(compocn)        , 'Foxx_sen', rc=rc) .and. &
+               fldchk(is_local%wrap%FBImp(compatm,compatm), 'Faxa_sen', rc=rc)) then
+             call addmap_from(compatm, 'Faxa_sen', compocn, mapconsf_aofrac, 'aofrac', 'unset')
+             call addmrg_to(compocn, 'Foxx_sen', &
+                  mrg_from=compatm, mrg_fld='Faxa_sen', mrg_type='copy_with_weights', mrg_fracname='ofrac')
+          end if
+       end if
+    end if
+
+    ! to ocn: evaporation water flux
+    if (phase == 'advertise') then
+       if (is_local%wrap%comp_present(compatm) .and. is_local%wrap%comp_present(compocn)) then
+          call addfld_aoflux('Faox_evap')
+          call addfld_from(compatm , 'Faxa_evap')
+          call addfld_to(compocn   , 'Foxx_evap')
+       end if
+    else
+       if (med_aoflux_to_ocn) then
+          if ( fldchk(is_local%wrap%FBexp(compocn)        , 'Foxx_evap', rc=rc) .and. &
+               fldchk(is_local%wrap%FBMed_aoflux_o        , 'Faox_evap' , rc=rc)) then
+             call addmrg_to(compocn, 'Foxx_evap', &
+                  mrg_from=compmed, mrg_fld='Faox_evap', mrg_type='copy_with_weights', mrg_fracname='ofrac')
+          end if
+       else
+          if ( fldchk(is_local%wrap%FBexp(compocn)        , 'Foxx_evap', rc=rc) .and. &
+               fldchk(is_local%wrap%FBImp(compatm,compatm), 'Faxa_evap' , rc=rc)) then
+             call addmap_from(compatm, 'Faxa_evap', compocn, mapconsf_aofrac, 'aofrac', 'unset')
+             call addmrg_to(compocn, 'Foxx_evap', &
+                  mrg_from=compatm, mrg_fld='Faxa_evap', mrg_type='copy_with_weights', mrg_fracname='ofrac')
+          end if
+       end if
+    end if
+
+    ! to ocn: unmerged fluxes from ice
+    ! - water flux due to melting ice from ice
+    ! - heat flux from melting ice from ice
+    ! - salt flux from ice
     allocate(flds(3))
     flds = (/'Fioi_meltw', 'Fioi_melth', 'Fioi_salt '/)
     do n = 1,size(flds)
        fldname = trim(flds(n))
        if (phase == 'advertise') then
           if (is_local%wrap%comp_present(compice) .and. is_local%wrap%comp_present(compocn)) then
-             call addfld_from(compice, trim(fldname))
-             call addfld_to(compocn, trim(fldname))
+             call addfld_from(compice , fldname)
+             call addfld_to(compocn   , fldname)
           end if
        else
-          if ( fldchk(is_local%wrap%FBexp(compocn)        , trim(fldname), rc=rc) .and. &
-               fldchk(is_local%wrap%FBImp(compice,compice), trim(fldname), rc=rc)) then
-             call addmap_from(compice, trim(fldname), compocn,  mapfcopy, 'unset', 'unset')
-             call addmrg_to(compocn, trim(fldname), &
-                  mrg_from=compice, mrg_fld=trim(fldname), mrg_type='copy_with_weights', mrg_fracname='ifrac')
+          if ( fldchk(is_local%wrap%FBexp(compocn)        , fldname, rc=rc) .and. &
+               fldchk(is_local%wrap%FBImp(compice,compice), fldname, rc=rc)) then
+             call addmap_from(compice, fldname, compocn,  mapfcopy, 'unset', 'unset')
+             call addmrg_to(compocn, fldname, &
+                  mrg_from=compice, mrg_fld=fldname, mrg_type='copy_with_weights', mrg_fracname='ifrac')
           end if
        end if
     end do
@@ -590,14 +523,14 @@ contains
        fldname = trim(flds(n))
        if (phase == 'advertise') then
           if (is_local%wrap%comp_present(compwav) .and. is_local%wrap%comp_present(compocn)) then
-             call addfld_from(compwav, trim(fldname))
-             call addfld_to(compocn, trim(fldname))
+             call addfld_from(compwav , fldname)
+             call addfld_to(compocn   , fldname)
           end if
        else
-          if ( fldchk(is_local%wrap%FBexp(compocn)        , trim(fldname), rc=rc) .and. &
-               fldchk(is_local%wrap%FBImp(compwav,compwav), trim(fldname), rc=rc)) then
-             call addmap_from(compwav, trim(fldname), compocn, mapbilnr_nstod, 'one', 'unset')
-             call addmrg_to(compocn, trim(fldname), mrg_from=compwav, mrg_fld=trim(fldname), mrg_type='copy')
+          if ( fldchk(is_local%wrap%FBexp(compocn)        , fldname, rc=rc) .and. &
+               fldchk(is_local%wrap%FBImp(compwav,compwav), fldname, rc=rc)) then
+             call addmap_from(compwav, fldname, compocn, mapbilnr_nstod, 'one', 'unset')
+             call addmrg_to(compocn, fldname, mrg_from=compwav, mrg_fld=fldname, mrg_type='copy')
           end if
        end if
     end do
@@ -607,14 +540,14 @@ contains
     ! FIELDS TO ICE (compice)
     !=====================================================================
 
-    ! to ice - fluxes from atm
-    ! to ice: downward longwave heat flux from atm
-    ! to ice: downward direct near-infrared incident solar radiation  from atm
-    ! to ice: downward direct visible incident solar radiation        from atm
-    ! to ice: downward diffuse near-infrared incident solar radiation from atm
-    ! to ice: downward Diffuse visible incident solar radiation       from atm
-    ! to ice: rain from atm
-    ! to ice: snow from atm
+    ! to ice: fluxes from atm
+    ! - downward longwave heat flux from atm
+    ! - downward direct near-infrared incident solar radiation  from atm
+    ! - downward direct visible incident solar radiation        from atm
+    ! - downward diffuse near-infrared incident solar radiation from atm
+    ! - downward Diffuse visible incident solar radiation       from atm
+    ! - rain from atm
+    ! - snow from atm
 
     allocate(flds(7))
     flds = (/'Faxa_lwdn ', 'Faxa_swndr', 'Faxa_swvdr', 'Faxa_swndf', 'Faxa_swvdf', &
@@ -623,69 +556,67 @@ contains
        fldname = trim(flds(n))
        if (phase == 'advertise') then
           if (is_local%wrap%comp_present(compatm) .and. is_local%wrap%comp_present(compice)) then
-             call addfld_from(compatm, trim(fldname))
-             call addfld_to(compice, trim(fldname))
+             call addfld_from(compatm , fldname)
+             call addfld_to(compice   , fldname)
           end if
        else
-          if ( fldchk(is_local%wrap%FBexp(compice)        , trim(fldname), rc=rc) .and. &
-               fldchk(is_local%wrap%FBImp(compatm,compatm), trim(fldname), rc=rc)) then
-             call addmap_from(compatm, trim(fldname), compice, maptype, 'one', 'unset')
-             call addmrg_to(compice, trim(fldname), mrg_from=compatm, mrg_fld=trim(fldname), mrg_type='copy')
+          if ( fldchk(is_local%wrap%FBexp(compice)        , fldname, rc=rc) .and. &
+               fldchk(is_local%wrap%FBImp(compatm,compatm), fldname, rc=rc)) then
+             call addmap_from(compatm, fldname, compice, maptype, 'one', 'unset')
+             call addmrg_to(compice, fldname, mrg_from=compatm, mrg_fld=fldname, mrg_type='copy')
           end if
        end if
     end do
     deallocate(flds)
 
-    ! to ice - state from atm
-    ! to ice: height at the lowest model level from atm
-    ! to ice: pressure at the lowest model level from atm
-    ! to ice: temperature at the lowest model level from atm
-    ! to ice: zonal wind at the lowest model level from atm
-    ! to ice: meridional wind at the lowest model level from atm
-    ! to ice: specific humidity at the lowest model level from atm
+    ! to ice: states from atm
+    ! - height at the lowest model level from atm
+    ! - pressure at the lowest model level from atm
+    ! - temperature at the lowest model level from atm
+    ! - zonal wind at the lowest model level from atm
+    ! - meridional wind at the lowest model level from atm
+    ! - specific humidity at the lowest model level from atm
     allocate(flds(6))
-    flds = (/'Sa_u   ', 'Sa_v   ', 'Sa_z   ', 'Sa_tbot', 'Sa_pbot', &
-             'Sa_shum'/)
+    flds = (/'Sa_u   ', 'Sa_v   ', 'Sa_z   ', 'Sa_tbot', 'Sa_pbot', 'Sa_shum'/)
     do n = 1,size(flds)
        fldname = trim(flds(n))
        if (phase == 'advertise') then
           if (is_local%wrap%comp_present(compatm) .and. is_local%wrap%comp_present(compice)) then
-             call addfld_from(compatm, trim(fldname))
-             call addfld_to(compice, trim(fldname))
+             call addfld_from(compatm , fldname)
+             call addfld_to(compice   , fldname)
           endif
        else
-          if ( fldchk(is_local%wrap%FBexp(compice)        , trim(fldname), rc=rc) .and. &
-               fldchk(is_local%wrap%FBImp(compatm,compatm), trim(fldname), rc=rc)) then
-             call addmap_from(compatm, trim(fldname), compice, maptype, 'one', 'unset')
-             call addmrg_to(compice, trim(fldname), mrg_from=compatm, mrg_fld=trim(fldname), mrg_type='copy')
+          if ( fldchk(is_local%wrap%FBexp(compice)        , fldname, rc=rc) .and. &
+               fldchk(is_local%wrap%FBImp(compatm,compatm), fldname, rc=rc)) then
+             call addmap_from(compatm, fldname, compice, maptype, 'one', 'unset')
+             call addmrg_to(compice, fldname, mrg_from=compatm, mrg_fld=fldname, mrg_type='copy')
           end if
        end if
     end do
     deallocate(flds)
 
-    ! to ice - states and fluxes from ocn
-    ! to ice: sea surface temperature from ocn
-    ! to ice: sea surface salinity from ocn
-    ! to ice: zonal sea water velocity from ocn
-    ! to ice: meridional sea water velocity from ocn
-    ! to ice: zonal sea surface slope from ocn
-    ! to ice: meridional sea surface slope from ocn
-    ! to ice: ocean melt and freeze potential from ocn
+    ! to ice: states and fluxes from ocn
+    ! - sea surface temperature from ocn
+    ! - sea surface salinity from ocn
+    ! - zonal sea water velocity from ocn
+    ! - meridional sea water velocity from ocn
+    ! - zonal sea surface slope from ocn
+    ! - meridional sea surface slope from ocn
+    ! - ocean melt and freeze potential from ocn
     allocate(flds(7))
-    flds = (/'So_t   ', 'So_s   ', 'So_u   ', 'So_v   ','So_dhdx', &
-             'So_dhdy', 'Fioo_q '/)
+    flds = (/'So_t   ', 'So_s   ', 'So_u   ', 'So_v   ','So_dhdx', 'So_dhdy', 'Fioo_q '/)
     do n = 1,size(flds)
        fldname = trim(flds(n))
        if (phase == 'advertise') then
           if (is_local%wrap%comp_present(compocn) .and. is_local%wrap%comp_present(compice)) then
-             call addfld_from(compocn, trim(fldname))
-             call addfld_to(compice, trim(fldname))
+             call addfld_from(compocn , fldname)
+             call addfld_to(compice   , fldname)
           endif
        else
-          if ( fldchk(is_local%wrap%FBexp(compice)        , trim(fldname), rc=rc) .and. &
-               fldchk(is_local%wrap%FBImp(compocn,compocn), trim(fldname), rc=rc)) then
-             call addmap_from(compocn, trim(fldname), compice, mapfcopy , 'unset', 'unset')
-             call addmrg_to(compice, trim(fldname), mrg_from=compocn, mrg_fld=trim(fldname), mrg_type='copy')
+          if ( fldchk(is_local%wrap%FBexp(compice)        , fldname, rc=rc) .and. &
+               fldchk(is_local%wrap%FBImp(compocn,compocn), fldname, rc=rc)) then
+             call addmap_from(compocn, fldname, compice, mapfcopy , 'unset', 'unset')
+             call addmrg_to(compice, fldname, mrg_from=compocn, mrg_fld=fldname, mrg_type='copy')
           end if
        end if
     end do
@@ -693,8 +624,8 @@ contains
 
     if (phase == 'advertise') then
        if (is_local%wrap%comp_present(compice) .and. is_local%wrap%comp_present(compwav)) then
-          call addfld_from(compwav, 'Sw_elevation_spectrum')
-          call addfld_to(compice, 'Sw_elevation_spectrum')
+          call addfld_from(compwav , 'Sw_elevation_spectrum')
+          call addfld_to(compice   , 'Sw_elevation_spectrum')
        end if
     else
        if ( fldchk(is_local%wrap%FBExp(compice)        , 'Sw_elevation_spectrum', rc=rc) .and. &
@@ -709,63 +640,69 @@ contains
     ! FIELDS TO WAV (compwav)
     !=====================================================================
 
-    ! to wav - 10m winds and bottom temperature from atm
+    ! to wav: states from atm
+    ! - 10m meridonal and zonal winds
+    ! - bottom temperature from atm
     allocate(flds(3))
     flds = (/'Sa_u10m', 'Sa_v10m', 'Sa_tbot'/)
     do n = 1,size(flds)
        fldname = trim(flds(n))
        if (phase == 'advertise') then
           if (is_local%wrap%comp_present(compatm) .and. is_local%wrap%comp_present(compwav)) then
-             call addfld_from(compatm, trim(fldname))
-             call addfld_to(compwav, trim(fldname))
+             call addfld_from(compatm , fldname)
+             call addfld_to(compwav   , fldname)
           end if
        else
-          if ( fldchk(is_local%wrap%FBexp(compwav)        , trim(fldname), rc=rc) .and. &
-               fldchk(is_local%wrap%FBImp(compatm,compatm), trim(fldname), rc=rc)) then
-             call addmap_from(compatm, trim(fldname), compwav, mapbilnr_nstod, 'one', 'unset')
-             call addmrg_to(compwav, trim(fldname), mrg_from=compatm, mrg_fld=trim(fldname), mrg_type='copy')
+          if ( fldchk(is_local%wrap%FBexp(compwav)        , fldname, rc=rc) .and. &
+               fldchk(is_local%wrap%FBImp(compatm,compatm), fldname, rc=rc)) then
+             call addmap_from(compatm, fldname, compwav, mapbilnr_nstod, 'one', 'unset')
+             call addmrg_to(compwav, fldname, mrg_from=compatm, mrg_fld=fldname, mrg_type='copy')
           end if
        end if
      end do
      deallocate(flds)
 
-     ! to wav: sea ice fraction, thickness and floe diameter
+     ! to wav: states from ice
+     ! - sea ice fraction
+     ! - sea ice thickness
+     ! - sea ice floe diameter
      allocate(flds(3))
      flds = (/'Si_ifrac   ', 'Si_floediam', 'Si_thick   '/)
      do n = 1,size(flds)
         fldname = trim(flds(n))
         if (phase == 'advertise') then
            if (is_local%wrap%comp_present(compice) .and. is_local%wrap%comp_present(compwav)) then
-              call addfld_from(compice, trim(fldname))
-              call addfld_to(compwav, trim(fldname))
+              call addfld_from(compice , fldname)
+              call addfld_to(compwav   , fldname)
         end if
         else
-           if ( fldchk(is_local%wrap%FBexp(compwav)        , trim(fldname), rc=rc) .and. &
-                fldchk(is_local%wrap%FBImp(compice,compice), trim(fldname), rc=rc)) then
-              call addmap_from(compice, trim(fldname), compwav, mapbilnr_nstod , 'one', 'unset')
-              call addmrg_to(compwav, trim(fldname), mrg_from=compice, mrg_fld=trim(fldname), mrg_type='copy')
+           if ( fldchk(is_local%wrap%FBexp(compwav)        , fldname, rc=rc) .and. &
+                fldchk(is_local%wrap%FBImp(compice,compice), fldname, rc=rc)) then
+              call addmap_from(compice, fldname, compwav, mapbilnr_nstod , 'one', 'unset')
+              call addmrg_to(compwav, fldname, mrg_from=compice, mrg_fld=fldname, mrg_type='copy')
            end if
         end if
       end do
       deallocate(flds)
 
-     ! to wav: zonal sea water velocity from ocn
-     ! to wav: meridional sea water velocity from ocn
-     ! to wav: surface temperature from ocn
-     allocate(flds(3))
-     flds = (/'So_u', 'So_v', 'So_t'/)
-     do n = 1,size(flds)
-        fldname = trim(flds(n))
-        if (phase == 'advertise') then
-           if (is_local%wrap%comp_present(compocn) .and. is_local%wrap%comp_present(compwav)) then
-              call addfld_from(compocn, trim(fldname))
-              call addfld_to(compwav, trim(fldname))
-           end if
-        else
-           if ( fldchk(is_local%wrap%FBexp(compwav)        , trim(fldname), rc=rc) .and. &
-                fldchk(is_local%wrap%FBImp(compocn,compocn), trim(fldname), rc=rc)) then
-              call addmap_from(compocn, trim(fldname), compwav, mapbilnr_nstod , 'one', 'unset')
-              call addmrg_to(compwav, trim(fldname), mrg_from=compocn, mrg_fld=trim(fldname), mrg_type='copy')
+      ! to wav: states from ocn
+      ! - zonal sea water velocity from ocn
+      ! - meridional sea water velocity from ocn
+      ! - surface temperature from ocn
+      allocate(flds(3))
+      flds = (/'So_u', 'So_v', 'So_t'/)
+      do n = 1,size(flds)
+         fldname = trim(flds(n))
+         if (phase == 'advertise') then
+            if (is_local%wrap%comp_present(compocn) .and. is_local%wrap%comp_present(compwav)) then
+               call addfld_from(compocn , fldname)
+               call addfld_to(compwav   , fldname)
+            end if
+         else
+            if ( fldchk(is_local%wrap%FBexp(compwav)        , fldname, rc=rc) .and. &
+                 fldchk(is_local%wrap%FBImp(compocn,compocn), fldname, rc=rc)) then
+               call addmap_from(compocn, fldname, compwav, mapbilnr_nstod , 'one', 'unset')
+              call addmrg_to(compwav, fldname, mrg_from=compocn, mrg_fld=fldname, mrg_type='copy')
            end if
         end if
      end do
@@ -796,14 +733,14 @@ contains
        fldname = trim(flds(n))
        if (phase == 'advertise') then
           if (is_local%wrap%comp_present(compatm) .and. is_local%wrap%comp_present(complnd)) then
-             call addfld_from(compatm, trim(fldname))
-             call addfld_to(complnd, trim(fldname))
+             call addfld_from(compatm , fldname)
+             call addfld_to(complnd   , fldname)
           end if
        else
-          if ( fldchk(is_local%wrap%FBexp(complnd)        , trim(fldname), rc=rc) .and. &
-               fldchk(is_local%wrap%FBImp(compatm,compatm), trim(fldname), rc=rc)) then
-             call addmap_from(compatm, trim(fldname), complnd, maptype, 'one', 'unset')
-             call addmrg_to(complnd, trim(fldname), mrg_from=compatm, mrg_fld=trim(fldname), mrg_type='copy')
+          if ( fldchk(is_local%wrap%FBexp(complnd)        , fldname, rc=rc) .and. &
+               fldchk(is_local%wrap%FBImp(compatm,compatm), fldname, rc=rc)) then
+             call addmap_from(compatm, fldname, complnd, maptype, 'one', 'unset')
+             call addmrg_to(complnd, fldname, mrg_from=compatm, mrg_fld=fldname, mrg_type='copy')
           end if
        end if
     end do

--- a/mediator/esmFldsExchange_nems_mod.F90
+++ b/mediator/esmFldsExchange_nems_mod.F90
@@ -453,13 +453,13 @@ contains
        ! to ocn: evaporation water flux (custom merge in med_phases_prep_ocn)
        if (phase == 'advertise') then
           if (is_local%wrap%comp_present(compatm) .and. is_local%wrap%comp_present(compocn)) then
-             call addfld_from(compatm, 'Faxa_lat')
+             call addfld_from(compatm, 'Faxa_evap')
              call addfld_to(compocn, 'Faxa_evap')
           end if
        else
           if ( fldchk(is_local%wrap%FBexp(compocn)        , 'Faxa_evap', rc=rc) .and. &
-               fldchk(is_local%wrap%FBImp(compatm,compatm), 'Faxa_lat' , rc=rc)) then
-             call addmap_from(compatm, 'Faxa_lat', compocn, mapconsf_aofrac, 'aofrac', 'unset')
+               fldchk(is_local%wrap%FBImp(compatm,compatm), 'Faxa_evap' , rc=rc)) then
+             call addmap_from(compatm, 'Faxa_evap', compocn, mapconsf_aofrac, 'aofrac', 'unset')
           end if
        end if
     else if (trim(coupling_mode) == 'nems_orig_data' .or. trim(coupling_mode) == 'nems_frac_aoflux') then

--- a/mediator/esmFldsExchange_nems_mod.F90
+++ b/mediator/esmFldsExchange_nems_mod.F90
@@ -394,7 +394,7 @@ contains
 
     if (trim(coupling_mode) == 'nems_orig' .or. trim(coupling_mode) == 'nems_frac' .or. &
         trim(coupling_mode) == 'nems_frac_aoflux_sbs') then
-       ! to ocn: merge surface stress (custom merge calculation in med_phases_prep_ocn)
+       ! to ocn: merge surface stress
        allocate(oflds(2))
        allocate(aflds(2))
        allocate(iflds(2))
@@ -415,6 +415,10 @@ contains
                   fldchk(is_local%wrap%FBImp(compatm,compatm), trim(aflds(n)), rc=rc)) then
                 call addmap_from(compice, trim(iflds(n)), compocn, mapfcopy, 'unset', 'unset')
                 call addmap_from(compatm, trim(aflds(n)), compocn, mapconsf_aofrac, 'aofrac', 'unset')
+                call addmrg_to(compocn, trim(oflds(n)), &
+                     mrg_from=compice, mrg_fld=trim(iflds(n)), mrg_type='merge', mrg_fracname='ifrac')
+                call addmrg_to(compocn, trim(oflds(n)), &
+                     mrg_from=compatm, mrg_fld=trim(aflds(n)), mrg_type='merge', mrg_fracname='ofrac')
              end if
           end if
        end do
@@ -437,7 +441,7 @@ contains
           end if
        end if
 
-       ! to ocn: merged sensible heat flux (custom merge in med_phases_prep_ocn)
+       ! to ocn: sensible heat flux
        if (phase == 'advertise') then
           if (is_local%wrap%comp_present(compatm) .and. is_local%wrap%comp_present(compocn)) then
              call addfld_from(compatm, 'Faxa_sen')
@@ -447,10 +451,12 @@ contains
           if ( fldchk(is_local%wrap%FBexp(compocn)        , 'Faxa_sen', rc=rc) .and. &
                fldchk(is_local%wrap%FBImp(compatm,compatm), 'Faxa_sen', rc=rc)) then
              call addmap_from(compatm, 'Faxa_sen', compocn, mapconsf_aofrac, 'aofrac', 'unset')
+             call addmrg_to(compocn, 'Faxa_sen', &
+                  mrg_from=compatm, mrg_fld='Faxa_sen', mrg_type='copy_with_weights', mrg_fracname='ofrac')
           end if
        end if
 
-       ! to ocn: evaporation water flux (custom merge in med_phases_prep_ocn)
+       ! to ocn: evaporation water flux
        if (phase == 'advertise') then
           if (is_local%wrap%comp_present(compatm) .and. is_local%wrap%comp_present(compocn)) then
              call addfld_from(compatm, 'Faxa_evap')
@@ -460,6 +466,8 @@ contains
           if ( fldchk(is_local%wrap%FBexp(compocn)        , 'Faxa_evap', rc=rc) .and. &
                fldchk(is_local%wrap%FBImp(compatm,compatm), 'Faxa_evap' , rc=rc)) then
              call addmap_from(compatm, 'Faxa_evap', compocn, mapconsf_aofrac, 'aofrac', 'unset')
+             call addmrg_to(compocn, 'Faxa_evap', &
+                  mrg_from=compatm, mrg_fld='Faxa_evap', mrg_type='copy_with_weights', mrg_fracname='ofrac')
           end if
        end if
     else if (trim(coupling_mode) == 'nems_orig_data' .or. trim(coupling_mode) == 'nems_frac_aoflux') then

--- a/mediator/esmFldsExchange_ufs_mod.F90
+++ b/mediator/esmFldsExchange_ufs_mod.F90
@@ -151,14 +151,6 @@ contains
        call addfld_ocnalb('So_anidf')
     end if
 
-    ! Advertise the ocean albedos. These are not sent to the ATM in UFS.
-    if (phase == 'advertise') then
-       call addfld_ocnalb('So_avsdr')
-       call addfld_ocnalb('So_avsdf')
-       call addfld_ocnalb('So_anidr')
-       call addfld_ocnalb('So_anidf')
-    end if
-
     !=====================================================================
     ! FIELDS TO ATMOSPHERE (compatm)
     !=====================================================================

--- a/mediator/med.F90
+++ b/mediator/med.F90
@@ -1837,7 +1837,7 @@ contains
       else if (trim(coupling_mode(1:3)) == 'ufs') then
          call esmFldsExchange_ufs(gcomp, phase='initialize', rc=rc)
          if (ChkErr(rc,__LINE__,u_FILE_u)) return
-      else if (trim(coupling_mode) == 'hafs') then
+      else if (trim(coupling_mode(1:4)) == 'hafs') then
          call esmFldsExchange_hafs(gcomp, phase='initialize', rc=rc)
          if (ChkErr(rc,__LINE__,u_FILE_u)) return
       end if

--- a/mediator/med.F90
+++ b/mediator/med.F90
@@ -950,6 +950,22 @@ contains
        endif
     endif
 
+    ! Should terget component use all data for first time step?
+    do ncomp = 1,ncomps
+       if (ncomp /= compmed) then
+          call NUOPC_CompAttributeGet(gcomp, name=trim(compname(ncomp))//"_use_data_first_import", value=cvalue, isPresent=isPresent, isSet=isSet, rc=rc)
+          if (ChkErr(rc,__LINE__,u_FILE_u)) return
+          if (isPresent .and. isSet) then
+             read(cvalue, *) is_local%wrap%med_data_force_first(ncomp)
+          else
+             is_local%wrap%med_data_force_first(ncomp) = .false.
+          endif
+          if (maintask) then
+             write(logunit,*) trim(compname(ncomp))//'_use_data_first_import is ', is_local%wrap%med_data_force_first(ncomp)
+          endif    
+       end if
+    end do
+
     if (profile_memory) call ESMF_VMLogMemInfo("Leaving "//trim(subname))
     call ESMF_LogWrite(trim(subname)//": done", ESMF_LOGMSG_INFO)
 

--- a/mediator/med.F90
+++ b/mediator/med.F90
@@ -950,7 +950,7 @@ contains
        endif
     endif
 
-    ! Should terget component use all data for first time step?
+    ! Should target component use all data for first time step?
     do ncomp = 1,ncomps
        if (ncomp /= compmed) then
           call NUOPC_CompAttributeGet(gcomp, name=trim(compname(ncomp))//"_use_data_first_import", value=cvalue, isPresent=isPresent, isSet=isSet, rc=rc)

--- a/mediator/med.F90
+++ b/mediator/med.F90
@@ -123,6 +123,9 @@ contains
     use med_diag_mod            , only: med_phases_diag_ice_ice2med, med_phases_diag_ice_med2ice
     use med_fraction_mod        , only: med_fraction_init, med_fraction_set
     use med_phases_profile_mod  , only: med_phases_profile
+#ifdef CDEPS_INLINE
+    use med_phases_cdeps_mod    , only: med_phases_cdeps_run
+#endif
 
     ! input/output variables
     type(ESMF_GridComp)  :: gcomp
@@ -504,6 +507,19 @@ contains
     call NUOPC_CompSpecialize(gcomp, specLabel=mediator_label_TimestampExport, &
          specPhaselabel="med_phases_diag_print", specRoutine=NUOPC_NoOp, rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
+
+#ifdef CDEPS_INLINE
+    !------------------
+    ! phase routine for cdeps inline capabilty 
+    !------------------
+
+    call NUOPC_CompSetEntryPoint(gcomp, ESMF_METHOD_RUN, &
+         phaseLabelList=(/"med_phases_cdeps_run"/), userRoutine=mediator_routine_Run, rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+    call NUOPC_CompSpecialize(gcomp, specLabel=mediator_label_Advance, &
+         specPhaseLabel="med_phases_cdeps_run", specRoutine=med_phases_cdeps_run, rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+#endif
 
     !------------------
     ! attach specializing method(s)

--- a/mediator/med.F90
+++ b/mediator/med.F90
@@ -661,7 +661,7 @@ contains
     use NUOPC , only : NUOPC_CompAttributeGet, NUOPC_CompAttributeSet, NUOPC_CompAttributeAdd
     use esmFlds, only : med_fldlist_init1, med_fld_GetFldInfo, med_fldList_entry_type
     use med_phases_history_mod, only : med_phases_history_init
-    use med_methods_mod       , only : mediator_checkfornans  
+    use med_methods_mod       , only : mediator_checkfornans
 
     ! input/output variables
     type(ESMF_GridComp)  :: gcomp
@@ -921,7 +921,7 @@ contains
     call NUOPC_CompAttributeGet(gcomp, name="check_for_nans", value=cvalue, isPresent=isPresent, isSet=isSet, rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
     if(isPresent .and. isSet) then
-       read(cvalue, *) mediator_checkfornans       
+       read(cvalue, *) mediator_checkfornans
     else
        mediator_checkfornans = .false.
     endif
@@ -1942,7 +1942,7 @@ contains
     ! Initialize ocean albedos (this is needed for cesm and hafs)
     !----------------------------------------------------------
 
-    if (trim(coupling_mode(1:5)) /= 'nems_') then
+    if (trim(coupling_mode(1:5)) == 'cesm_') then
        if (is_local%wrap%comp_present(compocn) .or. is_local%wrap%comp_present(compatm)) then
           call med_phases_ocnalb_run(gcomp, rc=rc)
           if (ChkErr(rc,__LINE__,u_FILE_u)) return

--- a/mediator/med.F90
+++ b/mediator/med.F90
@@ -1835,7 +1835,7 @@ contains
       else if (trim(coupling_mode(1:3)) == 'ufs') then
          call esmFldsExchange_ufs(gcomp, phase='initialize', rc=rc)
          if (ChkErr(rc,__LINE__,u_FILE_u)) return
-      else if (trim(coupling_mode(1:4)) == 'hafs') then
+      else if (coupling_mode(1:4) == 'hafs') then
          call esmFldsExchange_hafs(gcomp, phase='initialize', rc=rc)
          if (ChkErr(rc,__LINE__,u_FILE_u)) return
       end if

--- a/mediator/med.F90
+++ b/mediator/med.F90
@@ -934,7 +934,6 @@ contains
        endif
     endif
 
-
     if (profile_memory) call ESMF_VMLogMemInfo("Leaving "//trim(subname))
     call ESMF_LogWrite(trim(subname)//": done", ESMF_LOGMSG_INFO)
 
@@ -1775,7 +1774,7 @@ contains
       !---------------------------------------
 
       ! NOTE: this section must be done BEFORE the second call to esmFldsExchange
-      ! Create field bundles for mediator ocean albedo computation
+      ! Create field bundles for mediator atm/ocean flux computation
       fieldCount = med_fldList_GetNumFlds(med_fldList_getaofluxfldList())
       if ( fieldCount > 0 ) then
          if ( is_local%wrap%med_coupling_active(compocn,compatm) .or. &

--- a/mediator/med.F90
+++ b/mediator/med.F90
@@ -1804,7 +1804,8 @@ contains
          call esmFldsExchange_cesm(gcomp, phase='initialize', rc=rc)
          if (ChkErr(rc,__LINE__,u_FILE_u)) return
       else if (trim(coupling_mode(1:4)) == 'nems') then
-       call esmFldsExchange_nems(gcomp, phase='initialize', rc=rc)
+         call esmFldsExchange_nems(gcomp, phase='initialize', rc=rc)
+         if (ChkErr(rc,__LINE__,u_FILE_u)) return
       else if (trim(coupling_mode) == 'hafs') then
          call esmFldsExchange_hafs(gcomp, phase='initialize', rc=rc)
          if (ChkErr(rc,__LINE__,u_FILE_u)) return
@@ -1939,14 +1940,12 @@ contains
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
 
     !----------------------------------------------------------
-    ! Initialize ocean albedos (this is needed for cesm and hafs)
+    ! Initialize ocean albedos
     !----------------------------------------------------------
 
-    if (trim(coupling_mode(1:5)) == 'cesm_') then
-       if (is_local%wrap%comp_present(compocn) .or. is_local%wrap%comp_present(compatm)) then
-          call med_phases_ocnalb_run(gcomp, rc=rc)
-          if (ChkErr(rc,__LINE__,u_FILE_u)) return
-       end if
+    if (is_local%wrap%comp_present(compocn) .or. is_local%wrap%comp_present(compatm)) then
+       call med_phases_ocnalb_run(gcomp, rc=rc)
+       if (ChkErr(rc,__LINE__,u_FILE_u)) return
     end if
 
     !---------------------------------------

--- a/mediator/med_fraction_mod.F90
+++ b/mediator/med_fraction_mod.F90
@@ -365,11 +365,8 @@ contains
        call med_map_field(field_src, field_dst, is_local%wrap%RH(compocn,compatm,:), maptype, rc=rc)
        if (chkerr(rc,__LINE__,u_FILE_u)) return
 
-      ! Set 'aofrac' in FBfrac(compatm)
-       if (trim(coupling_mode) == 'nems_orig' .or. &
-           trim(coupling_mode) == 'nems_frac' .or. &
-           trim(coupling_mode) == 'nems_frac_aoflux' .or. &
-           trim(coupling_mode) == 'nems_frac_aoflux_sbs') then
+       ! Set 'aofrac' in FBfrac(compatm) if available
+       if ( fldbun_fldchk(is_local%wrap%FBImp(compatm,compatm), 'Sa_ofrac', rc=rc)) then
           call fldbun_getdata1d(is_local%wrap%FBImp(compatm,compatm), 'Sa_ofrac', Sa_ofrac, rc)
           if (ChkErr(rc,__LINE__,u_FILE_u)) return
           call fldbun_getdata1d(is_local%wrap%FBFrac(compatm), 'aofrac', aofrac, rc)
@@ -788,11 +785,8 @@ contains
              call med_map_field(field_src, field_dst, is_local%wrap%RH(compice,compatm,:), maptype, rc=rc)
              if (ChkErr(rc,__LINE__,u_FILE_u)) return
           end if
-          ! Set 'aofrac' from FBImp(compatm) to FBfrac(compatm)
-          if (trim(coupling_mode) == 'nems_orig' .or. &
-              trim(coupling_mode) == 'nems_frac' .or. &
-              trim(coupling_mode) == 'nems_frac_aoflux' .or. &
-              trim(coupling_mode) == 'nems_frac_aoflux_sbs') then
+          ! Set 'aofrac' from FBImp(compatm) to FBfrac(compatm) if available
+          if ( fldbun_fldchk(is_local%wrap%FBImp(compatm,compatm), 'Sa_ofrac', rc=rc)) then
              call fldbun_getdata1d(is_local%wrap%FBImp(compatm,compatm), 'Sa_ofrac', Sa_ofrac, rc)
              if (ChkErr(rc,__LINE__,u_FILE_u)) return
              call fldbun_getdata1d(is_local%wrap%FBFrac(compatm), 'aofrac', aofrac, rc)

--- a/mediator/med_internalstate_mod.F90
+++ b/mediator/med_internalstate_mod.F90
@@ -373,6 +373,7 @@ contains
     ! Initialize flag for background fill
     is_local%wrap%med_bg_fill_active(:,:) = .false.
     is_local%wrap%med_bg_fill_active(compocn,compatm) = .true.
+    is_local%wrap%med_bg_fill_active(compatm,compocn) = .true.
 
   end subroutine med_internalstate_init
 

--- a/mediator/med_internalstate_mod.F90
+++ b/mediator/med_internalstate_mod.F90
@@ -152,7 +152,6 @@ module med_internalstate_mod
     type(ESMF_State)       , pointer :: NStateExp(:)   ! Export data to various component, on their grid
     type(ESMF_FieldBundle) , pointer :: FBImp(:,:)     ! Import data from various components interpolated to various grids
     type(ESMF_FieldBundle) , pointer :: FBExp(:)       ! Export data for various components, on their grid
-    type(ESMF_FieldBundle) , pointer :: FBExpIn(:)     ! Export data for various components, on their grid, CDEPS inline
 
     ! Mediator field bundles for ocean albedo
     type(ESMF_FieldBundle) :: FBMed_ocnalb_o            ! Ocn albedo on ocn grid
@@ -174,6 +173,9 @@ module med_internalstate_mod
 
     ! Fractions
     type(ESMF_FieldBundle), pointer :: FBfrac(:)     ! Fraction data for various components, on their grid
+
+    ! Data
+    type(ESMF_FieldBundle) , pointer :: FBData(:)    ! Background data for various components, on their grid, provided by CDEPS inline
 
     ! Accumulators for export field bundles
     type(ESMF_FieldBundle) :: FBExpAccumOcn      ! Accumulator for Ocn export on Ocn grid
@@ -312,7 +314,6 @@ contains
     allocate(is_local%wrap%NStateExp(ncomps))
     allocate(is_local%wrap%FBImp(ncomps,ncomps))
     allocate(is_local%wrap%FBExp(ncomps))
-    allocate(is_local%wrap%FBExpIn(ncomps))
     allocate(is_local%wrap%packed_data_ocnalb_o2a(nmappers))
     allocate(is_local%wrap%packed_data_aoflux_o2a(nmappers))
     allocate(is_local%wrap%RH(ncomps,ncomps,nmappers))
@@ -320,6 +321,7 @@ contains
     allocate(is_local%wrap%packed_data(ncomps,ncomps,nmappers))
     allocate(is_local%wrap%FBfrac(ncomps))
     allocate(is_local%wrap%FBArea(ncomps))
+    allocate(is_local%wrap%FBData(ncomps))
     allocate(is_local%wrap%mesh_info(ncomps))
 
     ! Determine component names

--- a/mediator/med_internalstate_mod.F90
+++ b/mediator/med_internalstate_mod.F90
@@ -374,6 +374,7 @@ contains
     is_local%wrap%med_bg_fill_active(:,:) = .false.
     is_local%wrap%med_bg_fill_active(compocn,compatm) = .true.
     is_local%wrap%med_bg_fill_active(compatm,compocn) = .true.
+    is_local%wrap%med_bg_fill_active(compatm,compwav) = .true.
 
   end subroutine med_internalstate_init
 

--- a/mediator/med_internalstate_mod.F90
+++ b/mediator/med_internalstate_mod.F90
@@ -147,10 +147,11 @@ module med_internalstate_mod
     ! FBImp(n,n) = NState_Imp(n), copied in connector post phase
     ! FBImp(n,k) is the FBImp(n,n) interpolated to grid k
     ! Import/export States and field bundles (the field bundles have the scalar fields removed)
-    type(ESMF_State)       , pointer :: NStateImp(:) ! Import data from various component, on their grid
-    type(ESMF_State)       , pointer :: NStateExp(:) ! Export data to various component, on their grid
-    type(ESMF_FieldBundle) , pointer :: FBImp(:,:)   ! Import data from various components interpolated to various grids
-    type(ESMF_FieldBundle) , pointer :: FBExp(:)     ! Export data for various components, on their grid
+    type(ESMF_State)       , pointer :: NStateImp(:)   ! Import data from various component, on their grid
+    type(ESMF_State)       , pointer :: NStateExp(:)   ! Export data to various component, on their grid
+    type(ESMF_FieldBundle) , pointer :: FBImp(:,:)     ! Import data from various components interpolated to various grids
+    type(ESMF_FieldBundle) , pointer :: FBExp(:)       ! Export data for various components, on their grid
+    type(ESMF_FieldBundle) , pointer :: FBExpInline(:) ! Export data coming from CDEPS inline for various components, on their grid
 
     ! Mediator field bundles for ocean albedo
     type(ESMF_FieldBundle) :: FBMed_ocnalb_o            ! Ocn albedo on ocn grid

--- a/mediator/med_internalstate_mod.F90
+++ b/mediator/med_internalstate_mod.F90
@@ -262,7 +262,6 @@ contains
        end do
     end if
     is_local%wrap%num_icesheets = num_icesheets
-
     call NUOPC_CompAttributeGet(gcomp, name='mediator_present', value=cvalue, isPresent=isPresent, isSet=isSet, rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
     if (isPresent .and. isSet) then

--- a/mediator/med_internalstate_mod.F90
+++ b/mediator/med_internalstate_mod.F90
@@ -47,7 +47,7 @@ module med_internalstate_mod
   character(len=CS), public :: glc_name = ''
 
   ! Coupling mode
-  character(len=CS), public :: coupling_mode ! valid values are [cesm,ufs.nfrac,ufs.frac,ufs.nfrac.aoflux,ufs.frac.aoflux,hafs]
+  character(len=CS), public :: coupling_mode ! valid values are [cesm,ufs.nfrac,ufs.frac,ufs.nfrac.aoflux,ufs.frac.aoflux,hafs,hafs.mom6]
 
   ! Atmosphere-ocean flux algorithm
   character(len=CS), public :: aoflux_code   ! valid values are [cesm,ccpp]

--- a/mediator/med_internalstate_mod.F90
+++ b/mediator/med_internalstate_mod.F90
@@ -121,6 +121,7 @@ module med_internalstate_mod
     ! Present/allowed coupling/active coupling logical flags
     logical, pointer :: comp_present(:)            ! comp present flag
     logical, pointer :: med_coupling_active(:,:)   ! computes the active coupling
+    logical, pointer :: med_bg_fill_active(:,:)    ! use cdeps for background fill 
     integer          :: num_icesheets              ! obtained from attribute
     logical          :: ocn2glc_coupling = .false. ! obtained from attribute
     logical          :: lnd2glc_coupling = .false.
@@ -151,7 +152,7 @@ module med_internalstate_mod
     type(ESMF_State)       , pointer :: NStateExp(:)   ! Export data to various component, on their grid
     type(ESMF_FieldBundle) , pointer :: FBImp(:,:)     ! Import data from various components interpolated to various grids
     type(ESMF_FieldBundle) , pointer :: FBExp(:)       ! Export data for various components, on their grid
-    type(ESMF_FieldBundle) , pointer :: FBExpInline(:) ! Export data coming from CDEPS inline for various components, on their grid
+    type(ESMF_FieldBundle) , pointer :: FBExpIn(:)     ! Export data for various components, on their grid, CDEPS inline
 
     ! Mediator field bundles for ocean albedo
     type(ESMF_FieldBundle) :: FBMed_ocnalb_o            ! Ocn albedo on ocn grid
@@ -304,6 +305,7 @@ contains
 
     ! Allocate memory now that ncomps is determined
     allocate(is_local%wrap%med_coupling_active(ncomps,ncomps))
+    allocate(is_local%wrap%med_bg_fill_active(ncomps,ncomps))
     allocate(is_local%wrap%nx(ncomps))
     allocate(is_local%wrap%ny(ncomps))
     allocate(is_local%wrap%NStateImp(ncomps))
@@ -364,6 +366,10 @@ contains
     if (isPresent .and. isSet) dststatus_print=(trim(cvalue) == "true")
     write(msgString,*) trim(subname)//': Mediator dststatus_print is ',dststatus_print
     call ESMF_LogWrite(trim(msgString), ESMF_LOGMSG_INFO)
+
+    ! Initialize flag for background fill
+    is_local%wrap%med_bg_fill_active(:,:) = .false.
+    is_local%wrap%med_bg_fill_active(compocn,compatm) = .true.
 
   end subroutine med_internalstate_init
 

--- a/mediator/med_internalstate_mod.F90
+++ b/mediator/med_internalstate_mod.F90
@@ -312,6 +312,7 @@ contains
     allocate(is_local%wrap%NStateExp(ncomps))
     allocate(is_local%wrap%FBImp(ncomps,ncomps))
     allocate(is_local%wrap%FBExp(ncomps))
+    allocate(is_local%wrap%FBExpIn(ncomps))
     allocate(is_local%wrap%packed_data_ocnalb_o2a(nmappers))
     allocate(is_local%wrap%packed_data_aoflux_o2a(nmappers))
     allocate(is_local%wrap%RH(ncomps,ncomps,nmappers))

--- a/mediator/med_io_mod.F90
+++ b/mediator/med_io_mod.F90
@@ -75,7 +75,7 @@ module med_io_mod
   character(*),parameter         :: prefix    = "med_io_"
   character(*),parameter         :: modName   = "(med_io_mod) "
   character(*),parameter         :: version   = "cmeps0"
-  
+
   integer                        :: pio_iotype
   integer                        :: pio_ioformat
   type(iosystem_desc_t), pointer :: io_subsystem
@@ -1738,8 +1738,8 @@ contains
 
        deallocate(minIndexPTile, maxIndexPTile)
     else
-       if(maintask) write(logunit,*) trim(subname),' ERROR: '//trim(name1)//' is not present, aborting '
-       call ESMF_LogWrite(trim(subname)//' ERROR: '//trim(name1)//' is not present, aborting ', ESMF_LOGMSG_INFO)
+       if(maintask) write(logunit,'(a)') trim(subname)//' ERROR: '//trim(name1)//' is not present, aborting '
+       call ESMF_LogWrite(trim(subname)//' ERROR: '//trim(name1)//' is not present, aborting ', ESMF_LOGMSG_ERROR)
        rc = ESMF_FAILURE
     end if ! end if rcode check
 

--- a/mediator/med_map_mod.F90
+++ b/mediator/med_map_mod.F90
@@ -111,7 +111,7 @@ contains
     type(ESMF_Mesh)           :: mesh_dst
     type(med_fldlist_type), pointer :: FldListFr
     type(med_fldlist_entry_type), pointer :: fldptr
-    character(len=*), parameter :: subname=' (module_med_map: RouteHandles_init) '
+    character(len=*), parameter :: subname=' (med_map_mod: RouteHandles_init) '
     !-----------------------------------------------------------
 
     call t_startf('MED:'//subname)
@@ -259,7 +259,8 @@ contains
                       if (chkerr(rc,__LINE__,u_FILE_u)) return
                       if (maintask) then
                          write(logunit,'(a)') trim(subname)//' created field_NormOne for '&
-                              //compname(n1)//'->'//compname(n2)//' with mapping '//trim(mapnames(mapindex))
+                              //trim(compname(n1))//'->'//trim(compname(n2))//' with mapping '&
+                              //trim(mapnames(mapindex))
                       end if
                    end if
                 end do ! end of loop over map_indiex mappers
@@ -304,7 +305,7 @@ contains
     ! local variables
     type(ESMF_Field)   :: fldsrc
     type(ESMF_Field)   :: flddst
-    character(len=*), parameter :: subname=' (module_MED_map:med_map_routehandles_initfrom_fieldbundle) '
+    character(len=*), parameter :: subname=' (med_map_mod:med_map_routehandles_initfrom_fieldbundle) '
     !---------------------------------------------
 
     rc = ESMF_SUCCESS
@@ -653,7 +654,7 @@ contains
     integer                , intent(out)   :: rc
 
     ! local variables
-    character(len=*), parameter :: subname=' (module_MED_map:med_map_RH_is_created_RH3d) '
+    character(len=*), parameter :: subname=' (med_map_mod:med_map_RH_is_created_RH3d) '
     !-----------------------------------------------------------
 
     rc = ESMF_SUCCESS
@@ -678,7 +679,7 @@ contains
     ! local variables
     integer :: rc1, rc2
     logical :: mapexists
-    character(len=*), parameter :: subname=' (module_MED_map:med_map_RH_is_created_RH1d) '
+    character(len=*), parameter :: subname=' (med_map_mod:med_map_RH_is_created_RH1d) '
     !-----------------------------------------------------------
 
     rc  = ESMF_SUCCESS
@@ -750,7 +751,7 @@ contains
     character(CL), allocatable :: fieldNameList(:)
     character(CS)              :: mapnorm_mapindex
     character(len=CX)          :: tmpstr
-    character(len=*), parameter :: subname=' (module_MED_map:med_packed_field_create) '
+    character(len=*), parameter :: subname=' (med_map_mod:med_packed_field_create) '
     !-----------------------------------------------------------
 
     rc = ESMF_SUCCESS
@@ -818,6 +819,7 @@ contains
                       //'  '//trim(fieldnamelist(nf))
                    call ESMF_LogWrite(trim(tmpstr), ESMF_LOGMSG_INFO)
                 else
+                   !if(rof_name .ne. 'xrof' .and. compname(destcomp) .ne. 'ocn') then
                    if (mapnorm_mapindex /= packed_data(mapindex)%mapnorm) then
                      write(tmpstr,*)'Map type '//trim(mapnames(mapindex)) &
                         //', destcomp '//trim(compname(destcomp)) &
@@ -953,7 +955,7 @@ contains
     type(ESMF_Field), pointer  :: fieldlist_dst(:)
     real(r8), pointer          :: data_norm(:)
     real(r8), pointer          :: data_dst(:,:)
-    character(len=*), parameter  :: subname=' (module_MED_map:med_map_field_packed) '
+    character(len=*), parameter  :: subname=' (med_map_mod:med_map_field_packed) '
     !-----------------------------------------------------------
 
     call t_startf('MED:'//subname)
@@ -1165,7 +1167,7 @@ contains
     integer           :: ungriddedUBound(1)     ! currently the size must equal 1 for rank 2 fields
     integer           :: lsize_src
     integer           :: lsize_dst
-    character(len=*), parameter  :: subname=' (module_MED_map:med_map_field_normalized) '
+    character(len=*), parameter  :: subname=' (med_map_mod:med_map_field_normalized) '
     !-----------------------------------------------------------
 
     rc = ESMF_SUCCESS
@@ -1278,7 +1280,7 @@ contains
     logical :: checkflag = .false.
     character(len=CS) :: lfldname
     real(ESMF_KIND_R8), parameter :: fillValue = 9.99e20_ESMF_KIND_R8
-    character(len=*), parameter :: subname='(module_MED_map:med_map_field) '
+    character(len=*), parameter :: subname='(med_map_mod:med_map_field) '
     !---------------------------------------------------
 
     rc = ESMF_SUCCESS
@@ -1381,7 +1383,7 @@ contains
     integer             :: spatialDim
     real(r8), parameter :: deg2rad = shr_const_pi/180.0_R8  ! deg to rads
     logical             :: first_time = .true.
-    character(len=*), parameter :: subname=' (module_MED_map:med_map_uv_cart3d) '
+    character(len=*), parameter :: subname=' (med_map_mod:med_map_uv_cart3d) '
     !-------------------------------------------------------------------------------
 
     rc = ESMF_SUCCESS

--- a/mediator/med_map_mod.F90
+++ b/mediator/med_map_mod.F90
@@ -1062,6 +1062,7 @@ contains
              ! Fill destination field with background data provided by CDEPS inline 
              ! -----------------------------------
 
+             if (maintask) write(logunit,'(a,i)') trim(subname), fieldcount_dat
              if (fieldcount_dat > 0) then
                 ! First get the pointer for the packed destination data
                 call ESMF_FieldGet(packed_data(mapindex)%field_dst, farrayptr=dataptr2d_packed, rc=rc)
@@ -1075,10 +1076,11 @@ contains
                      ! Get size of ungridded dimension and name of the field
                      call ESMF_FieldGet(fieldlist_dst(nf), ungriddedUBound=ungriddedUBound, name=field_name, rc=rc)
                      if (chkerr(rc,__LINE__,u_FILE_u)) return
-                     if (maintask) write(logunit,'(a)') trim(subname)//" search "//trim(field_name)//" field for bg fill"
+                     if (maintask) write(logunit,'(a)') trim(subname)//" search "//trim(field_name)//" field for background fill."
 
                      ! Check if field has match in data fields
                      do nfd = 1, fieldcount_dat
+                        if (maintask) write(logunit,'(a)') trim(field_name)//" - "//trim(field_namelist_dat(nfd))
                         if (trim(field_name) == trim(field_namelist_dat(nfd))) then
                            if (maintask) write(logunit,'(a)') trim(subname)//" field "//trim(field_namelist_dat(nfd))//" is found!"
                            
@@ -1087,7 +1089,7 @@ contains
                            if (chkerr(rc,__LINE__,u_FILE_u)) return
 
                            if (dbug_flag > 1) then
-                              call Field_diagnose(fieldlist_dst(nf), trim(field_name), " --> before bg fill: ", rc=rc)
+                              call Field_diagnose(fieldlist_dst(nf), trim(field_name), " --> before background fill: ", rc=rc)
                               if (chkerr(rc,__LINE__,u_FILE_u)) return
                            end if
 
@@ -1106,7 +1108,7 @@ contains
                            end if
 
                            if (dbug_flag > 1) then
-                              call Field_diagnose(fieldlist_dst(nf), trim(field_name), " --> after  bg fill: ", rc=rc)
+                              call Field_diagnose(fieldlist_dst(nf), trim(field_name), " --> after  background fill: ", rc=rc)
                               if (chkerr(rc,__LINE__,u_FILE_u)) return
                            end if
 

--- a/mediator/med_map_mod.F90
+++ b/mediator/med_map_mod.F90
@@ -1367,7 +1367,7 @@ contains
     use ESMF                  , only : ESMF_LogWrite, ESMF_LOGMSG_INFO, ESMF_SUCCESS
     use ESMF                  , only : ESMF_LOGMSG_ERROR, ESMF_FAILURE, ESMF_MAXSTR
     use ESMF                  , only : ESMF_Field, ESMF_FieldRegrid
-    use ESMF                  , only : ESMF_TERMORDER_SRCSEQ, ESMF_Region_Flag, ESMF_REGION_TOTAL
+    use ESMF                  , only : ESMF_TERMORDER_SRCSEQ, ESMF_Region_Flag
     use ESMF                  , only : ESMF_REGION_SELECT
     use ESMF                  , only : ESMF_RouteHandle
     use ESMF                  , only : ESMF_FieldWriteVTK
@@ -1400,7 +1400,7 @@ contains
 
     if (maptype == mapnstod_consd) then
        call ESMF_FieldRegrid(field_src, field_dst, routehandle=RouteHandles(mapnstod), &
-            termorderflag=ESMF_TERMORDER_SRCSEQ, checkflag=checkflag, zeroregion=ESMF_REGION_TOTAL, rc=rc)
+            termorderflag=ESMF_TERMORDER_SRCSEQ, checkflag=checkflag, zeroregion=ESMF_REGION_SELECT, rc=rc)
        if (chkerr(rc,__LINE__,u_FILE_u)) return
        if (dbug_flag > 1) then
           call Field_diagnose(field_dst, lfldname, " --> after nstod: ", rc=rc)
@@ -1415,7 +1415,7 @@ contains
        end if
     else if (maptype == mapnstod_consf) then
        call ESMF_FieldRegrid(field_src, field_dst, routehandle=RouteHandles(mapnstod), &
-            termorderflag=ESMF_TERMORDER_SRCSEQ, checkflag=checkflag, zeroregion=ESMF_REGION_TOTAL, rc=rc)
+            termorderflag=ESMF_TERMORDER_SRCSEQ, checkflag=checkflag, zeroregion=ESMF_REGION_SELECT, rc=rc)
        if (chkerr(rc,__LINE__,u_FILE_u)) return
        if (dbug_flag > 1) then
           call Field_diagnose(field_dst, lfldname, " --> after nstod: ", rc=rc)
@@ -1438,7 +1438,7 @@ contains
        end if
     else
        call ESMF_FieldRegrid(field_src, field_dst, routehandle=RouteHandles(maptype), &
-            termorderflag=ESMF_TERMORDER_SRCSEQ, checkflag=checkflag, zeroregion=ESMF_REGION_TOTAL, rc=rc)
+            termorderflag=ESMF_TERMORDER_SRCSEQ, checkflag=checkflag, zeroregion=ESMF_REGION_SELECT, rc=rc)
        if (chkerr(rc,__LINE__,u_FILE_u)) return
     end if
 

--- a/mediator/med_map_mod.F90
+++ b/mediator/med_map_mod.F90
@@ -893,12 +893,14 @@ contains
        if (npacked(mapindex) > 0) then
           ! Create the packed source field bundle for mapindex
           allocate(ptrsrc_packed(npacked(mapindex), lsize_src))
+          ptrsrc_packed(npacked(mapindex),:) = 0._R8
           packed_data(mapindex)%field_src = ESMF_FieldCreate(lmesh_src, &
                ptrsrc_packed, gridToFieldMap=(/2/),  meshloc=ESMF_MESHLOC_ELEMENT, rc=rc)
           if (chkerr(rc,__LINE__,u_FILE_u)) return
 
           ! Create the packed destination field bundle for mapindex
           allocate(ptrdst_packed(npacked(mapindex), lsize_dst))
+          ptrdst_packed(npacked(mapindex),:) = 0._R8
           packed_data(mapindex)%field_dst = ESMF_FieldCreate(lmesh_dst, &
                ptrdst_packed, gridToFieldMap=(/2/),  meshloc=ESMF_MESHLOC_ELEMENT, rc=rc)
           if (chkerr(rc,__LINE__,u_FILE_u)) return

--- a/mediator/med_map_mod.F90
+++ b/mediator/med_map_mod.F90
@@ -414,7 +414,7 @@ contains
           dstMaskValue = ispval_mask
        end if
     end if
-    if (trim(coupling_mode(1:4)) == 'hafs') then
+    if (coupling_mode(1:4) == 'hafs') then
        if (n1 == compatm .and. n2 == compwav) then
           srcMaskValue = ispval_mask
        end if

--- a/mediator/med_map_mod.F90
+++ b/mediator/med_map_mod.F90
@@ -1062,7 +1062,6 @@ contains
              ! Fill destination field with background data provided by CDEPS inline 
              ! -----------------------------------
 
-             if (maintask) write(logunit,'(a,i)') trim(subname), fieldcount_dat
              if (fieldcount_dat > 0) then
                 ! First get the pointer for the packed destination data
                 call ESMF_FieldGet(packed_data(mapindex)%field_dst, farrayptr=dataptr2d_packed, rc=rc)

--- a/mediator/med_map_mod.F90
+++ b/mediator/med_map_mod.F90
@@ -414,7 +414,7 @@ contains
           dstMaskValue = ispval_mask
        end if
     end if
-    if (trim(coupling_mode) == 'hafs') then
+    if (trim(coupling_mode(1:4)) == 'hafs') then
        if (n1 == compatm .and. n2 == compwav) then
           srcMaskValue = ispval_mask
        end if

--- a/mediator/med_methods_mod.F90
+++ b/mediator/med_methods_mod.F90
@@ -1028,7 +1028,7 @@ contains
 
     lstring = ''
     if (present(string)) then
-       lstring = trim(string)//'_'
+       lstring = trim(string)
     endif
 
     ! Determine number of fields in field bundle and allocate memory for lfieldnamelist
@@ -1049,7 +1049,7 @@ contains
        if (chkerr(rc,__LINE__,u_FILE_u)) return
 
        if (lrank == 1) then
-          call ESMF_FieldWriteVTK(lfield, trim(lstring)//trim(lfieldnamelist(n)), rc=rc)
+          call ESMF_FieldWriteVTK(lfield, trim(lfieldnamelist(n))//'_'//trim(lstring), rc=rc)
           if (chkerr(rc,__LINE__,u_FILE_u)) return
        else
           call ESMF_LogWrite(trim(subname)//": ERROR rank not supported ", ESMF_LOGMSG_ERROR)

--- a/mediator/med_methods_mod.F90
+++ b/mediator/med_methods_mod.F90
@@ -1354,7 +1354,10 @@ contains
         call med_methods_Field_GetFldPtr(lfield, fldptr1=dataptro1, fldptr2=dataptro2, rank=lranko, rc=rc)
         if (chkerr(rc,__LINE__,u_FILE_u)) return
 
-        if (lranki == 1 .and. lranko == 1) then
+        if (lranki == 0 .and. lranko == 0) then
+           ! do nothing
+          call ESMF_LogWrite(trim(subname)//": Both ranki and ranko are 0", ESMF_LOGMSG_INFO)
+        elseif (lranki == 1 .and. lranko == 1) then
 
           if (.not.med_methods_FieldPtr_Compare(dataPtro1, dataPtri1, subname, rc)) then
             call ESMF_LogWrite(trim(subname)//": ERROR in dataPtr1 size ", ESMF_LOGMSG_ERROR)
@@ -1397,7 +1400,7 @@ contains
         else
 
           write(msgString,'(a,2i8)') trim(subname)//": ranki, ranko = ",lranki,lranko
-          call ESMF_LogWrite(trim(msgString), ESMF_LOGMSG_INFO)
+          call ESMF_LogWrite(trim(msgString), ESMF_LOGMSG_ERROR)
           call ESMF_LogWrite(trim(subname)//": ERROR ranki ranko not supported "//trim(lfieldnamelist(n)), &
                ESMF_LOGMSG_ERROR)
           rc = ESMF_FAILURE

--- a/mediator/med_methods_mod.F90
+++ b/mediator/med_methods_mod.F90
@@ -44,6 +44,7 @@ module med_methods_mod
   public med_methods_FB_init_pointer
   public med_methods_FB_reset
   public med_methods_FB_diagnose
+  public med_methods_FB_write
   public med_methods_FB_FldChk
   public med_methods_FB_GetFldPtr
   public med_methods_FB_getNameN
@@ -997,6 +998,72 @@ contains
     call ESMF_LogWrite(trim(subname)//": done", ESMF_LOGMSG_INFO)
 
   end subroutine med_methods_FB_diagnose
+
+  !-----------------------------------------------------------------------------
+
+  subroutine med_methods_FB_write(FB, string, rc)
+    ! ----------------------------------------------
+    ! Diagnose status of FB
+    ! ----------------------------------------------
+
+    use ESMF, only : ESMF_FieldBundle, ESMF_FieldBundleGet
+    use ESMF, only : ESMF_Field, ESMF_FieldGet
+    use ESMF, only : ESMF_FieldWriteVTK
+
+    type(ESMF_FieldBundle) , intent(inout)        :: FB
+    character(len=*)       , intent(in), optional :: string
+    integer                , intent(out)          :: rc
+
+    ! local variables
+    integer                         :: n
+    integer                         :: fieldCount, lrank
+    character(ESMF_MAXSTR), pointer :: lfieldnamelist(:)
+    character(len=CL)               :: lstring
+    type(ESMF_Field)                :: lfield
+    character(len=*), parameter     :: subname='(med_methods_FB_write)'
+    ! ----------------------------------------------
+
+    call ESMF_LogWrite(trim(subname)//": called", ESMF_LOGMSG_INFO)
+    rc = ESMF_SUCCESS
+
+    lstring = ''
+    if (present(string)) then
+       lstring = trim(string)//'_'
+    endif
+
+    ! Determine number of fields in field bundle and allocate memory for lfieldnamelist
+    call ESMF_FieldBundleGet(FB, fieldCount=fieldCount, rc=rc)
+    if (chkerr(rc,__LINE__,u_FILE_u)) return
+    allocate(lfieldnamelist(fieldCount))
+
+    ! Get the fields in the field bundle
+    call ESMF_FieldBundleGet(FB, fieldNameList=lfieldnamelist, rc=rc)
+    if (chkerr(rc,__LINE__,u_FILE_u)) return
+
+    ! For each field in the bundle, get its memory location and print out the field
+    do n = 1, fieldCount
+       call ESMF_FieldBundleGet(FB, fieldName=trim(lfieldnamelist(n)), field=lfield, rc=rc)
+       if (chkerr(rc,__LINE__,u_FILE_u)) return
+
+       call ESMF_FieldGet(lfield, rank=lrank, rc=rc)
+       if (chkerr(rc,__LINE__,u_FILE_u)) return
+
+       if (lrank == 1) then
+          call ESMF_FieldWriteVTK(lfield, trim(lstring)//trim(lfieldnamelist(n)), rc=rc)
+          if (chkerr(rc,__LINE__,u_FILE_u)) return
+       else
+          call ESMF_LogWrite(trim(subname)//": ERROR rank not supported ", ESMF_LOGMSG_ERROR)
+          rc = ESMF_FAILURE
+          return
+       endif
+    end do
+
+    ! Deallocate memory
+    deallocate(lfieldnamelist)
+
+    call ESMF_LogWrite(trim(subname)//": done", ESMF_LOGMSG_INFO)
+
+  end subroutine med_methods_FB_write
 
   !-----------------------------------------------------------------------------
 #ifdef DIAGNOSE

--- a/mediator/med_phases_aofluxes_mod.F90
+++ b/mediator/med_phases_aofluxes_mod.F90
@@ -1597,6 +1597,10 @@ end subroutine med_aofluxes_map_ogrid2xgrid_input
        if (chkerr(rc,__LINE__,u_FILE_u)) return
        call fldbun_getfldptr(fldbun_a, 'Sa_shum', aoflux_in%shum, xgrid=xgrid, rc=rc)
        if (chkerr(rc,__LINE__,u_FILE_u)) return
+       if (add_gusts) then
+          call fldbun_getfldptr(fldbun_a, 'Faxa_rainc', aoflux_in%rainc, xgrid=xgrid, rc=rc)
+          if (chkerr(rc,__LINE__,u_FILE_u)) return
+       end if
     end if
 
     ! extra fields for ufs.frac.aoflux

--- a/mediator/med_phases_aofluxes_mod.F90
+++ b/mediator/med_phases_aofluxes_mod.F90
@@ -1597,8 +1597,6 @@ end subroutine med_aofluxes_map_ogrid2xgrid_input
        if (chkerr(rc,__LINE__,u_FILE_u)) return
        call fldbun_getfldptr(fldbun_a, 'Sa_shum', aoflux_in%shum, xgrid=xgrid, rc=rc)
        if (chkerr(rc,__LINE__,u_FILE_u)) return
-       call fldbun_getfldptr(fldbun_a, 'Faxa_rainc', aoflux_in%rainc, xgrid=xgrid, rc=rc)
-       if (chkerr(rc,__LINE__,u_FILE_u)) return
     end if
 
     ! extra fields for ufs.frac.aoflux
@@ -1710,8 +1708,6 @@ end subroutine med_aofluxes_map_ogrid2xgrid_input
     if (chkerr(rc,__LINE__,u_FILE_u)) return
     call fldbun_getfldptr(fldbun, 'So_duu10n', aoflux_out%duu10n, xgrid=xgrid, rc=rc)
     if (chkerr(rc,__LINE__,u_FILE_u)) return
-    call fldbun_getfldptr(fldbun, 'So_ugustOut', aoflux_out%ugust_out, xgrid=xgrid, rc=rc)
-    if (chkerr(rc,__LINE__,u_FILE_u)) return
     call fldbun_getfldptr(fldbun, 'Faox_taux', aoflux_out%taux, xgrid=xgrid, rc=rc)
     if (chkerr(rc,__LINE__,u_FILE_u)) return
     call fldbun_getfldptr(fldbun, 'Faox_tauy', aoflux_out%tauy, xgrid=xgrid, rc=rc)
@@ -1724,6 +1720,7 @@ end subroutine med_aofluxes_map_ogrid2xgrid_input
     if (chkerr(rc,__LINE__,u_FILE_u)) return
     call fldbun_getfldptr(fldbun, 'Faox_lwup', aoflux_out%lwup, xgrid=xgrid, rc=rc)
     if (chkerr(rc,__LINE__,u_FILE_u)) return
+
     if (flds_wiso) then
        call fldbun_getfldptr(fldbun, 'Faox_evap_16O', aoflux_out%evap_16O, xgrid=xgrid, rc=rc)
        if (chkerr(rc,__LINE__,u_FILE_u)) return
@@ -1735,6 +1732,13 @@ end subroutine med_aofluxes_map_ogrid2xgrid_input
        allocate(aoflux_out%evap_16O(lsize)); aoflux_out%evap_16O(:) = 0._R8
        allocate(aoflux_out%evap_18O(lsize)); aoflux_out%evap_18O(:) = 0._R8
        allocate(aoflux_out%evap_HDO(lsize)); aoflux_out%evap_HDO(:) = 0._R8
+    end if
+
+    if (add_gusts) then
+       call fldbun_getfldptr(fldbun, 'So_ugustOut', aoflux_out%ugust_out, xgrid=xgrid, rc=rc)
+       if (chkerr(rc,__LINE__,u_FILE_u)) return
+    else
+       allocate(aoflux_out%ugust_out(lsize)); aoflux_out%ugust_out(:) = 0._R8
     end if
 
   end subroutine set_aoflux_out_pointers

--- a/mediator/med_phases_cdeps_mod.F90
+++ b/mediator/med_phases_cdeps_mod.F90
@@ -138,7 +138,7 @@ contains
        do n1 = 1, ncomps
           do n2 = 1, ncomps
              ! Check for coupling direction and background fill
-             if (n1 /= n2 .and. is_local%wrap%med_coupling_active(n1,n2) .and. is_local%wrap%med_bg_fill_active(n1,n2)) then
+             if (n1 /= n2 .and. is_local%wrap%med_coupling_active(n1,n2) .and. is_local%wrap%med_data_active(n1,n2)) then
                 ! Get number of fields
                 call FB_getNumflds(is_local%wrap%FBImp(n1,n2), trim(subname), nflds, rc)
                 if (chkerr(rc,__LINE__,u_FILE_u)) return

--- a/mediator/med_phases_cdeps_mod.F90
+++ b/mediator/med_phases_cdeps_mod.F90
@@ -209,8 +209,14 @@ contains
                          stream_dtlimit=sdat_config%stream(streamid)%dtlimit, &
                          stream_tintalgo=trim(sdat_config%stream(streamid)%tInterpAlgo), &
                          stream_name=trim(compname(n1))//'_'//trim(compname(n2)), &
+                         stream_src_mask=sdat_config%stream(streamid)%src_mask_val, &
+                         stream_dst_mask=sdat_config%stream(streamid)%dst_mask_val, &
                          rc=rc)
                       if (chkerr(rc,__LINE__,u_FILE_u)) return
+
+                      ! Print out source and destination mask used in the stream
+                      if (maintask) write(logunit,'(a,2i2)') trim(subname)//": mask values src, dst ", &
+                         sdat_config%stream(streamid)%src_mask_val, sdat_config%stream(streamid)%dst_mask_val
 
                       ! Remove temporary variables
                       deallocate(fileList)

--- a/mediator/med_phases_cdeps_mod.F90
+++ b/mediator/med_phases_cdeps_mod.F90
@@ -153,6 +153,7 @@ contains
                    ! Query destination field name and its mesh
                    call ESMF_FieldGet(flddst, mesh=meshdst, name=fldname, rc=rc)
                    if (chkerr(rc,__LINE__,u_FILE_u)) return
+                   if (maintask) write(logunit,'(a)') trim(subname)//": extracting destination mesh from "//trim(fldname)
 
                    ! Check if any field in FB in the given stream
                    ! NOTE: Single stream could provide multiple fields !!!
@@ -165,11 +166,11 @@ contains
                       end do
                    end do
 
-                   ! If match is found, then initialize cdeps inline for the stream
-                   if (streamid /= 0) then
+                   ! If match is found and previously not initialized, then initialize cdeps inline for the stream
+                   if (size(sdat(n1,n2)%stream) == 0 .and. streamid /= 0) then
                       ! Debug print
                       if (maintask) then
-                         write(logunit,'(a,i)') trim(subname)//": "//trim(fldname)//" is found in stream ", streamid
+                         write(logunit,'(a,i)') trim(subname)//": initialize stream ", streamid
                       end if
 
                       ! Allocate temporary variable to store file names in the stream
@@ -179,7 +180,7 @@ contains
                       ! Fill file abd variable lists with data
                       do l = 1, sdat_config%stream(streamid)%nfiles
                          fileList(l) = trim(sdat_config%stream(streamid)%file(l)%name) 
-                         if (maintask) write(logunit,'(a,i2,x,a)') trim(subname)//": file ", l, trim(fileList(l))
+                         if (maintask) write(logunit,'(a,i2,x,a)') trim(subname)//": file     ", l, trim(fileList(l))
                       end do
                       do l = 1, sdat_config%stream(streamid)%nvars
                          varList(l,1) = trim(sdat_config%stream(streamid)%varlist(l)%nameinfile)

--- a/mediator/med_phases_cdeps_mod.F90
+++ b/mediator/med_phases_cdeps_mod.F90
@@ -1,0 +1,68 @@
+module med_phases_cdeps_mod
+
+  use ESMF, only: ESMF_GridComp
+  use ESMF, only: ESMF_LogWrite
+  use ESMF, only: ESMF_SUCCESS, ESMF_LOGMSG_INFO
+
+  use dshr_strdata_mod, only: shr_strdata_type
+  use dshr_strdata_mod, only: shr_strdata_init_from_inline
+  use perf_mod        , only: t_startf, t_stopf
+
+  implicit none
+  private
+
+  !--------------------------------------------------------------------------
+  ! Public interf aces
+  !--------------------------------------------------------------------------
+
+  public med_phases_cdeps_run
+
+  !--------------------------------------------------------------------------
+  ! Private interfaces
+  !--------------------------------------------------------------------------
+
+
+
+  !--------------------------------------------------------------------------
+  ! Private data
+  !--------------------------------------------------------------------------
+
+
+
+  character(*),parameter :: u_FILE_u = __FILE__
+
+!============================================================================
+contains
+!============================================================================
+
+  subroutine med_phases_cdeps_run(gcomp, rc)
+
+    !------------------------------------------------------------------------
+    ! Use CDEPS inline capability to read in data
+    !------------------------------------------------------------------------
+
+    use ESMF, only : ESMF_GridComp
+
+    ! input/output variables
+    type(ESMF_GridComp)  :: gcomp
+    integer, intent(out) :: rc
+
+    character(len=*)  , parameter :: subname='(med_phases_cdeps_run)'
+    !---------------------------------------
+
+    rc = ESMF_SUCCESS
+
+    call t_startf('MED:'//subname)
+    !if (dbug_flag > 5) then
+       call ESMF_LogWrite(trim(subname)//": called", ESMF_LOGMSG_INFO)
+    !endif
+
+
+    !if (dbug_flag > 5) then
+      call ESMF_LogWrite(trim(subname)//": done", ESMF_LOGMSG_INFO)
+    !endif
+    call t_stopf('MED:'//subname)
+
+  end subroutine med_phases_cdeps_run
+
+end module med_phases_cdeps_mod

--- a/mediator/med_phases_cdeps_mod.F90
+++ b/mediator/med_phases_cdeps_mod.F90
@@ -170,7 +170,7 @@ contains
                    if (size(sdat(n1,n2)%stream) == 0 .and. streamid /= 0) then
                       ! Debug print
                       if (maintask) then
-                         write(logunit,'(a,i)') trim(subname)//": initialize stream ", streamid
+                         write(logunit,'(a,i3)') trim(subname)//": initialize stream ", streamid
                       end if
 
                       ! Allocate temporary variable to store file names in the stream
@@ -258,7 +258,7 @@ contains
           if (size(sdat(n1,n2)%stream) > 0) then
              ! Debug print
              if (maintask) then
-                 write(logunit,'(a,i)') trim(subname)//": read stream "//trim(compname(n1))//" -> "//trim(compname(n2))  
+                 write(logunit,'(a)') trim(subname)//": read stream "//trim(compname(n1))//" -> "//trim(compname(n2))  
              end if
 
              ! Read data

--- a/mediator/med_phases_cdeps_mod.F90
+++ b/mediator/med_phases_cdeps_mod.F90
@@ -1,33 +1,61 @@
 module med_phases_cdeps_mod
 
-  use ESMF, only: ESMF_GridComp
+  use ESMF, only: ESMF_Clock, ESMF_ClockGet, ESMF_Time, ESMF_TimeGet
+  use ESMF, only: ESMF_Mesh
+  use ESMF, only: ESMF_GridComp, ESMF_GridCompGet
   use ESMF, only: ESMF_LogWrite
+  use ESMF, only: ESMF_Field, ESMF_FieldGet
+  use ESMF, only: ESMF_FieldBundleGet
+  use ESMF, only: ESMF_StateIsCreated
+  use ESMF, only: ESMF_GridCompGetInternalState
   use ESMF, only: ESMF_SUCCESS, ESMF_LOGMSG_INFO
 
-  use dshr_strdata_mod, only: shr_strdata_type
-  use dshr_strdata_mod, only: shr_strdata_init_from_inline
-  use perf_mod        , only: t_startf, t_stopf
+  use med_internalstate_mod, only: InternalState
+  use med_internalstate_mod, only: compname, compatm, compocn
+  use perf_mod             , only: t_startf, t_stopf
+  use med_kind_mod         , only: cl => shr_kind_cl
+  use med_kind_mod         , only: r8 => shr_kind_r8
+  use med_constants_mod    , only: dbug_flag => med_constants_dbug_flag
+  use med_utils_mod        , only: chkerr => med_utils_ChkErr
+  use med_methods_mod      , only: med_methods_FB_FldChk 
+  use med_methods_mod      , only: med_methods_FB_getFieldN
+  use med_methods_mod      , only: FB_init_pointer => med_methods_FB_Init_pointer
+
+  use dshr_strdata_mod     , only: shr_strdata_type
+  use dshr_strdata_mod     , only: shr_strdata_init_from_inline
+  use dshr_strdata_mod     , only: shr_strdata_advance
 
   implicit none
   private
 
   !--------------------------------------------------------------------------
-  ! Public interf aces
+  ! Public interfaces
   !--------------------------------------------------------------------------
 
   public med_phases_cdeps_run
 
   !--------------------------------------------------------------------------
-  ! Private interfaces
-  !--------------------------------------------------------------------------
-
-
-
-  !--------------------------------------------------------------------------
   ! Private data
   !--------------------------------------------------------------------------
 
+  type config
+     integer :: year_first
+     integer :: year_last
+     integer :: year_align
+     integer :: offset
+     real(r8) :: dtlimit
+     character(len=cl) :: mesh_filename
+     character(len=cl), allocatable :: data_filename(:)
+     character(len=cl), allocatable :: fld_list(:)
+     character(len=cl), allocatable :: fld_list_model(:)
+     character(len=cl) :: mapalgo
+     character(len=cl) :: taxmode
+     character(len=cl) :: tintalgo
+     character(len=cl) :: name
+  end type config
 
+  type(config), allocatable           :: stream(:) ! stream configuration
+  type(shr_strdata_type), allocatable :: sdat(:)   ! input data stream
 
   character(*),parameter :: u_FILE_u = __FILE__
 
@@ -47,22 +75,144 @@ contains
     type(ESMF_GridComp)  :: gcomp
     integer, intent(out) :: rc
 
-    character(len=*)  , parameter :: subname='(med_phases_cdeps_run)'
+    ! local variables
+    type(InternalState)         :: is_local
+    type(ESMF_Clock)            :: clock
+    type(ESMF_Time)             :: currTime
+    type(ESMF_Mesh)             :: meshdst
+    type(ESMF_Field)            :: flddst
+    integer                     :: n1, n2, item, localPet
+    integer                     :: curr_ymd, sec
+    integer                     :: year, month, day, hour, minute, second
+    logical, save               :: first_time = .true.
+    character(len=*), parameter :: subname = '(med_phases_cdeps_run)'
     !---------------------------------------
 
     rc = ESMF_SUCCESS
 
     call t_startf('MED:'//subname)
-    !if (dbug_flag > 5) then
+    if (dbug_flag > 5) then
        call ESMF_LogWrite(trim(subname)//": called", ESMF_LOGMSG_INFO)
-    !endif
+    endif
 
+    ! Get the internal state from gcomp
+    nullify(is_local%wrap)
+    call ESMF_GridCompGetInternalState(gcomp, is_local, rc)
+    if (chkerr(rc,__LINE__,u_FILE_u)) return
 
-    !if (dbug_flag > 5) then
+    ! Query component
+    call ESMF_GridCompGet(gcomp, clock=clock, localPet=localPet, rc=rc)
+    if (chkerr(rc,__LINE__,u_FILE_u)) return
+
+    ! Initialize cdeps inline
+    if (first_time) then 
+       ! Set components in both side
+       ! TODO: This needs to be dynamic and read from hconfig file
+       n1 = compocn
+       n2 = compatm
+
+       ! Allocate data structures
+       ! TODO: The number of stream will come from config file
+       if (.not. allocated(sdat)) allocate(sdat(1))
+       if (.not. allocated(stream)) allocate(stream(1))
+
+       ! Check coupling direction
+       if (n1 /= n2) then
+          if (is_local%wrap%med_coupling_active(n1,n2)) then
+             ! Get destination field
+             call med_methods_FB_getFieldN(is_local%wrap%FBImp(n2,n2), 1, flddst, rc)
+             if (chkerr(rc,__LINE__,u_FILE_u)) return
+
+             ! Get destination field mesh
+             call ESMF_FieldGet(flddst, mesh=meshdst, rc=rc)
+             if (chkerr(rc,__LINE__,u_FILE_u)) return
+
+             ! Initialize cdeps inline
+             call shr_strdata_init_from_inline(sdat(1), my_task = localPet, logunit = 6, &
+                compname = trim(compname(n2)), &
+                model_clock = clock, model_mesh = meshdst, &
+                stream_meshfile     = 'INPUT_DATA/ESMFmesh.nc', &
+                stream_filenames    = (/ 'INPUT_DATA/tsfc_fv3grid_202318612_sub.nc' /), &
+                stream_yearFirst    = 2023, &
+                stream_yearLast     = 2023,               &
+                stream_yearAlign    = 2023,              &
+                stream_fldlistFile  = (/ 'twsfc' /),                 &
+                stream_fldListModel = (/ 'twsfc' /),                 &
+                stream_lev_dimname  = 'null',                              &
+                stream_mapalgo      = 'bilinear',                          &
+                stream_offset       = 0,                                   &
+                stream_taxmode      = 'cycle',                             &
+                stream_dtlimit      = 1.5d0,                           &
+                stream_tintalgo     = 'linear',                            &
+                stream_name         = 'fvcom great lakes',         &
+                rc                  = rc) 
+
+             ! Create FB to store data
+             if (ESMF_StateIsCreated(is_local%wrap%NStateExp(n2), rc=rc)) then
+                call FB_init_pointer(is_local%wrap%NStateExp(n2), is_local%wrap%FBExpInline(n2), &
+                   is_local%wrap%flds_scalar_name, name='FBExpInline'//trim(compname(n2)), rc=rc)
+                if (chkerr(rc,__LINE__,u_FILE_u)) return
+             end if
+          end if
+       end if
+
+       ! Set flag to false
+       first_time = .false.
+    end if
+
+    ! Get current time
+    call ESMF_ClockGet(clock, currTime=currTime, rc=rc)
+    if (chkerr(rc,__LINE__,u_FILE_u)) return
+
+    ! Query current time
+    call ESMF_TimeGet(currTime, yy=year, mm=month, dd=day, h=hour, m=minute, s=second, rc=rc)
+    if (chkerr(rc,__LINE__,u_FILE_u)) return
+
+    curr_ymd = abs(year)*10000+month*100+day
+    sec = hour*3600+minute*60+second
+
+    ! Run inline cdeps and read data
+    n1 = compocn
+    n2 = compatm
+
+    if (n1 /= n2) then
+       if (is_local%wrap%med_coupling_active(n1,n2)) then
+          call shr_strdata_advance(sdat(1), ymd=curr_ymd, tod=sec, logunit=6, istr=trim(compname(n2)), rc=rc) 
+          if (chkerr(rc,__LINE__,u_FILE_u)) return
+
+          ! Loop over fields provided by CDEPS inline and add it to FB
+          do item = 1, 1 !size(config%stream_fldListFile)
+             ! Get field
+             !call ESMF_FieldBundleGet(sdat(1)%pstrm(1)%fldbun_model, fieldName=trim(config%stream_fldListFile(item)), field=flddst, rc=rc)
+             call ESMF_FieldBundleGet(sdat(1)%pstrm(1)%fldbun_model, fieldName='So_t', field=flddst, rc=rc)
+             if (chkerr(rc,__LINE__,u_FILE_u)) return
+
+             ! Check FB for field
+             !if (med_methods_FB_FldChk(is_local%wrap%FBExpInline(n2), trim(config%stream_fldListFile(item)))) then
+             !   
+             !end if
+
+          end do
+       end if
+    end if      
+
+    if (dbug_flag > 5) then
       call ESMF_LogWrite(trim(subname)//": done", ESMF_LOGMSG_INFO)
-    !endif
+    endif
     call t_stopf('MED:'//subname)
 
   end subroutine med_phases_cdeps_run
+
+  !==========================================================================
+
+  subroutine read_config()
+
+    !------------------------------------------------------------------------
+    ! Read YAML based Hconfig file
+    !------------------------------------------------------------------------
+
+
+
+  end subroutine read_config
 
 end module med_phases_cdeps_mod

--- a/mediator/med_phases_cdeps_mod.F90
+++ b/mediator/med_phases_cdeps_mod.F90
@@ -228,8 +228,8 @@ contains
                 end do ! nflds
 
                 ! Create empty FB
-                if (.not. ESMF_FieldBundleIsCreated(is_local%wrap%FBExpIn(n2), rc=rc) .and. found) then
-                   is_local%wrap%FBExpIn(n2) = ESMF_FieldBundleCreate(name="inline_"//trim(compname(n2)), rc=rc)
+                if (.not. ESMF_FieldBundleIsCreated(is_local%wrap%FBData(n2), rc=rc) .and. found) then
+                   is_local%wrap%FBData(n2) = ESMF_FieldBundleCreate(name="inline_"//trim(compname(n2)), rc=rc)
                    if (chkerr(rc,__LINE__,u_FILE_u)) return
                 end if
              end if
@@ -271,12 +271,12 @@ contains
              if (chkerr(rc,__LINE__,u_FILE_u)) return
 
              ! Point FB from internal one
-             is_local%wrap%FBExpIn(n2) = sdat(n1,n2)%pstrm(1)%fldbun_model
+             is_local%wrap%FBData(n2) = sdat(n1,n2)%pstrm(1)%fldbun_model
   
              ! Write FB for debugging
              if (dbug_flag > 10) then
                 write(suffix, fmt='(i4,a1,i2.2,a1,i2.2,a1,i5.5)') year, '-', month, '-', day, '-', sec
-                call FB_write(is_local%wrap%FBExpIn(n2), suffix, rc)
+                call FB_write(is_local%wrap%FBData(n2), suffix, rc)
                 if (chkerr(rc,__LINE__,u_FILE_u)) return
              end if
           end if

--- a/mediator/med_phases_history_mod.F90
+++ b/mediator/med_phases_history_mod.F90
@@ -25,7 +25,7 @@ module med_phases_history_mod
   use med_io_mod            , only : med_io_write, med_io_wopen, med_io_enddef, med_io_close
   use perf_mod              , only : t_startf, t_stopf
   use pio                   , only : file_desc_t
-  
+
   implicit none
   private
 

--- a/mediator/med_phases_ocnalb_mod.F90
+++ b/mediator/med_phases_ocnalb_mod.F90
@@ -6,13 +6,11 @@ module med_phases_ocnalb_mod
   use med_utils_mod         , only : chkerr          => med_utils_chkerr
   use med_methods_mod       , only : FB_diagnose     => med_methods_FB_diagnose
   use med_methods_mod       , only : State_GetScalar => med_methods_State_GetScalar
-  use med_internalstate_mod , only : mapconsf, mapnames, compatm, compocn
+  use med_internalstate_mod , only : mapconsf, mapnames, compatm, compocn, maintask
   use perf_mod              , only : t_startf, t_stopf
-#ifdef CESMCOUPLED
   use shr_orb_mod           , only : shr_orb_cosz, shr_orb_decl
   use shr_orb_mod           , only : shr_orb_params, SHR_ORB_UNDEF_INT, SHR_ORB_UNDEF_REAL
   use shr_log_mod           , only : shr_log_unit
-#endif
 
   implicit none
   private
@@ -26,11 +24,10 @@ module med_phases_ocnalb_mod
   !--------------------------------------------------------------------------
   ! Private interfaces
   !--------------------------------------------------------------------------
-#ifdef CESMCOUPLED
+
   private med_phases_ocnalb_init
   private med_phases_ocnalb_orbital_update
   private med_phases_ocnalb_orbital_init
-#endif
 
   !--------------------------------------------------------------------------
   ! Private data
@@ -47,25 +44,30 @@ module med_phases_ocnalb_mod
      logical            :: created   ! has memory been allocated here
   end type ocnalb_type
 
-  ! Conversion from degrees to radians
   character(*),parameter :: u_FILE_u = &
        __FILE__
-#ifdef CESMCOUPLED
   character(len=CL)      :: orb_mode        ! attribute - orbital mode
   integer                :: orb_iyear       ! attribute - orbital year
   integer                :: orb_iyear_align ! attribute - associated with model year
   real(R8)               :: orb_obliq       ! attribute - obliquity in degrees
   real(R8)               :: orb_mvelp       ! attribute - moving vernal equinox longitude
   real(R8)               :: orb_eccen       ! attribute and update-  orbital eccentricity
-#endif
+
   character(len=*) , parameter :: orb_fixed_year       = 'fixed_year'
   character(len=*) , parameter :: orb_variable_year    = 'variable_year'
   character(len=*) , parameter :: orb_fixed_parameters = 'fixed_parameters'
 
+  ! used, reused in module
+  logical  :: flux_albav      ! use average dif and dir albedos
+  logical  :: use_nextswcday  ! use the scalar field for next time (otherwise, will be set using clock)
+  logical  :: use_min_albedo  ! apply minimum value of albedo for direct vis, nir
+  real(R8) :: min_albedo      ! minimum value of albedo for direct vis, nir
+  real(R8) :: albdif          ! 60 deg reference albedo, diffuse
+  real(R8) :: albdir          ! 60 deg reference albedo, direct
 !===============================================================================
 contains
 !===============================================================================
-#ifdef CESMCOUPLED
+
   subroutine med_phases_ocnalb_init(gcomp, ocnalb, rc)
 
     !-----------------------------------------------------------------------
@@ -74,11 +76,12 @@ contains
     ! All input field bundles are ASSUMED to be on the ocean grid
     !-----------------------------------------------------------------------
 
-    use ESMF , only : ESMF_LogWrite, ESMF_LOGMSG_INFO, ESMF_SUCCESS, ESMF_FAILURE
-    use ESMF , only : ESMF_VM, ESMF_VMGet, ESMF_Mesh, ESMF_MeshGet
-    use ESMF , only : ESMF_GridComp, ESMF_GridCompGet
-    use ESMF , only : ESMF_FieldBundleGet, ESMF_Field, ESMF_FieldGet
-    use ESMF , only : operator(==)
+    use ESMF  , only : ESMF_LogWrite, ESMF_LOGMSG_INFO, ESMF_SUCCESS, ESMF_FAILURE
+    use ESMF  , only : ESMF_VM, ESMF_VMGet, ESMF_Mesh, ESMF_MeshGet
+    use ESMF  , only : ESMF_GridComp, ESMF_GridCompGet
+    use ESMF  , only : ESMF_FieldBundleGet, ESMF_Field, ESMF_FieldGet
+    use NUOPC , only : NUOPC_CompAttributeGet
+    use ESMF  , only : operator(==)
 
     ! Arguments
     type(ESMF_GridComp)               :: gcomp
@@ -97,7 +100,11 @@ contains
     type(InternalState)      :: is_local
     real(R8), pointer        :: ownedElemCoords(:)
     character(len=CL)        :: tempc1,tempc2
+    character(len=CS)        :: cvalue
+    logical                  :: use_min_ocnalb
+    logical                  :: isPresent, isSet
     integer                  :: fieldCount
+    character(CL)            :: msg
     type(ESMF_Field), pointer :: fieldlist(:)
     character(*), parameter  :: subname = '(med_phases_ocnalb_init) '
     !-----------------------------------------------------------------------
@@ -186,13 +193,65 @@ contains
     call  med_phases_ocnalb_orbital_init(gcomp, logunit, iam==0, rc)
     if (chkerr(rc,__LINE__,u_FILE_u)) return
 
+    ! Determine if reference albedos are used
+    flux_albav = .false.
+    call NUOPC_CompAttributeGet(gcomp, name='flux_albav', value=cvalue, isPresent=isPresent, isSet=isSet, rc=rc)
+    if (chkerr(rc,__LINE__,u_FILE_u)) return
+    if (isPresent .and. isSet) then
+       read(cvalue,*) flux_albav
+    end if
+    ! Set reference albedo values
+    call NUOPC_CompAttributeGet(gcomp, name="albdif", value=cvalue, isPresent=isPresent, isSet=isSet, rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+    if (isPresent .and. isSet) then
+       read(cvalue,*) albdif
+    else
+       albdif = 0.06_r8
+    end if
+    call NUOPC_CompAttributeGet(gcomp, name="albdir", value=cvalue, isPresent=isPresent, isSet=isSet, rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+    if (isPresent .and. isSet) then
+       read(cvalue,*) albdir
+    else
+       albdir = 0.07_r8
+    end if
+    ! Determine if direct albedo should have a minimum value
+    call NUOPC_CompAttributeGet(gcomp, name="ocean_albedo_limit", value=cvalue, isPresent=isPresent, isSet=isSet, rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+    if (isPresent .and. isSet) then
+       read(cvalue,*) min_albedo
+       use_min_albedo = .true.
+    else
+       min_albedo = 0.0_R8
+       use_min_ocnalb = .false.
+    endif
+    ! Allow setting of albedo timestep using the clock instead of the atm's next timestep
+    use_nextswcday = .true.
+    call NUOPC_CompAttributeGet(gcomp, name="ScalarFieldIdxNextSwCday", isPresent=isPresent, rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+    if (.not. isPresent ) then
+       use_nextswcday = .false.
+    endif
+
+    if (flux_albav) then
+       write(msg,'(2(A,f8.2))') trim(subname)//': mean albedos set: albdif = ',albdif,', albdir = ',albdir
+       call ESMF_LogWrite(trim(msg), ESMF_LOGMSG_INFO)
+    else
+       if (use_min_albedo) then
+          write(msg,'(A,f8.2)') trim(subname)//': min_albedo setting = ',min_albedo
+          call ESMF_LogWrite(trim(msg), ESMF_LOGMSG_INFO)
+       end if
+    end if
+    write(msg,'(A,l)') trim(subname)//': use_nextswcday setting is ',use_nextswcday
+    call ESMF_LogWrite(trim(msg), ESMF_LOGMSG_INFO)
+
     if (dbug_flag > 5) then
       call ESMF_LogWrite(trim(subname)//": done", ESMF_LOGMSG_INFO)
     endif
     call t_stopf('MED:'//subname)
 
   end subroutine med_phases_ocnalb_init
-#endif
+
   !===============================================================================
 
   subroutine med_phases_ocnalb_run(gcomp, rc)
@@ -201,8 +260,10 @@ contains
     ! Compute ocean albedos (on the ocean grid)
     !-----------------------------------------------------------------------
 
+    use NUOPC_Mediator, only : NUOPC_MediatorGet
     use ESMF          , only : ESMF_GridComp, ESMF_GridCompGet, ESMF_TimeInterval
     use ESMF          , only : ESMF_Clock, ESMF_ClockGet, ESMF_Time, ESMF_TimeGet
+    use ESMF          , only : ESMF_ClockIsCreated, ESMF_ClockGetNextTime
     use ESMF          , only : ESMF_VM, ESMF_VMGet
     use ESMF          , only : ESMF_LogWrite, ESMF_LogFoundError
     use ESMF          , only : ESMF_SUCCESS, ESMF_FAILURE, ESMF_LOGMSG_INFO
@@ -211,11 +272,11 @@ contains
     use ESMF          , only : operator(+)
     use NUOPC         , only : NUOPC_CompAttributeGet
     use med_constants_mod , only : shr_const_pi
+    use med_phases_history_mod, only : med_phases_history_write_med
 
     ! input/output variables
     type(ESMF_GridComp)  :: gcomp
     integer, intent(out) :: rc
-#ifdef CESMCOUPLED
     ! local variables
     type(ocnalb_type), save :: ocnalb
     type(ESMF_VM)           :: vm
@@ -224,12 +285,13 @@ contains
     logical                 :: update_alb
     type(InternalState)     :: is_local
     type(ESMF_Clock)        :: clock
+    type(ESMF_Clock)        :: dclock
     type(ESMF_Time)         :: currTime
+    type(ESMF_Time)         :: nextTime
     type(ESMF_TimeInterval) :: timeStep
     character(CL)           :: cvalue
     character(CS)           :: starttype        ! config start type
     character(CL)           :: runtype          ! initial, continue, hybrid, branch
-    logical                 :: flux_albav       ! flux avg option
     real(R8)                :: nextsw_cday      ! calendar day of next atm shortwave
     real(R8), pointer       :: ofrac(:)
     real(R8), pointer       :: ofrad(:)
@@ -246,21 +308,13 @@ contains
     real(R8)                :: obliqr           ! Earth orbit
     real(R8)                :: delta            ! Solar declination angle  in radians
     real(R8)                :: eccf             ! Earth orbit eccentricity factor
-    real(R8), parameter     :: albdif = 0.06_r8 ! 60 deg reference albedo, diffuse
-    real(R8), parameter     :: albdir = 0.07_r8 ! 60 deg reference albedo, direct
     real(R8), parameter     :: const_deg2rad = shr_const_pi/180.0_R8  ! deg to rads
     character(CL)           :: msg
     logical                 :: first_call = .true.
     character(len=*)  , parameter :: subname='(med_phases_ocnalb_run)'
     !---------------------------------------
-#endif
+
     rc = ESMF_SUCCESS
-
-#ifndef CESMCOUPLED
-
-    RETURN  ! the following code is not executed unless the model is CESM
-
-#else
 
     ! Determine main task
     call ESMF_GridCompGet(gcomp, vm=vm, rc=rc)
@@ -275,8 +329,7 @@ contains
 
     ! Determine if ocnalb data type will be initialized - and if not return
     if (first_call) then
-       if ( ESMF_FieldBundleIsCreated(is_local%wrap%FBMed_aoflux_a, rc=rc) .and. &
-            ESMF_FieldBundleIsCreated(is_local%wrap%FBMed_aoflux_o, rc=rc)) then
+       if (ESMF_FieldBundleIsCreated(is_local%wrap%FBMed_ocnalb_o, rc=rc)) then
           ocnalb%created = .true.
        else
           ocnalb%created = .false.
@@ -331,6 +384,26 @@ contains
           call ESMF_TimeGet( currTime, dayOfYear_r8=nextsw_cday, rc=rc )
           if (chkerr(rc,__LINE__,u_FILE_u)) return
        else
+          ! obtain nextsw_cday from atm if it is in the import state
+          if (use_nextswcday) then
+             call State_GetScalar(&
+                  state=is_local%wrap%NstateImp(compatm), &
+                  flds_scalar_name=is_local%wrap%flds_scalar_name, &
+                  flds_scalar_num=is_local%wrap%flds_scalar_num, &
+                  scalar_id=is_local%wrap%flds_scalar_index_nextsw_cday, &
+                  scalar_value=nextsw_cday, rc=rc)
+             if (chkerr(rc,__LINE__,u_FILE_u)) return
+          else
+             call ESMF_TimeGet( currTime, dayOfYear_r8=nextsw_cday, rc=rc )
+             if (ChkErr(rc,__LINE__,u_FILE_u)) return
+          end if
+       end if
+
+       first_call = .false.
+
+    else
+       ! Note that med_methods_State_GetScalar includes a broadcast to all other pets
+       if (use_nextswcday) then
           call State_GetScalar(&
                state=is_local%wrap%NstateImp(compatm), &
                flds_scalar_name=is_local%wrap%flds_scalar_name, &
@@ -338,26 +411,13 @@ contains
                scalar_id=is_local%wrap%flds_scalar_index_nextsw_cday, &
                scalar_value=nextsw_cday, rc=rc)
           if (chkerr(rc,__LINE__,u_FILE_u)) return
+       else
+          call ESMF_ClockGetNextTime(clock, nextTime, rc=rc)
+          if (ChkErr(rc,__LINE__,u_FILE_u)) return
+          call ESMF_TimeGet(nextTime, dayOfYear_r8=nextsw_cday, rc=rc)
+          if (ChkErr(rc,__LINE__,u_FILE_u)) return
        end if
-
-       first_call = .false.
-
-    else
-
-       ! Note that med_methods_State_GetScalar includes a broadcast to all other pets
-       call State_GetScalar(&
-            state=is_local%wrap%NstateImp(compatm), &
-            flds_scalar_name=is_local%wrap%flds_scalar_name, &
-            flds_scalar_num=is_local%wrap%flds_scalar_num, &
-            scalar_id=is_local%wrap%flds_scalar_index_nextsw_cday, &
-            scalar_value=nextsw_cday, rc=rc)
-       if (chkerr(rc,__LINE__,u_FILE_u)) return
-
     end if
-
-    call NUOPC_CompAttributeGet(gcomp, name='flux_albav', value=cvalue, rc=rc)
-    if (chkerr(rc,__LINE__,u_FILE_u)) return
-    read(cvalue,*) flux_albav
 
     ! Get orbital values
     call med_phases_ocnalb_orbital_update(clock, logunit, iam==0, eccen, obliqr, lambm0, mvelpp, rc)
@@ -393,6 +453,9 @@ contains
                 ocnalb%anidr(n) = (.026_r8/(cosz**1.7_r8 + 0.065_r8)) +   &
                                   (.150_r8*(cosz         - 0.100_r8 ) *   &
                                   (cosz - 0.500_r8 ) * (cosz - 1.000_r8 )  )
+                if (use_min_albedo) then
+                   ocnalb%anidr(n) = max (ocnalb%anidr(n), min_albedo)
+                end if
                 ocnalb%avsdr(n) = ocnalb%anidr(n)
                 ocnalb%anidf(n) = albdif
                 ocnalb%avsdf(n) = albdif
@@ -430,18 +493,25 @@ contains
        ofrad(:) = ofrac(:)
     endif
 
+    if (ESMF_FieldBundleIsCreated(is_local%wrap%FBMed_ocnalb_o, rc=rc)) then
+       call NUOPC_MediatorGet(gcomp, driverClock=dClock, rc=rc)
+       if (ChkErr(rc,__LINE__,u_FILE_u)) return
+       if (ESMF_ClockIsCreated(dclock)) then
+          call med_phases_history_write_med(gcomp, rc=rc)
+          if (ChkErr(rc,__LINE__,u_FILE_u)) return
+       end if
+    end if
+
     if (dbug_flag > 1) then
        call FB_diagnose(is_local%wrap%FBMed_ocnalb_o, string=trim(subname)//' FBMed_ocnalb_o', rc=rc)
        if (chkerr(rc,__LINE__,u_FILE_u)) return
     end if
     call t_stopf('MED:'//subname)
 
-#endif
-
   end subroutine med_phases_ocnalb_run
 
 !===============================================================================
-#ifdef CESMCOUPLED
+
   subroutine med_phases_ocnalb_orbital_init(gcomp, logunit, maintask, rc)
 
     !----------------------------------------------------------
@@ -601,7 +671,6 @@ contains
     endif
 
   end subroutine med_phases_ocnalb_orbital_update
-#endif
 
 !===============================================================================
 

--- a/mediator/med_phases_post_atm_mod.F90
+++ b/mediator/med_phases_post_atm_mod.F90
@@ -65,6 +65,7 @@ contains
             FBSrc=is_local%wrap%FBImp(compatm,compatm), &
             FBDst=is_local%wrap%FBImp(compatm,compocn), &
             FBFracSrc=is_local%wrap%FBFrac(compatm), &
+            FBDat=is_local%wrap%FBData(compocn), &
             field_normOne=is_local%wrap%field_normOne(compatm,compocn,:), &
             packed_data=is_local%wrap%packed_data(compatm,compocn,:), &
             routehandles=is_local%wrap%RH(compatm,compocn,:), rc=rc)

--- a/mediator/med_phases_post_atm_mod.F90
+++ b/mediator/med_phases_post_atm_mod.F90
@@ -105,6 +105,7 @@ contains
             FBSrc=is_local%wrap%FBImp(compatm,compatm), &
             FBDst=is_local%wrap%FBImp(compatm,compwav), &
             FBFracSrc=is_local%wrap%FBFrac(compatm), &
+            FBDat=is_local%wrap%FBData(compwav), &
             field_normOne=is_local%wrap%field_normOne(compatm,compwav,:), &
             packed_data=is_local%wrap%packed_data(compatm,compwav,:), &
             routehandles=is_local%wrap%RH(compatm,compwav,:), rc=rc)

--- a/mediator/med_phases_prep_atm_mod.F90
+++ b/mediator/med_phases_prep_atm_mod.F90
@@ -81,6 +81,7 @@ contains
             FBSrc=is_local%wrap%FBImp(compocn,compocn), &
             FBDst=is_local%wrap%FBImp(compocn,compatm), &
             FBFracSrc=is_local%wrap%FBFrac(compocn), &
+            FBDat=is_local%wrap%FBData(compatm), &
             field_NormOne=is_local%wrap%field_normOne(compocn,compatm,:), &
             packed_data=is_local%wrap%packed_data(compocn,compatm,:), &
             routehandles=is_local%wrap%RH(compocn,compatm,:), rc=rc)

--- a/mediator/med_phases_prep_atm_mod.F90
+++ b/mediator/med_phases_prep_atm_mod.F90
@@ -115,7 +115,6 @@ contains
     !--- map atm/ocn fluxes from ocn to atm grid if appropriate
     !---------------------------------------
     if (trim(coupling_mode) == 'cesm' .or. &
-        trim(coupling_mode) == 'hafs' .or. &
         trim(coupling_mode) == 'nems_frac_aoflux' .or. &
         trim(coupling_mode) == 'nems_frac_aoflux_sbs') then
        if (is_local%wrap%aoflux_grid == 'ogrid') then
@@ -134,8 +133,7 @@ contains
     !---------------------------------------
     fldList => med_fldList_GetfldListTo(compatm)
     if (trim(coupling_mode) == 'cesm' .or. &
-        trim(coupling_mode) == 'nems_frac_aoflux' .or. &
-        trim(coupling_mode) == 'hafs') then
+        trim(coupling_mode) == 'nems_frac_aoflux') then
        call med_merge_auto(&
             is_local%wrap%med_coupling_active(:,compatm), &
             is_local%wrap%FBExp(compatm), &
@@ -147,6 +145,7 @@ contains
        if (ChkErr(rc,__LINE__,u_FILE_u)) return
     else if (trim(coupling_mode) == 'nems_frac' .or. &
              trim(coupling_mode) == 'nems_orig' .or. &
+             trim(coupling_mode) == 'hafs'      .or. &
              trim(coupling_mode) == 'nems_frac_aoflux_sbs') then
        call med_merge_auto(&
             is_local%wrap%med_coupling_active(:,compatm), &

--- a/mediator/med_phases_prep_atm_mod.F90
+++ b/mediator/med_phases_prep_atm_mod.F90
@@ -132,30 +132,15 @@ contains
     !--- merge all fields to atm
     !---------------------------------------
     fldList => med_fldList_GetfldListTo(compatm)
-    if (trim(coupling_mode) == 'cesm' .or. &
-        trim(coupling_mode) == 'nems_frac_aoflux') then
-       call med_merge_auto(&
-            is_local%wrap%med_coupling_active(:,compatm), &
-            is_local%wrap%FBExp(compatm), &
-            is_local%wrap%FBFrac(compatm), &
-            is_local%wrap%FBImp(:,compatm), &
-            fldList, &
-            FBMed1=is_local%wrap%FBMed_ocnalb_a, &
-            FBMed2=is_local%wrap%FBMed_aoflux_a, rc=rc)
-       if (ChkErr(rc,__LINE__,u_FILE_u)) return
-    else if (trim(coupling_mode) == 'nems_frac' .or. &
-             trim(coupling_mode) == 'nems_orig' .or. &
-             trim(coupling_mode) == 'hafs'      .or. &
-             trim(coupling_mode) == 'nems_frac_aoflux_sbs') then
-       call med_merge_auto(&
-            is_local%wrap%med_coupling_active(:,compatm), &
-            is_local%wrap%FBExp(compatm), &
-            is_local%wrap%FBFrac(compatm), &
-            is_local%wrap%FBImp(:,compatm), &
-            fldList, &
-            rc=rc)
-       if (ChkErr(rc,__LINE__,u_FILE_u)) return
-    end if
+    call med_merge_auto(&
+         is_local%wrap%med_coupling_active(:,compatm), &
+         is_local%wrap%FBExp(compatm), &
+         is_local%wrap%FBFrac(compatm), &
+         is_local%wrap%FBImp(:,compatm), &
+         fldList, &
+         FBMed1=is_local%wrap%FBMed_ocnalb_a, &
+         FBMed2=is_local%wrap%FBMed_aoflux_a, rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
 
     if (dbug_flag > 1) then
        call FB_diagnose(is_local%wrap%FBExp(compatm),string=trim(subname)//' FBexp(compatm) ', rc=rc)

--- a/mediator/med_phases_prep_ocn_mod.F90
+++ b/mediator/med_phases_prep_ocn_mod.F90
@@ -469,11 +469,18 @@ contains
        end do
        ! Compute sw export to ocean bands if required
        if (export_swnet_by_bands) then
-          c1 = 0.285; c2 = 0.285; c3 = 0.215; c4 = 0.215
-          Foxx_swnet_vdr(:) = c1 * Foxx_swnet(:)
-          Foxx_swnet_vdf(:) = c2 * Foxx_swnet(:)
-          Foxx_swnet_idr(:) = c3 * Foxx_swnet(:)
-          Foxx_swnet_idf(:) = c4 * Foxx_swnet(:)
+          if (trim(coupling_mode) == 'cesm') then
+             c1 = 0.285; c2 = 0.285; c3 = 0.215; c4 = 0.215
+             Foxx_swnet_vdr(:) = c1 * Foxx_swnet(:)
+             Foxx_swnet_vdf(:) = c2 * Foxx_swnet(:)
+             Foxx_swnet_idr(:) = c3 * Foxx_swnet(:)
+             Foxx_swnet_idf(:) = c4 * Foxx_swnet(:)
+          else
+             Foxx_swnet_vdr(:) = Faxa_swvdr(:) * (1.0_R8 - avsdr(:))
+             Foxx_swnet_vdf(:) = Faxa_swvdf(:) * (1.0_R8 - avsdf(:))
+             Foxx_swnet_idr(:) = Faxa_swndr(:) * (1.0_R8 - anidr(:))
+             Foxx_swnet_idf(:) = Faxa_swndf(:) * (1.0_R8 - anidf(:))
+          end if
        end if
     end if
 

--- a/mediator/med_phases_prep_ocn_mod.F90
+++ b/mediator/med_phases_prep_ocn_mod.F90
@@ -116,30 +116,14 @@ contains
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
     fldList => med_fldList_GetfldListTo(compocn)
     ! auto merges to ocn
-    if ( trim(coupling_mode) == 'cesm' .or. &
-         trim(coupling_mode) == 'nems_orig_data' .or. &
-         trim(coupling_mode) == 'nems_frac_aoflux') then
-       call med_merge_auto(&
-            is_local%wrap%med_coupling_active(:,compocn), &
-            is_local%wrap%FBExp(compocn), &
-            is_local%wrap%FBFrac(compocn), &
-            is_local%wrap%FBImp(:,compocn), &
-            fldList, &
-            FBMed1=is_local%wrap%FBMed_aoflux_o, rc=rc)
-       if (ChkErr(rc,__LINE__,u_FILE_u)) return
-    else if (trim(coupling_mode) == 'nems_frac' .or. &
-             trim(coupling_mode) == 'nems_orig' .or. &
-             trim(coupling_mode) == 'hafs'      .or. &
-             trim(coupling_mode) == 'nems_frac_aoflux_sbs') then
-       call med_merge_auto(&
-            is_local%wrap%med_coupling_active(:,compocn), &
-            is_local%wrap%FBExp(compocn), &
-            is_local%wrap%FBFrac(compocn), &
-            is_local%wrap%FBImp(:,compocn), &
-            fldList, &
-            rc=rc)
-       if (ChkErr(rc,__LINE__,u_FILE_u)) return
-    end if
+    call med_merge_auto(&
+         is_local%wrap%med_coupling_active(:,compocn), &
+         is_local%wrap%FBExp(compocn), &
+         is_local%wrap%FBFrac(compocn), &
+         is_local%wrap%FBImp(:,compocn), &
+         fldList, &
+         FBMed1=is_local%wrap%FBMed_aoflux_o, rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
 
     ! compute enthaly associated with rain, snow, condensation and liquid river runoff
     ! the sea-ice model already accounts for the enthalpy flux (as part of melth), so

--- a/mediator/med_phases_prep_ocn_mod.F90
+++ b/mediator/med_phases_prep_ocn_mod.F90
@@ -31,8 +31,7 @@ module med_phases_prep_ocn_mod
   public :: med_phases_prep_ocn_accum  ! called from run sequence
   public :: med_phases_prep_ocn_avg    ! called from run sequence
 
-  private :: med_phases_prep_ocn_custom_cesm
-  private :: med_phases_prep_ocn_custom_nems
+  private :: med_phases_prep_ocn_custom
 
   character(*), parameter :: u_FILE_u  = &
        __FILE__
@@ -217,13 +216,8 @@ contains
     end if
 
     ! custom merges to ocean
-    if (trim(coupling_mode) == 'cesm') then
-       call med_phases_prep_ocn_custom_cesm(gcomp, rc)
-       if (ChkErr(rc,__LINE__,u_FILE_u)) return
-    else if (trim(coupling_mode(1:5)) == 'nems_') then
-       call med_phases_prep_ocn_custom_nems(gcomp, rc)
-       if (ChkErr(rc,__LINE__,u_FILE_u)) return
-    end if
+    call med_phases_prep_ocn_custom(gcomp, rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
 
     ! ocean accumulator
     call FB_accum(is_local%wrap%FBExpAccumOcn, is_local%wrap%FBExp(compocn), rc=rc)
@@ -315,7 +309,7 @@ contains
   end subroutine med_phases_prep_ocn_avg
 
   !-----------------------------------------------------------------------------
-  subroutine med_phases_prep_ocn_custom_cesm(gcomp, rc)
+  subroutine med_phases_prep_ocn_custom(gcomp, rc)
 
     !---------------------------------------
     ! custom calculations for cesm
@@ -372,7 +366,7 @@ contains
     integer             :: lsize
     real(R8)            :: c1,c2,c3,c4
     character(len=64), allocatable :: fldnames(:)
-    character(len=*), parameter    :: subname='(med_phases_prep_ocn_custom_cesm)'
+    character(len=*), parameter    :: subname='(med_phases_prep_ocn_custom)'
     !---------------------------------------
 
     rc = ESMF_SUCCESS
@@ -620,80 +614,6 @@ contains
     end if
     call t_stopf('MED:'//subname)
 
-  end subroutine med_phases_prep_ocn_custom_cesm
-
-  !-----------------------------------------------------------------------------
-  subroutine med_phases_prep_ocn_custom_nems(gcomp, rc)
-
-    ! ----------------------------------------------
-    ! Custom calculation for nems_orig or nems_frac
-    ! ----------------------------------------------
-
-    use ESMF , only : ESMF_GridComp
-    use ESMF , only : ESMF_LogWrite, ESMF_LOGMSG_INFO, ESMF_SUCCESS
-    use ESMF , only : ESMF_FAILURE,  ESMF_LOGMSG_ERROR
-
-    ! input/output variables
-    type(ESMF_GridComp)  :: gcomp
-    integer, intent(out) :: rc
-
-    ! local variables
-    type(InternalState) :: is_local
-    real(R8), pointer   :: customwgt(:)
-    real(R8), pointer   :: ifrac(:)
-    real(R8), pointer   :: ofrac(:)
-    integer             :: lsize
-    character(len=*), parameter    :: subname='(med_phases_prep_ocn_custom_nems)'
-    !---------------------------------------
-
-    rc = ESMF_SUCCESS
-
-    call t_startf('MED:'//subname)
-    if (dbug_flag > 20) then
-       call ESMF_LogWrite(subname//' called', ESMF_LOGMSG_INFO)
-    end if
-    call memcheck(subname, 5, maintask)
-
-    ! Get the internal state
-    nullify(is_local%wrap)
-    call ESMF_GridCompGetInternalState(gcomp, is_local, rc)
-    if (ChkErr(rc,__LINE__,u_FILE_u)) return
-
-    ! get ice and open ocean fractions on the ocn mesh
-    call FB_GetFldPtr(is_local%wrap%FBfrac(compocn), 'ifrac' , ifrac, rc=rc)
-    if (ChkErr(rc,__LINE__,u_FILE_u)) return
-    call FB_GetFldPtr(is_local%wrap%FBfrac(compocn), 'ofrac' , ofrac, rc=rc)
-    if (ChkErr(rc,__LINE__,u_FILE_u)) return
-
-    lsize = size(ofrac)
-    allocate(customwgt(lsize))
-
-    ! netsw_for_ocn = [downsw_from_atm*(1-ice_fraction)*(1-ocn_albedo)] + [pensw_from_ice*(ice_fraction)]
-    customwgt(:) = ofrac(:) * (1.0_R8 - 0.06_R8)
-    call med_merge_field(is_local%wrap%FBExp(compocn),      'Foxx_swnet_vdr', &
-         FBinA=is_local%wrap%FBImp(compatm,compocn), fnameA='Faxa_swvdr'    , wgtA=customwgt, &
-         FBinB=is_local%wrap%FBImp(compice,compocn), fnameB='Fioi_swpen_vdr', wgtB=ifrac, rc=rc)
-    if (ChkErr(rc,__LINE__,u_FILE_u)) return
-    call med_merge_field(is_local%wrap%FBExp(compocn),      'Foxx_swnet_vdf', &
-         FBinA=is_local%wrap%FBImp(compatm,compocn), fnameA='Faxa_swvdf'    , wgtA=customwgt, &
-         FBinB=is_local%wrap%FBImp(compice,compocn), fnameB='Fioi_swpen_vdf', wgtB=ifrac, rc=rc)
-    if (ChkErr(rc,__LINE__,u_FILE_u)) return
-    call med_merge_field(is_local%wrap%FBExp(compocn),      'Foxx_swnet_idr', &
-         FBinA=is_local%wrap%FBImp(compatm,compocn), fnameA='Faxa_swndr'    , wgtA=customwgt, &
-         FBinB=is_local%wrap%FBImp(compice,compocn), fnameB='Fioi_swpen_idr', wgtB=ifrac, rc=rc)
-    if (ChkErr(rc,__LINE__,u_FILE_u)) return
-    call med_merge_field(is_local%wrap%FBExp(compocn),      'Foxx_swnet_idf', &
-         FBinA=is_local%wrap%FBImp(compatm,compocn), fnameA='Faxa_swndf'    , wgtA=customwgt, &
-         FBinB=is_local%wrap%FBImp(compice,compocn), fnameB='Fioi_swpen_idf', wgtB=ifrac, rc=rc)
-    if (ChkErr(rc,__LINE__,u_FILE_u)) return
-
-    deallocate(customwgt)
-
-    if (dbug_flag > 20) then
-       call ESMF_LogWrite(trim(subname)//": done", ESMF_LOGMSG_INFO)
-    end if
-    call t_stopf('MED:'//subname)
-
-  end subroutine med_phases_prep_ocn_custom_nems
+  end subroutine med_phases_prep_ocn_custom
 
 end module med_phases_prep_ocn_mod

--- a/mediator/med_phases_prep_ocn_mod.F90
+++ b/mediator/med_phases_prep_ocn_mod.F90
@@ -119,8 +119,7 @@ contains
     ! auto merges to ocn
     if ( trim(coupling_mode) == 'cesm' .or. &
          trim(coupling_mode) == 'nems_orig_data' .or. &
-         trim(coupling_mode) == 'nems_frac_aoflux' .or. &
-         trim(coupling_mode) == 'hafs') then
+         trim(coupling_mode) == 'nems_frac_aoflux') then
        call med_merge_auto(&
             is_local%wrap%med_coupling_active(:,compocn), &
             is_local%wrap%FBExp(compocn), &
@@ -131,6 +130,7 @@ contains
        if (ChkErr(rc,__LINE__,u_FILE_u)) return
     else if (trim(coupling_mode) == 'nems_frac' .or. &
              trim(coupling_mode) == 'nems_orig' .or. &
+             trim(coupling_mode) == 'hafs'      .or. &
              trim(coupling_mode) == 'nems_frac_aoflux_sbs') then
        call med_merge_auto(&
             is_local%wrap%med_coupling_active(:,compocn), &
@@ -667,30 +667,6 @@ contains
 
     lsize = size(ofrac)
     allocate(customwgt(lsize))
-
-    if (trim(coupling_mode) == 'nems_orig' .or. &
-        trim(coupling_mode) == 'nems_frac' .or. &
-        trim(coupling_mode) == 'nems_frac_aoflux_sbs') then
-       customwgt(:) = -ofrac(:)
-       call med_merge_field(is_local%wrap%FBExp(compocn),      'Faxa_evap', &
-            FBinA=is_local%wrap%FBImp(compatm,compocn), fnameA='Faxa_evap' , wgtA=customwgt, rc=rc)
-       if (ChkErr(rc,__LINE__,u_FILE_u)) return
-
-       customwgt(:) = -ofrac(:)
-       call med_merge_field(is_local%wrap%FBExp(compocn),      'Faxa_sen',  &
-            FBinA=is_local%wrap%FBImp(compatm,compocn), fnameA='Faxa_sen', wgtA=customwgt, rc=rc)
-       if (ChkErr(rc,__LINE__,u_FILE_u)) return
-
-       customwgt(:) = -ofrac(:)
-       call med_merge_field(is_local%wrap%FBExp(compocn),      'Foxx_taux', &
-            FBinA=is_local%wrap%FBImp(compice,compocn), fnameA='Fioi_taux', wgtA=ifrac, &
-            FBinB=is_local%wrap%FBImp(compatm,compocn), fnameB='Faxa_taux', wgtB=customwgt, rc=rc)
-       if (ChkErr(rc,__LINE__,u_FILE_u)) return
-       call med_merge_field(is_local%wrap%FBExp(compocn),      'Foxx_tauy', &
-            FBinA=is_local%wrap%FBImp(compice,compocn), fnameA='Fioi_tauy', wgtA=ifrac, &
-            FBinB=is_local%wrap%FBImp(compatm,compocn), fnameB='Faxa_tauy', wgtB=customwgt, rc=rc)
-       if (ChkErr(rc,__LINE__,u_FILE_u)) return
-    end if
 
     ! netsw_for_ocn = [downsw_from_atm*(1-ice_fraction)*(1-ocn_albedo)] + [pensw_from_ice*(ice_fraction)]
     customwgt(:) = ofrac(:) * (1.0_R8 - 0.06_R8)

--- a/mediator/med_phases_prep_ocn_mod.F90
+++ b/mediator/med_phases_prep_ocn_mod.F90
@@ -643,7 +643,6 @@ contains
     real(R8), pointer   :: ifrac(:)
     real(R8), pointer   :: ofrac(:)
     integer             :: lsize
-    real(R8)        , parameter    :: const_lhvap = 2.501e6_R8  ! latent heat of evaporation ~ J/kg
     character(len=*), parameter    :: subname='(med_phases_prep_ocn_custom_nems)'
     !---------------------------------------
 
@@ -672,9 +671,9 @@ contains
     if (trim(coupling_mode) == 'nems_orig' .or. &
         trim(coupling_mode) == 'nems_frac' .or. &
         trim(coupling_mode) == 'nems_frac_aoflux_sbs') then
-       customwgt(:) = -ofrac(:) / const_lhvap
+       customwgt(:) = -ofrac(:)
        call med_merge_field(is_local%wrap%FBExp(compocn),      'Faxa_evap', &
-            FBinA=is_local%wrap%FBImp(compatm,compocn), fnameA='Faxa_lat' , wgtA=customwgt, rc=rc)
+            FBinA=is_local%wrap%FBImp(compatm,compocn), fnameA='Faxa_evap' , wgtA=customwgt, rc=rc)
        if (ChkErr(rc,__LINE__,u_FILE_u)) return
 
        customwgt(:) = -ofrac(:)

--- a/mediator/med_phases_prep_wav_mod.F90
+++ b/mediator/med_phases_prep_wav_mod.F90
@@ -19,7 +19,7 @@ module med_phases_prep_wav_mod
   use med_methods_mod       , only : FB_reset      => med_methods_FB_reset
   use med_methods_mod       , only : FB_check_for_nans => med_methods_FB_check_for_nans
   use esmFlds               , only : med_fldList_GetfldListTo
-  use med_internalstate_mod , only : compwav
+  use med_internalstate_mod , only : compatm, compwav
   use perf_mod              , only : t_startf, t_stopf
 
   implicit none
@@ -92,12 +92,39 @@ contains
     rc = ESMF_SUCCESS
     call memcheck(subname, 5, maintask)
 
-    ! Get the internal state
+    !---------------------------------------
+    ! --- Get the internal state
+    !---------------------------------------
     nullify(is_local%wrap)
     call ESMF_GridCompGetInternalState(gcomp, is_local, rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
 
-    ! auto merges to wav
+    !---------------------------------------
+    ! --- map atm to wav, only if data stream is available
+    !---------------------------------------
+    if (is_local%wrap%med_coupling_active(compatm,compwav) .and. &
+        is_local%wrap%med_data_active(compatm,compwav) .and. &
+        is_local%wrap%med_data_force_first(compwav)) then
+       call t_startf('MED:'//trim(subname)//' map_atm2wav')
+       call med_map_field_packed( &
+            FBSrc=is_local%wrap%FBImp(compatm,compatm), &
+            FBDst=is_local%wrap%FBImp(compatm,compwav), &
+            FBFracSrc=is_local%wrap%FBFrac(compatm), &
+            FBDat=is_local%wrap%FBData(compwav), &
+            use_data=is_local%wrap%med_data_force_first(compwav), &
+            field_normOne=is_local%wrap%field_normOne(compatm,compwav,:), &
+            packed_data=is_local%wrap%packed_data(compatm,compwav,:), &
+            routehandles=is_local%wrap%RH(compatm,compwav,:), rc=rc)
+       if (ChkErr(rc,__LINE__,u_FILE_u)) return
+       call t_stopf('MED:'//trim(subname)//' map_atm2wav')
+
+       ! Reset flag to use data
+       is_local%wrap%med_data_force_first(compwav) = .false.
+    end if
+
+    !---------------------------------------
+    !--- merge all fields to wav 
+    !---------------------------------------
     call med_merge_auto(&
          is_local%wrap%med_coupling_active(:,compwav), &
          is_local%wrap%FBExp(compwav), &


### PR DESCRIPTION
### Description of changes
This PR aims to bring CDEPS inline capability to CMEPS to fill unmapped regions for the regional modeling configurations. More information can be found in the following presentation: https://docs.google.com/presentation/d/1Tk76zlsRiT7_KMJiZsEJHNvlHciZJJBBhsJurRMxVy4/edit#slide=id.g2613ed2f8f8_0_0

This PR is also linked to complete the implementation: https://github.com/ESCOMP/CDEPS/pull/259

### Specific notes

Contributors other than yourself, if any: @danrosen25 @binli2337 @BinLiu-NOAA 

CMEPS Issues Fixed (include github issue #): No

Are changes expected to change answers? (specify if bfb, different at roundoff, more substantial) No

Any User Interface Changes (namelist or namelist defaults changes)? No. 

The user need to add new phase (`med_phases_cdeps_run`) to the run sequence to activate the feature. Then, needs to provide `stream.config` configuration file.

Additional changes also made to allow filling exchange fields with all data in the first coupling time step. I introduce set of new mediator namelist option to make it configurable. So, for example I am setting following in the nems.configure for ocean and wave (in mediator section),

```
  ocn_use_data_first_import = .true.
  wav_use_data_first_import = .true.
``` 

By default the values are .false. and it is only usable when CDEPS Inline feature activated. I also modify the wave and ocean prep phases to get the data and pass it to the components.

### Testing performed
Please describe the tests along with the target model and machine(s) 
If possible, please also added hashes that were used in the testing

This is initially tested under UFS Weather Model and did. not change the answer for `hafs_regional_atm_ocn_wav` and `cpld_control_p8` cases. More test will be performed with both UFS Weather Model and also CESM.