### PR TITLE
remove  ESMF_GridCompGetInternalState from use statement, not working…

### DIFF
--- a/mediator/med_phases_aofluxes_mod.F90
+++ b/mediator/med_phases_aofluxes_mod.F90
@@ -1601,10 +1601,8 @@ end subroutine med_aofluxes_map_ogrid2xgrid_input
        if (chkerr(rc,__LINE__,u_FILE_u)) return
        call fldbun_getfldptr(fldbun_a, 'Sa_shum', aoflux_in%shum, xgrid=xgrid, rc=rc)
        if (chkerr(rc,__LINE__,u_FILE_u)) return
-       if (add_gusts) then
-          call fldbun_getfldptr(fldbun_a, 'Faxa_rainc', aoflux_in%rainc, xgrid=xgrid, rc=rc)
-          if (chkerr(rc,__LINE__,u_FILE_u)) return
-       end if
+       call fldbun_getfldptr(fldbun_a, 'Faxa_rainc', aoflux_in%rainc, xgrid=xgrid, rc=rc)
+       if (chkerr(rc,__LINE__,u_FILE_u)) return
     end if
 
     ! extra fields for ufs.frac.aoflux

--- a/mediator/med_phases_cdeps_mod.F90
+++ b/mediator/med_phases_cdeps_mod.F90
@@ -7,7 +7,6 @@ module med_phases_cdeps_mod
   use ESMF, only: ESMF_Field, ESMF_FieldGet
   use ESMF, only: ESMF_FieldBundleGet, ESMF_FieldBundleIsCreated
   use ESMF, only: ESMF_FieldBundleCreate
-  use ESMF, only: ESMF_GridCompGetInternalState
   use ESMF, only: ESMF_SUCCESS, ESMF_LOGMSG_INFO
 
   use med_internalstate_mod, only: InternalState

--- a/mediator/med_phases_cdeps_mod.F90
+++ b/mediator/med_phases_cdeps_mod.F90
@@ -179,12 +179,12 @@ contains
                       ! Fill file abd variable lists with data
                       do l = 1, sdat_config%stream(streamid)%nfiles
                          fileList(l) = trim(sdat_config%stream(streamid)%file(l)%name) 
-                         if (maintask) write(logunit,'(a,i2,x,a)') trim(subname)//": file     ", l, trim(fileList(l))
+                         if (maintask) write(logunit,'(a,i2,2x,a)') trim(subname)//": file     ", l, trim(fileList(l))
                       end do
                       do l = 1, sdat_config%stream(streamid)%nvars
                          varList(l,1) = trim(sdat_config%stream(streamid)%varlist(l)%nameinfile)
                          varList(l,2) = trim(sdat_config%stream(streamid)%varlist(l)%nameinmodel)
-                         if (maintask) write(logunit,'(a,i2,x,a)') trim(subname)//": variable ", l, trim(varList(l,1))//" -> "//trim(varList(l,2))
+                         if (maintask) write(logunit,'(a,i2,2x,a)') trim(subname)//": variable ", l, trim(varList(l,1))//" -> "//trim(varList(l,2))
                       end do
 
                       ! Set PIO related variables


### PR DESCRIPTION
… with nag and apparently not needed

### Description of changes
Remove the use ESMF_GridCompGetInternalState it is not needed and fails for the nag compiler.  

### Specific notes

Contributors other than yourself, if any:

CMEPS Issues Fixed (include github issue #):

Are changes expected to change answers? (specify if bfb, different at roundoff, more substantial) 

Any User Interface Changes (namelist or namelist defaults changes)?

### Testing performed
Please describe the tests along with the target model and machine(s) 
If possible, please also added hashes that were used in the testing

