### PR TITLE
Add ability to obtain multi level input from ocn and map and pass it back to cism

### DIFF
--- a/.github/workflows/extbuild.yml
+++ b/.github/workflows/extbuild.yml
@@ -73,8 +73,8 @@ jobs:
         id: cache-cdeps
         uses: actions/cache@v4
         with:
-          path: cdeps-src
-          key: ${{ runner.os }}-${{ env.CDEPS_VERSION }}.cdeps
+          path: /homme/runner/work/CMEPS/CMEPS/build-cdeps
+          key: ${{ runner.os }}-${{ env.CDEPS_VERSION }}.cdeps1
           
       - name: checkout CDEPS
         uses: actions/checkout@v4

--- a/.github/workflows/extbuild.yml
+++ b/.github/workflows/extbuild.yml
@@ -24,7 +24,7 @@ jobs:
       PNETCDF_VERSION: checkpoint.1.12.3
       NETCDF_FORTRAN_VERSION: v4.6.1
       PIO_VERSION: pio2_6_2
-      CDEPS_VERSION: cdeps1.0.35
+      CDEPS_VERSION: cdeps1.0.36
     steps:
       - uses: actions/checkout@v4
         # Build the ESMF library, if the cache contains a previous build
@@ -99,6 +99,7 @@ jobs:
       - name: Build CMEPS
         run: |
           export PIO=$HOME/pio
+          export ESMFMKFILE=$HOME/ESMF/lib/libg/Linux.gfortran.64.openmpi.default/esmf.mk
           mkdir build-cmeps
           pushd build-cmeps
           cmake -DCMAKE_BUILD_TYPE=DEBUG -DCMAKE_Fortran_FLAGS="-g -Wall -Werror -ffree-form -ffree-line-length-none  -Wno-unused-dummy-argument -I /home/runner/work/CMEPS/CMEPS/build-cdeps/share" ../

--- a/.github/workflows/extbuild.yml
+++ b/.github/workflows/extbuild.yml
@@ -73,7 +73,7 @@ jobs:
         id: cache-cdeps
         uses: actions/cache@v4
         with:
-          path: $HOME/cdeps
+          path: cdeps-src
           key: ${{ runner.os }}-${{ env.CDEPS_VERSION }}.cdeps
           
       - name: checkout CDEPS
@@ -82,6 +82,10 @@ jobs:
           repository: ESCOMP/CDEPS
           path: cdeps-src
           ref: ${{ env.CDEPS_VERSION }}
+      - name: get genf90
+        run: |
+          cd cdeps-src
+          git submodule update --init 
       - name: Build CDEPS
         if: steps.cache-cdeps.outputs.cache-hit != 'true'
         uses: ESCOMP/CDEPS/.github/actions/buildcdeps@cdeps1.0.26

--- a/.github/workflows/extbuild.yml
+++ b/.github/workflows/extbuild.yml
@@ -89,7 +89,7 @@ jobs:
           esmfmkfile: $HOME/ESMF/lib/libg/Linux.gfortran.64.openmpi.default/esmf.mk
           pio_path: $HOME/pio
           src_root: ${GITHUB_WORKSPACE}/cdeps-src
-          cmake_flags: " -Wno-dev -DDISABLE_FOX=ON -DCMAKE_BUILD_TYPE=DEBUG -DWERROR=ON  -DCMAKE_Fortran_FLAGS=\"-DCPRGNU -g -Wall \
+          cmake_flags: " -Wno-dev -DDISABLE_FoX=ON -DCMAKE_BUILD_TYPE=DEBUG -DWERROR=ON  -DCMAKE_Fortran_FLAGS=\"-DCPRGNU -g -Wall \
           -ffree-form -ffree-line-length-none -fallow-argument-mismatch \""
       
       - name: Build CMEPS

--- a/.github/workflows/extbuild.yml
+++ b/.github/workflows/extbuild.yml
@@ -89,12 +89,11 @@ jobs:
           esmfmkfile: $HOME/ESMF/lib/libg/Linux.gfortran.64.openmpi.default/esmf.mk
           pio_path: $HOME/pio
           src_root: ${GITHUB_WORKSPACE}/cdeps-src
