### PR TITLE
Run MED -> GLC in CISM NOEVOLVE mode

### DIFF
--- a/cime_config/runseq/driver_config.py
+++ b/cime_config/runseq/driver_config.py
@@ -58,7 +58,7 @@ class DriverConfig(dict):
             med_to_glc = False
         elif (comp_glc == 'cism'):
             if not case.get_value("CISM_EVOLVE"):
-                med_to_glc = False
+                run_glc = False
 
         # If CISM is not evolving only get data back from cism at the initial time
         # However will still need to call the exchange at the end if the stop_option

--- a/cime_config/runseq/runseq_TG.py
+++ b/cime_config/runseq/runseq_TG.py
@@ -35,7 +35,9 @@ def gen_runseq(case, coupling_times):
         runseq.add_action ("MED med_phases_prep_glc"        , med_to_glc)
         runseq.add_action ("MED -> GLC :remapMethod=redist" , med_to_glc)
         runseq.add_action ("GLC"                            , run_glc)
-        runseq.add_action ("GLC -> MED :remapMethod=redist" , run_glc)
+        # Need to do GLC -> MED even if not running GLC; otherwise, we get a
+        # failure in InitializeRealize ("Object being used before creation")
+        runseq.add_action ("GLC -> MED :remapMethod=redist" , med_to_glc)
         runseq.add_action ("MED med_phases_history_write"   , True)
 
         runseq.leave_time_loop(True)

--- a/cime_config/runseq/runseq_TG.py
+++ b/cime_config/runseq/runseq_TG.py
@@ -34,7 +34,7 @@ def gen_runseq(case, coupling_times):
         runseq.add_action ("MED med_phases_post_lnd"        , run_lnd)
         runseq.add_action ("MED med_phases_prep_glc"        , med_to_glc)
         runseq.add_action ("MED -> GLC :remapMethod=redist" , med_to_glc)
-        runseq.add_action ("GLC"                            , run_glc and med_to_glc)
+        runseq.add_action ("GLC"                            , run_glc)
         runseq.add_action ("GLC -> MED :remapMethod=redist" , run_glc)
         runseq.add_action ("MED med_phases_history_write"   , True)
 

--- a/cime_config/runseq/runseq_general.py
+++ b/cime_config/runseq/runseq_general.py
@@ -35,19 +35,6 @@ def gen_runseq(case, coupling_times):
     run_rof, med_to_rof, rof_cpl_time = driver_config['rof']
     run_wav, med_to_wav, wav_cpl_time = driver_config['wav']
 
-    comp_glc = case.get_value("COMP_GLC")
-    run_glc = False
-    post_glc = False
-    if (comp_glc == 'cism'):
-        run_glc = True
-        if case.get_value("CISM_EVOLVE"):
-            post_glc = True
-        else:
-            post_glc = False
-    elif (comp_glc == 'xglc'):
-        run_glc = True
-        post_glc = True
-
     # Note: assume that atm_cpl_dt, lnd_cpl_dt, ice_cpl_dt and wav_cpl_dt are the same
 
     if lnd_cpl_time != atm_cpl_time:
@@ -59,18 +46,32 @@ def gen_runseq(case, coupling_times):
     if rof_cpl_time < ocn_cpl_time:
         expect(False, "assume that rof_cpl_time is always greater than or equal to ocn_cpl_time")
 
+    if run_glc:
+        # It wouldn't make sense to run GLC unless we also do MED -> GLC to transfer fields to GLC,
+        # and some of the below logic controlling what appears in the run sequence depends on this
+        # (i.e., depends on the fact that, if run_glc is True, then med_to_glc is also True).
+        expect(med_to_glc, "if run_glc is True, then med_to_glc must also be True")
+
     rof_outer_loop = run_rof and rof_cpl_time > atm_cpl_time
     ocn_outer_loop = run_ocn and ocn_cpl_time > atm_cpl_time
 
