### PR TITLE
renames ww3dev to ww3

### DIFF
--- a/cime_config/buildnml
+++ b/cime_config/buildnml
@@ -127,7 +127,7 @@ def _create_drv_namelists(case, infile, confdir, nmlgen, files):
     elif case.get_value("RUN_TYPE") == "branch":
         config["run_type"] = "branch"
 
-    config['wav_ice_coupling'] = config['COMP_WAV'] == 'ww3dev' and config['COMP_ICE'] == 'cice'
+    config['wav_ice_coupling'] = 'ww3' in config['COMP_WAV'] and config['COMP_ICE'] == 'cice'
 
     # ----------------------------------------------------
     # Initialize namelist defaults


### PR DESCRIPTION
### Description of changes
One line change so that ww3dev can be renamed ww3 

### Specific notes

Contributors other than yourself, if any:

CMEPS Issues Fixed (include github issue #):

Are changes expected to change answers? (specify if bfb, different at roundoff, more substantial) 

Any User Interface Changes (namelist or namelist defaults changes)?

### Testing performed
Please describe the tests along with the target model and machine(s) 
If possible, please also added hashes that were used in the testing

