### PR TITLE
Output downscaled glacier data in cpl glc hist file

### DIFF
--- a/mediator/med_phases_history_mod.F90
+++ b/mediator/med_phases_history_mod.F90
@@ -549,7 +549,6 @@ contains
     character(len=CL)       :: hist_file
     integer                 :: m,n
     logical                 :: isPresent
-    character(len=CS)       :: cvalue
     character(len=*), parameter :: subname='(med_phases_history_write_lnd2glc)'
     !---------------------------------------
 


### PR DESCRIPTION
### Description of changes
In order to evaluate coupled CESM runs with no active ice sheets, it is very helpful to output the glacier forcing fields from the coupler on the glacier grid. @mvertens wrote this update to CMEPS to support exporting state to glc, added into the lnd2glc auxiliary file.

### Specific notes

Contributors other than yourself, if any: @mvertens 

CMEPS Issues Fixed (include github issue #):

Are changes expected to change answers? (specify if bfb, different at roundoff, more substantial) 
bfb with added fields in the glc cpl hist files.

Any User Interface Changes (namelist or namelist defaults changes)? No

### Testing performed
Please describe the tests along with the target model and machine(s) 
If possible, please also added hashes that were used in the testing

I tested this with various configurations and grids. The output looked like what we (the liwg) need for evaluation. We would like to have this in beta 17 for coupled CESM runs.
