### PR TITLE
avoid integer overflow by skipping mediator in restart loop

### DIFF
--- a/mediator/med.F90
+++ b/mediator/med.F90
@@ -2122,7 +2122,7 @@ contains
        do n1 = 1,ncomps
           if (maintask) then
              write(logunit,*)
-             write(logunit,'(a)') trim(subname)//" "//trim(compname(n1))
+             write(logunit,'(a,2L2)') trim(subname)//" "//trim(compname(n1)), is_local%wrap%comp_present(n1), ESMF_StateIsCreated(is_local%wrap%NStateImp(n1),rc=rc)
           end if
           if (is_local%wrap%comp_present(n1) .and. ESMF_StateIsCreated(is_local%wrap%NStateImp(n1),rc=rc)) then
              call State_GetScalar(scalar_value=real_nx, &
@@ -2150,12 +2150,14 @@ contains
              end if
              is_local%wrap%nx(n1) = nint(real_nx)
              is_local%wrap%ny(n1) = nint(real_ny)
+          endif
+          if (is_local%wrap%comp_present(n1)) then
              write(msgString,'(3i8)') is_local%wrap%nx(n1), is_local%wrap%ny(n1), is_local%wrap%ntile(n1)
              if (maintask) then
                 write(logunit,'(a)') 'global nx,ny,ntile sizes for '//trim(compname(n1))//":"//trim(msgString)
              end if
              call ESMF_LogWrite(trim(subname)//":"//trim(compname(n1))//":"//trim(msgString), ESMF_LOGMSG_INFO)
-          end if
+          endif
        end do
        if (maintask) write(logunit,*)
 

--- a/mediator/med_phases_restart_mod.F90
+++ b/mediator/med_phases_restart_mod.F90
@@ -342,13 +342,14 @@ contains
           call med_io_write(io_file, next_tod , 'curr_tod' , whead(m), wdata(m), rc=rc)
           if (ChkErr(rc,__LINE__,u_FILE_u)) return
 
-          do n = 1,ncomps
+          do n = 2,ncomps
              if (is_local%wrap%comp_present(n)) then
-                nx = is_local%wrap%nx(n)
-                ny = is_local%wrap%ny(n)
                 if (is_local%wrap%ntile(n) > 0) then
                    nx = is_local%wrap%ntile(n)*is_local%wrap%ny(n)*is_local%wrap%nx(n)
                    ny = 1
+                else
+                   nx = is_local%wrap%nx(n)
+                   ny = is_local%wrap%ny(n)
                 end if
                 ! Write import field bundles
                 if (ESMF_FieldBundleIsCreated(is_local%wrap%FBimp(n,n),rc=rc)) then


### PR DESCRIPTION
### Description of changes
This loop in med_phases_restart_mod.F90 was causing integer overflow because the med component should not be included.   This was only happening with the nag compiler in debug mode and would not normally be a problem since integer overflows are ignored (except by nag in debug mode) and the resulting values were never used.  

### Specific notes

Contributors other than yourself, if any:

CMEPS Issues Fixed (include github issue #):

Are changes expected to change answers? (specify if bfb, different at roundoff, more substantial) 

Any User Interface Changes (namelist or namelist defaults changes)?

### Testing performed
Please describe the tests along with the target model and machine(s) 
If possible, please also added hashes that were used in the testing

