### PR TITLE
turn add_gusts on by default for camdev

### DIFF
--- a/cime_config/buildnml
+++ b/cime_config/buildnml
@@ -106,7 +106,8 @@ def _create_drv_namelists(case, infile, confdir, nmlgen, files):
     config["COMP_OCN"] = case.get_value("COMP_OCN")
     config["COMP_ROF"] = case.get_value("COMP_ROF")
     config["COMP_WAV"] = case.get_value("COMP_WAV")
-
+    config["CAMDEV"] = "True" if "CAM%DEV" in case.get_value("COMPSET") else "False"
+    
     if (
         (
             case.get_value("COMP_ROF") == "mosart"

--- a/cime_config/namelist_definition_drv.xml
+++ b/cime_config/namelist_definition_drv.xml
@@ -954,7 +954,8 @@
       add a wind gustiness factor
     </desc>
     <values>
-      <value>.false.</value>
+      <value CAMDEV="True">.true.</value>
+      <value CAMDEV="False">.false.</value>
     </values>
   </entry>
 


### PR DESCRIPTION
### Description of changes
Turn on gust by default for cam%dev compsets.

### Specific notes

Contributors other than yourself, if any:

CMEPS Issues Fixed (include github issue #):

Are changes expected to change answers? (specify if bfb, different at roundoff, more substantial) 

Any User Interface Changes (namelist or namelist defaults changes)?

### Testing performed
Please describe the tests along with the target model and machine(s) 
If possible, please also added hashes that were used in the testing

