### PR TITLE
remove the SMP_PRESENT variable and replace with BUILD_THREADED

### DIFF
--- a/cime_config/config_component.xml
+++ b/cime_config/config_component.xml
@@ -821,15 +821,6 @@
     different MPI ranks to different GPUs within the same compute node</desc>
   </entry>
 
-  <entry id="SMP_PRESENT">
-    <type>logical</type>
-    <valid_values>TRUE,FALSE</valid_values>
-    <default_value>FALSE</default_value>
-    <group>build_def</group>
-    <file>env_build.xml</file>
-    <desc>TRUE implies that at least one of the components is built threaded (DO NOT EDIT)</desc>
-  </entry>
-
   <entry id="ESMF_AWARE_THREADING">
     <type>logical</type>
     <valid_values>TRUE,FALSE</valid_values>


### PR DESCRIPTION
### Description of changes
Removes SMP_PRESENT from xml  

### Specific notes
Requires cime PR https://github.com/ESMCI/cime/pull/4546
Contributors other than yourself, if any:

CMEPS Issues Fixed (include github issue #):

Are changes expected to change answers? no bfb

Any User Interface Changes (namelist or namelist defaults changes)?

### Testing performed
Please describe the tests along with the target model and machine(s) 
If possible, please also added hashes that were used in the testing