-          cmake_flags: " -Wno-dev -DCMAKE_BUILD_TYPE=DEBUG -DWERROR=ON  -DCMAKE_Fortran_FLAGS=\"-DCPRGNU -g -Wall \
+          cmake_flags: " -Wno-dev -DDISABLE_FOX=ON -DCMAKE_BUILD_TYPE=DEBUG -DWERROR=ON  -DCMAKE_Fortran_FLAGS=\"-DCPRGNU -g -Wall \
           -ffree-form -ffree-line-length-none -fallow-argument-mismatch \""
       
       - name: Build CMEPS
         run: |
-          export ESMFMKFILE=$HOME/ESMF/lib/libg/Linux.gfortran.64.openmpi.default/esmf.mk
           export PIO=$HOME/pio
           mkdir build-cmeps
           pushd build-cmeps

--- a/.github/workflows/extbuild.yml
+++ b/.github/workflows/extbuild.yml
@@ -20,13 +20,13 @@ jobs:
       CPPFLAGS: "-I/usr/include -I/usr/local/include"
 
       # Versions of all dependencies can be updated here
-      ESMF_VERSION: v8.6.0
+      ESMF_VERSION: v8.6.1
       PNETCDF_VERSION: checkpoint.1.12.3
       NETCDF_FORTRAN_VERSION: v4.6.1
       PIO_VERSION: pio2_6_2
-      CDEPS_VERSION: cdeps1.0.26
+      CDEPS_VERSION: cdeps1.0.35
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         # Build the ESMF library, if the cache contains a previous build
         # it will be used instead
       - id: load-env
@@ -40,13 +40,13 @@ jobs:
           sudo apt-get install pnetcdf-bin libpnetcdf-dev
           sudo apt-get install autotools-dev autoconf
       - id: cache-esmf
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~/ESMF
           key: ${{ runner.os }}-${{ env.ESMF_VERSION }}-ESMF
       - name: Cache ParallelIO
         id: cache-ParallelIO
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~/pio
           key: ${{ runner.os }}-${{ env.PIO_VERSION }}.pio
@@ -71,13 +71,13 @@ jobs:
           parallelio_path: $HOME/pio
       - name: Cache CDEPS
         id: cache-cdeps
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: $HOME/cdeps
           key: ${{ runner.os }}-${{ env.CDEPS_VERSION }}.cdeps
           
       - name: checkout CDEPS
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: ESCOMP/CDEPS
           path: cdeps-src

--- a/.github/workflows/srt.yml
+++ b/.github/workflows/srt.yml
@@ -120,7 +120,7 @@ jobs:
         id: cache-ParallelIO
         uses: actions/cache@v4
         with:
-          path: ~/pio
+          path: ${GITHUB_WORKSPACE}/pio
           key: ${{ runner.os }}-${{ env.PARALLELIO_VERSION }}.parallelio
       - name: Cache inputdata
         id: cache-inputdata
@@ -147,7 +147,7 @@ jobs:
         with:
           parallelio_version: ${{ env.ParallelIO_VERSION }}
           enable_fortran: True
-          install_prefix: /home/runner/pio
+          install_prefix: ${GITHUB_WORKSPACE}/pio
           
       - name: Install ESMF
         uses: esmf-org/install-esmf-action@v1
@@ -174,8 +174,8 @@ jobs:
           pushd $GITHUB_WORKSPACE/cesm/cime/CIME/tests
           export SRCROOT=$GITHUB_WORKSPACE/cesm/
           export CIME_TEST_PLATFORM=ubuntu-latest
-          export PIO_INCDIR=$HOME/pio/include
-          export PIO_LIBDIR=$HOME/pio/lib
+          export PIO_INCDIR=$GITHUB_WORKSPACE/pio/include
+          export PIO_LIBDIR=$GITHUB_WORKSPACE/pio/lib
           export PIO_VERSION_MAJOR=2
           export PIO_TYPENAME_VALID_VALUES="netcdf,pnetcdf"
           export NETCDF_PATH=/usr

--- a/.github/workflows/srt.yml
+++ b/.github/workflows/srt.yml
@@ -181,7 +181,7 @@ jobs:
           export NETCDF_PATH=/usr
           export PNETCDF_PATH=/usr
           export LD_LIBRARY_PATH=/usr/lib/libx86_64-linux-gnu/:$LD_LIBRARY_PATH
