### PR TITLE
Change CAM%DEV to CAM70 in buildnml

### DIFF
--- a/cime_config/buildnml
+++ b/cime_config/buildnml
@@ -106,7 +106,7 @@ def _create_drv_namelists(case, infile, confdir, nmlgen, files):
     config["COMP_OCN"] = case.get_value("COMP_OCN")
     config["COMP_ROF"] = case.get_value("COMP_ROF")
     config["COMP_WAV"] = case.get_value("COMP_WAV")
-    config["CAMDEV"] = "True" if "CAM%DEV" in case.get_value("COMPSET") else "False"
+    config["CAMDEV"] = "True" if "CAM70" in case.get_value("COMPSET") else "False"
     
     if (
         (
@@ -146,10 +146,10 @@ def _create_drv_namelists(case, infile, confdir, nmlgen, files):
     if config["COMP_OCN"] == "docn" and "aqua" in case.get_value("DOCN_MODE"):
         nmlgen.set_value("aqua_planet", value=".true.")
 
-    # make sure that variable add_gusts is only set to true if compset includes cam_dev
+    # make sure that variable add_gusts is only set to true if compset includes cam7 physics
     add_gusts = literal_to_python_value(nmlgen.get_value("add_gusts"), type_="logical")
     if add_gusts:
-        expect("CAM%DEV" in case.get_value("COMPSET"),"ERROR: add_gusts can only be set if CAM%DEV in compset {}".format(case.get_value("COMPSET")))
+        expect("CAM70" in case.get_value("COMPSET"),"ERROR: add_gusts can only be set if CAM70 in compset {}".format(case.get_value("COMPSET")))
             
     # --------------------------------
     # Overwrite: set component coupling frequencies


### PR DESCRIPTION
### Description of changes

Change `CAM%DEV` to `CAM70` in buildnml

### Specific notes

This change needs to be coordinated with the upcoming CAM tag which changes the physics package descriptor `cam_dev` to `cam7`.  Concurrently the compset token `CAM%DEV` is changing to `CAM70`.  The CMEPS buildnml script has a hardcoded `CAM%DEV` token which must be changed to `CAM70` for consistency.

