### PR TITLE
For T compsets, only run GLC if med_to_glc is true

### DIFF
--- a/cime_config/runseq/runseq_TG.py
+++ b/cime_config/runseq/runseq_TG.py
@@ -34,7 +34,7 @@ def gen_runseq(case, coupling_times):
         runseq.add_action ("MED med_phases_post_lnd"        , run_lnd)
         runseq.add_action ("MED med_phases_prep_glc"        , med_to_glc)
         runseq.add_action ("MED -> GLC :remapMethod=redist" , med_to_glc)
-        runseq.add_action ("GLC"                            , run_glc)
+        runseq.add_action ("GLC"                            , run_glc and med_to_glc)
         runseq.add_action ("GLC -> MED :remapMethod=redist" , run_glc)
         runseq.add_action ("MED med_phases_history_write"   , True)
 


### PR DESCRIPTION
### Description of changes

This makes the logic for running GLC consistent with runseq_general.py. This change is relevant for the unusual case where a T compset (CISM forced by dlnd) is being run with CISM in noevolve mode: in this case, we don't want to run CISM, and trying to run CISM leads to incorrect behavior in a restart case (which is how this issue was detected).

With this change,
ERS_D_Ly3.f09_g17_gris4.T1850Gg.derecho_intel.cism-noevolve passes.

### Specific notes

Contributors other than yourself, if any: @Katetc 

CMEPS Issues Fixed (include github issue #): none

Are changes expected to change answers? No - bfb (except for the unusual case of a T compset with noevolve CISM)

Any User Interface Changes (namelist or namelist defaults changes)? No

### Testing performed

ERS_D_Ly3.f09_g17_gris4.T1850Gg.derecho_intel.cism-noevolve

Using escomp/cism-wrapper@bf0b382