-          export ESMFMKFILE=$HOME/ESMF/lib/libg/Linux.gfortran.64.openmpi.default/esmf.mk
+          export ESMFMKFILE=$GITHUB_WORKSPACE/ESMF/lib/libg/Linux.gfortran.64.openmpi.default/esmf.mk
           cat <<EOF >> $GITHUB_WORKSPACE/cesm/ccs_config/machines/cmake_macros/ubuntu-latest.cmake
           set(NetCDF_Fortran_INCLUDE_DIR /usr/include)
           set(NetCDF_Fortran_LIBRARY /usr/lib/x86_64-gnu-Linux/libnetcdff.so)

--- a/.github/workflows/srt.yml
+++ b/.github/workflows/srt.yml
@@ -26,7 +26,7 @@ jobs:
       CPPFLAGS: "-I/usr/include -I/usr/local/include "
       LDFLAGS: "-L/usr/lib/x86_64-linux-gnu -lnetcdf -lnetcdff -lpnetcdf"     
       # Versions of all dependencies can be updated here
-      ESMF_VERSION: v8.6.0
+      ESMF_VERSION: v8.6.1
       PARALLELIO_VERSION: pio2_6_2
       CIME_MODEL: cesm
       CIME_DRIVER: nuopc
@@ -64,13 +64,13 @@ jobs:
         run: pip install -r requirements.txt
       # use the latest cesm main
       - name: cesm checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: ESCOMP/CESM
           path: cesm
       # this cmeps commit
       - name: cmeps checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: cesm/components/cmeps
           
@@ -94,10 +94,11 @@ jobs:
           git submodule update --init
           cd ../components/cdeps
           git checkout main
+          git submodule update --init
           
       - name: Cache ESMF
         id: cache-esmf
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~/ESMF
           key: ${{ runner.os }}-${{ env.ESMF_VERSION }}-ESMF1
@@ -117,13 +118,13 @@ jobs:
 
       - name: Cache ParallelIO
         id: cache-ParallelIO
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~/pio
           key: ${{ runner.os }}-${{ env.PARALLELIO_VERSION }}.parallelio
       - name: Cache inputdata
         id: cache-inputdata
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: $HOME/cesm/inputdata
           key: inputdata
@@ -148,18 +149,22 @@ jobs:
           enable_fortran: True
           install_prefix: /home/runner/pio
           
-      - name: Build ESMF
-        if: steps.cache-esmf.outputs.cache-hit != 'true'
-        uses: ESCOMP/CDEPS/.github/actions/buildesmf@e06246b560d3132170bb1a5443fa3d65dfbd2040
+      - name: Install ESMF
+        uses: esmf-org/install-esmf-action@v1
+        env:
+          ESMF_COMPILER: gfortran
+          ESMF_BOPT: g
+          ESMF_COMM: openmpi
+          ESMF_NETCDF: nc-config
+          ESMF_PNETCDF: pnetcdf-config
+          ESMF_INSTALL_PREFIX: ${GITHUB_WORKSPACE}/ESMF
+          ESMF_PIO: external
+          ESMF_PIO_INCLUDE: ${GITHUB_WORKSPACE}/pio/include
+          ESMF_PIO_LIBPATH: ${GITHUB_WORKSPACE}/pio/lib
         with:
-          esmf_version: ${{ env.ESMF_VERSION }}
-          esmf_bopt: g
-          esmf_comm: openmpi
-          install_prefix: ~/ESMF
-          netcdf_c_path: /usr
-          netcdf_fortran_path: /usr
-          pnetcdf_path: /usr
-          parallelio_path: ~/pio
+          version: ${{ env.ESMF_VERSION }}
+          esmpy: false
+          cache: true
 
 
       - name: PREP for scripts regression test
@@ -190,6 +195,6 @@ jobs:
           popd
 #     the following can be used by developers to login to the github server in case of errors
 #     see https://github.com/marketplace/actions/debugging-with-tmate for further details
-      - name: Setup tmate session
-        if: ${{ failure() }}
-        uses: mxschmitt/action-tmate@v3
+#      - name: Setup tmate session
+#        if: ${{ failure() }}
+#        uses: mxschmitt/action-tmate@v3