+    # Note that we do some aspects of the GLC outer loop even if run_glc is False
+    # (as long as med_to_glc is True).
+    #
+    # Note that, in contrast to the other outer_loop variables, this doesn't check glc_cpl_time.
+    # This is for consistency with the logic that was in place before adding this variable;
+    # this seems to implicitly assume that glc_cpl_time > atm_cpl_time.
+    glc_outer_loop = med_to_glc
+
     inner_loop = ((atm_cpl_time < ocn_cpl_time) or
                   (atm_cpl_time < rof_cpl_time) or
-                  (run_glc and atm_cpl_time < glc_cpl_time) or
+                  (glc_outer_loop and atm_cpl_time < glc_cpl_time) or
                   atm_cpl_time == ocn_cpl_time)
 
     with RunSeq(os.path.join(caseroot, "CaseDocs", "nuopc.runseq")) as runseq:
 
         #------------------
-        runseq.enter_time_loop(glc_cpl_time, newtime=run_glc, active=med_to_glc)
+        runseq.enter_time_loop(glc_cpl_time, newtime=glc_outer_loop)
         #------------------
 
         #------------------
@@ -199,8 +200,8 @@ def gen_runseq(case, coupling_times):
 
         runseq.add_action("MED med_phases_prep_glc"        , med_to_glc)
         runseq.add_action("MED -> GLC :remapMethod=redist" , med_to_glc)
-        runseq.add_action("GLC"                            , run_glc and med_to_glc)
+        runseq.add_action("GLC"                            , run_glc)
         runseq.add_action("GLC -> MED :remapMethod=redist" , run_glc)
-        runseq.add_action("MED med_phases_post_glc"        , run_glc and post_glc)
+        runseq.add_action("MED med_phases_post_glc"        , run_glc)
 
     shutil.copy(os.path.join(caseroot, "CaseDocs", "nuopc.runseq"), rundir)

--- a/cime_config/runseq/runseq_general.py
+++ b/cime_config/runseq/runseq_general.py
@@ -201,7 +201,9 @@ def gen_runseq(case, coupling_times):
         runseq.add_action("MED med_phases_prep_glc"        , med_to_glc)
         runseq.add_action("MED -> GLC :remapMethod=redist" , med_to_glc)
         runseq.add_action("GLC"                            , run_glc)
-        runseq.add_action("GLC -> MED :remapMethod=redist" , run_glc)
+        # Need to do GLC -> MED even if not running GLC; otherwise, we get a
+        # failure in InitializeRealize ("Object being used before creation")
+        runseq.add_action("GLC -> MED :remapMethod=redist" , med_to_glc)
         runseq.add_action("MED med_phases_post_glc"        , run_glc)
 
     shutil.copy(os.path.join(caseroot, "CaseDocs", "nuopc.runseq"), rundir)


### PR DESCRIPTION
### Description of changes

Previously we hadn't been doing the mapping from MED -> GLC when CISM was running in NOEVOLVE mode. This was a problem because this downscaled SMB is one of the main benefits of running CISM in NOEVOLVE mode.

Resolves ESCOMP/CMEPS#426. See that issue for details.

### Specific notes

Contributors other than yourself, if any: Consultation with @mvertens 

