### PR TITLE
move control of this variable to cam

### DIFF
--- a/cime_config/buildnml
+++ b/cime_config/buildnml
@@ -106,7 +106,6 @@ def _create_drv_namelists(case, infile, confdir, nmlgen, files):
     config["COMP_OCN"] = case.get_value("COMP_OCN")
     config["COMP_ROF"] = case.get_value("COMP_ROF")
     config["COMP_WAV"] = case.get_value("COMP_WAV")
-    config["CAMDEV"] = "True" if "CAM%DEV" in case.get_value("COMPSET") else "False"
     
     if (
         (
@@ -145,11 +144,6 @@ def _create_drv_namelists(case, infile, confdir, nmlgen, files):
     # set aquaplanet if appropriate
     if config["COMP_OCN"] == "docn" and "aqua" in case.get_value("DOCN_MODE"):
         nmlgen.set_value("aqua_planet", value=".true.")
-
-    # make sure that variable add_gusts is only set to true if compset includes cam_dev
-    add_gusts = literal_to_python_value(nmlgen.get_value("add_gusts"), type_="logical")
-    if add_gusts:
-        expect("CAM%DEV" in case.get_value("COMPSET"),"ERROR: add_gusts can only be set if CAM%DEV in compset {}".format(case.get_value("COMPSET")))
             
     # --------------------------------
     # Overwrite: set component coupling frequencies

--- a/cime_config/namelist_definition_drv.xml
+++ b/cime_config/namelist_definition_drv.xml
@@ -946,19 +946,6 @@
     </values>
   </entry>
 
-  <entry id="add_gusts">
-    <type>logical</type>
-    <category>control</category>
-    <group>MED_attributes</group>
-    <desc>
-      add a wind gustiness factor
-    </desc>
-    <values>
-      <value CAMDEV="True">.true.</value>
-      <value CAMDEV="False">.false.</value>
-    </values>
-  </entry>
-
   <entry id="do_budgets" modify_via_xml="BUDGETS">
     <type>logical</type>
     <category>budget</category>

--- a/cime_config/namelist_definition_drv_flds.xml
+++ b/cime_config/namelist_definition_drv_flds.xml
@@ -170,4 +170,18 @@
     </desc>
   </entry>
 
+  <!-- ========================================================================================  -->
+  <!-- Gusts                                                                                     -->
+  <!-- ========================================================================================  -->
+
+  <entry id="add_gusts">
+    <type>logical</type>
+    <category>control</category>
+    <group>wind_gusts_nl</group>
+    <valid_values>.true.,.false.</valid_values>
+    <desc>
+      add a wind gustiness factor
+    </desc>
+  </entry>
+  
 </entry_id>

--- a/cime_config/namelist_definition_drv_flds.xml
+++ b/cime_config/namelist_definition_drv_flds.xml
@@ -178,7 +178,6 @@
     <type>logical</type>
     <category>control</category>
     <group>wind_gusts_nl</group>
-    <valid_values>.true.,.false.</valid_values>
     <desc>
       add a wind gustiness factor
     </desc>


### PR DESCRIPTION
### Description of changes
moves variable add_gusts from  namelist_definition_drv.xml  to namelist_definition_drv_flds.xml so that cam controls the settings. 

### Specific notes

Contributors other than yourself, if any:

CMEPS Issues Fixed (include github issue #):

Are changes expected to change answers? (specify if bfb, different at roundoff, more substantial) 

Any User Interface Changes (namelist or namelist defaults changes)?

### Testing performed
Please describe the tests along with the target model and machine(s) 
If possible, please also added hashes that were used in the testing