--- a/.github/workflows/srt.yml
+++ b/.github/workflows/srt.yml
@@ -101,20 +101,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/ESMF
-          key: ${{ runner.os }}-${{ env.ESMF_VERSION }}-ESMF1
-      # - name: cache pnetcdf
-      #   id: cache-pnetcdf
-      #   uses: actions/cache@v3
-      #   with:
-      #     path: ~/pnetcdf
-      #     key: ${{ runner.os }}-${{ env.PNETCDF_VERSION}}-pnetcdf
-
-      # - name: Cache netcdf-fortran
-      #   id: cache-netcdf-fortran
-      #   uses: actions/cache@v3
-      #   with:
-      #     path: ~/netcdf-fortran
-      #     key: ${{ runner.os }}-${{ env.NETCDF_FORTRAN_VERSION }}-netcdf-fortran
+          key: ${{ runner.os }}-${{ env.ESMF_VERSION }}
 
       - name: Cache ParallelIO
         id: cache-ParallelIO
@@ -122,25 +109,14 @@ jobs:
         with:
           path: ${GITHUB_WORKSPACE}/pio
           key: ${{ runner.os }}-${{ env.PARALLELIO_VERSION }}.parallelio
+
       - name: Cache inputdata
         id: cache-inputdata
         uses: actions/cache@v4
         with:
           path: $HOME/cesm/inputdata
           key: inputdata
-      # - name: Build PNetCDF
-      #   if: steps.cache-pnetcdf.outputs.cache-hit != 'true'
-      #   uses: ESCOMP/CDEPS/.github/actions/buildpnetcdf@e06246b560d3132170bb1a5443fa3d65dfbd2040
-      #   with:
-      #     pnetcdf_version: ${{ env.PNETCDF_VERSION }}
-      #     install_prefix: $HOME/pnetcdf
-      # - name: Build NetCDF Fortran
-      #   if: steps.cache-netcdf-fortran.outputs.cache-hit != 'true'
-      #   uses: ESCOMP/CDEPS/.github/actions/buildnetcdff@e06246b560d3132170bb1a5443fa3d65dfbd2040
-      #   with:
-      #     netcdf_fortran_version: ${{ env.NETCDF_FORTRAN_VERSION }}
-      #     install_prefix: $HOME/netcdf-fortran
-      #     netcdf_c_path: /usr
+
       - name: Build ParallelIO
         if: steps.cache-PARALLELIO.outputs.cache-hit != 'true'
         uses: NCAR/ParallelIO/.github/actions/parallelio_cmake@05173a6556ea8d80eb34e3881a5014ea8f4b7543
@@ -181,7 +157,6 @@ jobs:
           export NETCDF_PATH=/usr
           export PNETCDF_PATH=/usr
           export LD_LIBRARY_PATH=/usr/lib/libx86_64-linux-gnu/:$LD_LIBRARY_PATH
-          export ESMFMKFILE=$GITHUB_WORKSPACE/ESMF/lib/libg/Linux.gfortran.64.openmpi.default/esmf.mk
           cat <<EOF >> $GITHUB_WORKSPACE/cesm/ccs_config/machines/cmake_macros/ubuntu-latest.cmake
           set(NetCDF_Fortran_INCLUDE_DIR /usr/include)
           set(NetCDF_Fortran_LIBRARY /usr/lib/x86_64-gnu-Linux/libnetcdff.so)

--- a/cime_config/namelist_definition_drv.xml
+++ b/cime_config/namelist_definition_drv.xml
@@ -620,19 +620,6 @@
     </values>
   </entry>
 
-  <entry id="ocn2glc_levels">
-    <type>char</type>
-    <category>flds</category>
-    <group>ALLCOMP_attributes</group>
-    <desc>
-      if the ocean component sends fields at multiple ocean levels to the
-      land-ice component, these are the colon deliminted level indices
-    </desc>
-    <values>
-      <value>1:10:19:26:30:33:35</value>
-    </values>
-  </entry>
-
   <entry id="tfreeze_option" modify_via_xml="TFREEZE_SALTWATER_OPTION">
     <type>char</type>
     <category>control</category>