CMEPS Issues Fixed (include github issue #): #426 

Are changes expected to change answers? Changes answers for some cpl hist fields (diagnostic only) in configurations with CISM in NOEVOLVE mode. Otherwise bit-for-bit.

Any User Interface Changes (namelist or namelist defaults changes)? No

### Diffs in runseq

I have verified that the run sequence is the same as before for cases with CISM in EVOLVE mode, as well as for cases with sglc or xglc. Differences just appear in cases with CISM in NOEVOLVE mode.

#### T compset NOEVOLVE

These are the diffs for `ERS_D_Ly3.f09_g17_gris4.T1850Gg.green_gnu.cism-noevolve`:

```diff
--- ERS_D_Ly3.f09_g17_gris4.T1850Gg.green_gnu.cism-noevolve.20240320_165142_7a4g4j/CaseDocs/nuopc.runseq	2024-03-20 16:54:53
+++ ERS_D_Ly3.f09_g17_gris4.T1850Gg.green_gnu.cism-noevolve.20240320_165220_owwtn2/CaseDocs/nuopc.runseq	2024-03-20 16:53:06
@@ -3,6 +3,8 @@
   LND
   LND -> MED :remapMethod=redist
   MED med_phases_post_lnd
+  MED med_phases_prep_glc
+  MED -> GLC :remapMethod=redist
   GLC -> MED :remapMethod=redist
   MED med_phases_history_write
   MED med_phases_history_write
```

#### I compset NOEVOLVE

These are the diffs for `SMS_Lm13.f10_f10_mg37.I1850Clm50SpG.green_gnu.cism-noevolve`:

```diff
--- SMS_Lm13.f10_f10_mg37.I1850Clm50SpG.green_gnu.cism-noevolve.20240320_165200_idgr5p/CaseDocs/nuopc.runseq	2024-03-20 16:55:01
+++ SMS_Lm13.f10_f10_mg37.I1850Clm50SpG.green_gnu.cism-noevolve.20240320_165228_o0jlbq/CaseDocs/nuopc.runseq	2024-03-20 16:53:12
@@ -16,10 +16,12 @@
   ROF
   ROF -> MED :remapMethod=redist
   MED med_phases_post_rof
+@
+  MED med_phases_prep_glc
+  MED -> GLC :remapMethod=redist
+  GLC -> MED :remapMethod=redist
   MED med_phases_history_write
   MED med_phases_restart_write
   MED med_phases_profile
 @
-  GLC -> MED :remapMethod=redist
-@
 ::
```

**Note that, in addition to adding `MED med_phases_prep_glc` and `MED -> GLC :remapMethod=redist` at daily frequency, this also changes `MED med_phases_history_write`, `MED med_phases_restart_write` and `MED med_phases_profile` to be done in the outer (86400) loop rather than the 10800 loop.** This is because I have removed the setting of the `active` flag in the relevant call to `runseq.enter_time_loop`. This is an intentional change: my intuition is that it's right to only call these things daily in this case, since the med2glc fields will likely be wrong if history / restart is at a frequency other than daily. But I think this will restrict us to restarting a CISM NOEVOLVE case no more frequently than daily (as is also the case for a CISM EVOLVE case), and I'm not sure if this change might have some other negative implications that I'm not thinking of / aware of. We could change this back if people feel it would be better to leave it as it was before. (This could be changed back by restoring the `active` flag but now setting `active=run_glc`.)

### Testing performed

Tested in the context of CISM-wrapper on ESCOMP/CISM-wrapper@feaf293 (on the branch in this PR: https://github.com/ESCOMP/CISM-wrapper/pull/86). I ran the full aux_glc test suite on derecho (intel & gnu) with comparisons against baseline. Failures were as expected:
```
    FAIL ERS_D_Ly3.f09_g17_gris4.T1850Gg.derecho_intel.cism-noevolve NLCOMP
    FAIL ERS_D_Ly3.f09_g17_gris4.T1850Gg.derecho_intel.cism-noevolve BASELINE /glade/derecho/scratch/sacks/aux_glc_240301164745/baselines: DIFF
    FAIL NCK_Ly3.f09_g17_gris20.T1850Gg.derecho_gnu COMPARE_base_multiinst
    FAIL SMS_Lm13.f10_f10_mg37.I1850Clm50SpG.derecho_intel.cism-noevolve NLCOMP
    FAIL SMS_Lm13.f10_f10_mg37.I1850Clm50SpG.derecho_intel.cism-noevolve BASELINE /glade/derecho/scratch/sacks/aux_glc_240301164745/baselines: DIFF
```

(The NCK test fails on master, too.) I confirmed that the diffs are as expected.

Note that, for this testing, I cherry-picked the changes on this CMEPS branch onto `cmeps0.14.43`, which is the version currently used in CISM-wrapper master.