### PR TITLE
[WIP] Add shr_dust_emis_mod to handle options for dust emissions between CTSM and CAM

### DIFF
--- a/cime_config/namelist_definition_drv_flds.xml
+++ b/cime_config/namelist_definition_drv_flds.xml
@@ -142,6 +142,33 @@
   </entry>
 
   <!-- ========================================================================================  -->
+  <!-- Dust emission fields                                                                      -->
+  <!-- ========================================================================================  -->
+
+  <entry id="dust_emis_method">
+    <type>char*80</type>
+    <category>dust_emissions</category>
+    <group>dust_emis_inparm</group>
+    <valid_values>Zender_2003,Leung_2023</valid_values>
+    <desc>
+        Which dust emission method is going to be used. Either the Zender 2003 scheme or the Leung 2023
+        scheme.
+    </desc>
+  </entry>
+
+  <entry id="zender_soil_erod_source">
+    <type>char*80</type>
+    <category>dust_emissions</category>
+    <group>dust_emis_inparm</group>
+    <valid_values>none,lnd,atm</valid_values>
+    <desc>
+        Option only applying for the Zender_2003 method for whether the soil erodibility file is handled
+        in the active LAND model or in the ATM model.
+        (only used when dust_emis_method is Zender_2003)
+    </desc>
+  </entry>
+
+  <!-- ========================================================================================  -->
   <!-- Ozone control                                                                             -->
   <!-- ========================================================================================  -->
 


### PR DESCRIPTION
### Description of changes

Add a shared module for controlling how dust emissions are handled in CTSM and CAM.
This will allow us to use the current dust emission options, and also the new dust emissions
being developed.

This implements the design given for this work in:

https://docs.google.com/document/d/18nZ3LJF5W-YF9iBhqed6s_NWeKOvSSL2-k0Lye1nnLg/edit#heading=h.c1sjcqnqh1zs

### Specific notes

Contributors other than yourself, if any: @fvitt 

CMEPS Issues Fixed (include github issue #):

  Fixes #353

Are changes expected to change answers? No

Any User Interface Changes (namelist or namelist defaults changes)?

  Namelist items added the drv_fls_in namelist:

```
   dust_emis_method
   zender_soil_erod_source
```
   These will be set by either CAM or CTSM to control how dust emissions work.

### Testing performed

 None so far. But, will do standard testing in CTSM as well as any CMEPS test lists.
 This shouldn't effect anything outside of CTSM and CAM, and even then only for
 versions that use it.