--- a/mediator/esmFldsExchange_cesm_mod.F90
+++ b/mediator/esmFldsExchange_cesm_mod.F90
@@ -3206,7 +3206,7 @@ contains
     !-----------------------------
     ! to glc: from ocn
     !-----------------------------
-    if (is_local%wrap%ocn2glc_coupling) then
+    if (ocn2glc_coupling) then
        if (phase == 'advertise') then
           call addfld_from(compocn, 'So_t_depth')
           call addfld_from(compocn, 'So_s_depth')

--- a/mediator/med_internalstate_mod.F90
+++ b/mediator/med_internalstate_mod.F90
@@ -477,7 +477,7 @@ contains
             isPresent=isPresent, isSet=isSet, rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
     if (isPresent .and. isSet) then
-       ! are multiple ocean depths for temperature and salinity sent from the ocn to glc?
+       ! multiple ocean depths for temperature and salinity sent from the ocn to glc
        read(cvalue,*) is_local%wrap%ocn2glc_coupling
     else
        is_local%wrap%ocn2glc_coupling = .false.

--- a/mediator/med_phases_post_ocn_mod.F90
+++ b/mediator/med_phases_post_ocn_mod.F90
@@ -83,6 +83,7 @@ contains
 
     ! Accumulate ocn input for glc if there is ocn->glc coupling
     if (is_local%wrap%ocn2glc_coupling) then
+       call ESMF_LogWrite(subname//' DEBUG: calling med_phases_prep_glc_accum_ocn', ESMF_LOGMSG_INFO)
        call med_phases_prep_glc_accum_ocn(gcomp, rc)
        if (ChkErr(rc,__LINE__,u_FILE_u)) return
     end if

--- a/mediator/med_phases_prep_glc_mod.F90
+++ b/mediator/med_phases_prep_glc_mod.F90
@@ -523,7 +523,7 @@ contains
     logical             :: isPresent, isSet
     logical             :: write_histaux_l2x1yrg
     character(len=*) , parameter   :: subname=' (med_phases_prep_glc) '
-    integer :: k,cnt
+
     !---------------------------------------
 
     call t_startf('MED:'//subname)
@@ -1255,7 +1255,7 @@ contains
     integer           , intent(out)           :: rc
 
     ! local variables
-    integer  :: no, ni, i, j
+    integer  :: no, ni
     real(ESMF_KIND_R8)  :: renorm
     !---------------------------------------------------------------
 

--- a/mediator/med_phases_prep_glc_mod.F90
+++ b/mediator/med_phases_prep_glc_mod.F90
@@ -45,8 +45,6 @@ module med_phases_prep_glc_mod
   use glc_elevclass_mod     , only : glc_get_fractional_icecov
   use perf_mod              , only : t_startf, t_stopf
 
-  use shr_sys_mod, only : shr_sys_abort
-
   implicit none
   private
 


### PR DESCRIPTION
### Description of changes
Add ability to obtain multi level input from ocn and map and pass it back to cism

### Specific notes
This PR also depends on the CDEPS https://github.com/ESCOMP/CDEPS/pull/280

Contributors other than yourself, if any: None

CMEPS Issues Fixed: None

Are changes expected to change answers? bfb 

Any User Interface Changes? None

### Testing performed
Verified that the running the  aux_cdeps on derecho was bfb with cdeps1.0.30
Verified that the following case generated the appropriate input for CISM 
```bash
 ./create_newcase --case /glade/u/home/mvertens/run/test_cism_docn_multi2 --compset 2000_DATM%GSWP3v1_CLM50%SP_SICE_DOCN%MULTILEV_MOSART_CISM2%AIS-EVOLVE%GRIS-EVOLVE_SWAV --project nn9039k -res a%1.9x2.5_l%1.9x2.5_oi%tnx1v4_r%null_g%ais8:gris4_w%nu
ll_z%null_m%tnx1v4 --run-unsupported
```
- with the caveat that the user_nl_cpl contained the following entries:
```
ocn2glc_coupling = .true.
histaux_l2x1yrg = .true.
```
To obtain the code base for this case on derecho:
```bash
> git clone https://github.com/mvertens/NorESM.git noresm2_5_alpha02_v2
> cd noresm2_5_alpha02_v2
> git checkout feature/noresm2_5_alpha02_v2
> ./manage_externals/checkout_externals -v
```

