### PR TITLE
Implementation of glc->ocn coupling via going through mosart 

### DIFF
--- a/cime_config/config_component.xml
+++ b/cime_config/config_component.xml
@@ -1389,14 +1389,6 @@
     <desc>rof2lnd flux mapping file</desc>
   </entry>
 
-  <entry id="ROF2OCN_FMAPNAME">
-    <type>char</type>
-    <default_value>idmap</default_value>
-    <group>run_domain</group>
-    <file>env_run.xml</file>
-    <desc>rof2ocn flux mapping file</desc>
-  </entry>
-
   <entry id="ROF2OCN_LIQ_RMAPNAME">
     <type>char</type>
     <default_value>idmap</default_value>
@@ -1411,54 +1403,6 @@
     <group>run_domain</group>
     <file>env_run.xml</file>
     <desc>rof2ocn runoff mapping file</desc>
-  </entry>
-
-  <entry id="GLC2ICE_RMAPNAME">
-    <type>char</type>
-    <default_value>idmap</default_value>
-    <group>run_domain</group>
-    <file>env_run.xml</file>
-    <desc>glc2ice runoff mapping file</desc>
-  </entry>
-
-  <entry id="GLC2OCN_LIQ_RMAPNAME">
-    <type>char</type>
-    <default_value>idmap</default_value>
-    <group>run_domain</group>
-    <file>env_run.xml</file>
-    <desc>glc2ocn runoff mapping file for liquid runoff</desc>
-  </entry>
-
-  <entry id="GLC2OCN_ICE_RMAPNAME">
-    <type>char</type>
-    <default_value>idmap</default_value>
-    <group>run_domain</group>
-    <file>env_run.xml</file>
-    <desc>glc2ocn runoff mapping file for ice runoff</desc>
-  </entry>
-
-  <entry id="OCN2WAV_SMAPNAME">
-    <type>char</type>
-    <default_value>idmap</default_value>
-    <group>run_domain</group>
-    <file>env_run.xml</file>
-    <desc>ocn2wav state mapping file</desc>
-  </entry>
-
-  <entry id="ICE2WAV_SMAPNAME">
-    <type>char</type>
-    <default_value>idmap</default_value>
-    <group>run_domain</group>
-    <file>env_run.xml</file>
-    <desc>ice2wav state mapping file</desc>
-  </entry>
-
-  <entry id="WAV2OCN_SMAPNAME">
-    <type>char</type>
-    <default_value>idmap</default_value>
-    <group>run_domain</group>
-    <file>env_run.xml</file>
-    <desc>wav2ocn state mapping file</desc>
   </entry>
 
   <entry id="EPS_FRAC">

--- a/cime_config/namelist_definition_drv.xml
+++ b/cime_config/namelist_definition_drv.xml
@@ -2256,42 +2256,6 @@
     </values>
   </entry>
 
-  <entry id="glc2ocn_liq_rmapname"    modify_via_xml="GLC2OCN_LIQ_RMAPNAME">
-    <type>char</type>
-    <category>mapping</category>
-    <input_pathname>abs</input_pathname>
-    <group>MED_attributes</group>
-    <desc>
-      glc2ocn runoff mapping file for liquid runoff
-    </desc>
-    <values>
-      <value>$GLC2OCN_LIQ_RMAPNAME</value>
-    </values>
-  </entry>
-  <entry id="glc2ice_rmapname"    modify_via_xml="GLC2ICE_RMAPNAME">
-    <type>char</type>
-    <category>mapping</category>
-    <input_pathname>abs</input_pathname>
-    <group>MED_attributes</group>
-    <desc>
-      glc to ice runoff conservative mapping file
-    </desc>
-    <values>
-      <value>$GLC2ICE_RMAPNAME</value>
-    </values>
-  </entry>
-  <entry id="glc2ocn_ice_rmapname"    modify_via_xml="GLC2OCN_ICE_RMAPNAME">
-    <type>char</type>
-    <category>mapping</category>
-    <input_pathname>abs</input_pathname>
-    <group>MED_attributes</group>
-    <desc>
-      glc2ocn runoff mapping file for ice runoff
-    </desc>
-    <values>
-      <value>$GLC2OCN_ICE_RMAPNAME</value>
-    </values>
-  </entry>
   <entry id="rof2ocn_fmapname"    modify_via_xml="ROF2OCN_FMAPNAME">
     <type>char</type>
     <category>mapping</category>

--- a/cime_config/namelist_definition_drv.xml
+++ b/cime_config/namelist_definition_drv.xml
@@ -2256,18 +2256,6 @@
     </values>
   </entry>
 
-  <entry id="rof2ocn_fmapname"    modify_via_xml="ROF2OCN_FMAPNAME">
-    <type>char</type>
-    <category>mapping</category>
-    <input_pathname>abs</input_pathname>
-    <group>MED_attributes</group>
-    <desc>
-      runoff to ocn area overlap conservative mapping file
-    </desc>
-    <values>
-      <value>$ROF2OCN_FMAPNAME</value>
-    </values>
-  </entry>
   <entry id="rof2ocn_liq_rmapname"    modify_via_xml="ROF2OCN_LIQ_RMAPNAME">
     <type>char</type>
     <category>mapping</category>
@@ -2290,42 +2278,6 @@
     </desc>
     <values>
       <value>$ROF2OCN_ICE_RMAPNAME</value>
-    </values>
-  </entry>
-  <entry id="ocn2wav_smapname"    modify_via_xml="OCN2WAV_SMAPNAME">
-    <type>char</type>
-    <category>mapping</category>
-    <input_pathname>abs</input_pathname>
-    <group>MED_attributes</group>
-    <desc>
-      ocn to wav state mapping file for states
-    </desc>
-    <values>
-      <value>$OCN2WAV_SMAPNAME</value>
-    </values>
-  </entry>
-  <entry id="ice2wav_smapname"    modify_via_xml="ICE2WAV_SMAPNAME">
-    <type>char</type>
-    <category>mapping</category>
-    <input_pathname>abs</input_pathname>
-    <group>MED_attributes</group>
-    <desc>
-      ice to wav state mapping file for states
-    </desc>
-    <values>
-      <value>$ICE2WAV_SMAPNAME</value>
-    </values>
-  </entry>
-  <entry id="wav2ocn_smapname"    modify_via_xml="WAV2OCN_SMAPNAME">
-    <type>char</type>
-    <category>mapping</category>
-    <input_pathname>abs</input_pathname>
-    <group>MED_attributes</group>
-    <desc>
-      wav to ocn state mapping file for states
-    </desc>
-    <values>
-      <value>$WAV2OCN_SMAPNAME</value>
     </values>
   </entry>
 

--- a/mediator/esmFldsExchange_cesm_mod.F90
+++ b/mediator/esmFldsExchange_cesm_mod.F90
@@ -3037,30 +3037,44 @@ contains
     ! ---------------------------------------------------------------------
     ! to rof: liquid and ice from glc
     ! ---------------------------------------------------------------------
-    ! Note: we are assuming that the rof mesh has a mask of one everywhere
-    ! TODO: should the following have fractional mapping?
     do ns = 1, is_local%wrap%num_icesheets
-       if (fldchk(is_local%wrap%FBImp(compglc(ns), compglc(ns)), 'Fgrg_rofl' , rc=rc)) then
-          call addmap_from(compglc(ns), 'Fgrg_rofl', comprof, mapconsd, 'one' , 'unset')
-          ! Custom merge in med_phases_prep_rof
-       end if
-       if (fldchk(is_local%wrap%FBImp(compglc(ns), compglc(ns)), 'Fgrg_rofi' , rc=rc)) then
-          call addmap_from(compglc(ns), 'Fgrg_rofi', comprof, mapconsd, 'one', 'unset')
-          ! Custom merge in med_phases_prep_rof
+       if (phase == 'advertise') then
+          call addfld_from(compglc(ns), 'Fgrg_rofl')
+          call addfld_from(compglc(ns), 'Fgrg_rofi')
+          call addfld_to(comprof, 'Fgrg_rofl')
+          call addfld_to(comprof, 'Fgrg_rofi')
+       else
+          ! Note: we are assuming that the rof mesh has a mask of one everywhere
+          ! TODO: should the following have fractional mapping?
+          if (fldchk(is_local%wrap%FBImp(compglc(ns), compglc(ns)), 'Fgrg_rofl' , rc=rc)) then
+             call addmap_from(compglc(ns), 'Fgrg_rofl', comprof, mapconsd, 'one' , 'unset')
+             ! Custom merge in med_phases_prep_rof
+          end if
+          if (fldchk(is_local%wrap%FBImp(compglc(ns), compglc(ns)), 'Fgrg_rofi' , rc=rc)) then
+             call addmap_from(compglc(ns), 'Fgrg_rofi', comprof, mapconsd, 'one', 'unset')
+             ! Custom merge in med_phases_prep_rof
+          end if
        end if
     end do
 
     ! ---------------------------------------------------------------------
-    ! to rof: liquid and ice from glc
+    ! to rof: liquid and ice from glc water isoptopes
     ! ---------------------------------------------------------------------
     do ns = 1, is_local%wrap%num_icesheets
-       if (fldchk(is_local%wrap%FBImp(compglc(ns), compglc(ns)), 'Fgrg_rofl_wiso' , rc=rc)) then
-          call addmap_from(compglc(ns), 'Fgrg_rofl_wiso', comprof, mapconsd, 'one' , 'unset')
-          ! TODO: implement custom merge
-       end if
-       if (fldchk(is_local%wrap%FBImp(compglc(ns), compglc(ns)), 'Fgrg_rofi_wiso' , rc=rc)) then
-          call addmap_from(compglc(ns), 'Fgrg_rofi_wiso', comprof, mapconsd, 'one', 'unset')
-          ! TODO: implement custom merge
+       if (phase == 'advertise') then
+          call addfld_from(compglc(ns), 'Fgrg_rofl_wiso')
+          call addfld_from(compglc(ns), 'Fgrg_rofi_wiso')
+          call addfld_to(comprof, 'Fgrg_rofl_wiso')
+          call addfld_to(comprof, 'Fgrg_rofi_wiso')
+       else
+          if (fldchk(is_local%wrap%FBImp(compglc(ns), compglc(ns)), 'Fgrg_rofl_wiso' , rc=rc)) then
+             call addmap_from(compglc(ns), 'Fgrg_rofl_wiso', comprof, mapconsd, 'one' , 'unset')
+             ! TODO: implement custom merge
+          end if
+          if (fldchk(is_local%wrap%FBImp(compglc(ns), compglc(ns)), 'Fgrg_rofi_wiso' , rc=rc)) then
+             call addmap_from(compglc(ns), 'Fgrg_rofi_wiso', comprof, mapconsd, 'one', 'unset')
+             ! TODO: implement custom merge
+          end if
        end if
     end do
 

--- a/mediator/esmFldsExchange_cesm_mod.F90
+++ b/mediator/esmFldsExchange_cesm_mod.F90
@@ -74,16 +74,16 @@ module esmFldsExchange_cesm_mod
   character(len=CX)   :: atm2ice_map  = 'unset'
   character(len=CX)   :: atm2ocn_map  = 'unset'
   character(len=CX)   :: atm2lnd_map  = 'unset'
+  character(len=CX)   :: atm2wav_map  = 'unset'
   character(len=CX)   :: ice2atm_map  = 'unset'
-  character(len=CX)   :: ocn2atm_map  = 'unset'
+  character(len=CX)   :: ice2wav_smap = 'unset'
   character(len=CX)   :: lnd2atm_map  = 'unset'
   character(len=CX)   :: lnd2rof_map  = 'unset'
-  character(len=CX)   :: rof2lnd_map  = 'unset'
-  character(len=CX)   :: atm2wav_map  = 'unset'
-  character(len=CX)   :: wav2ocn_smap = 'unset'
-  character(len=CX)   :: ice2wav_smap = 'unset'
+  character(len=CX)   :: ocn2atm_map  = 'unset'
   character(len=CX)   :: ocn2wav_smap = 'unset'
+  character(len=CX)   :: rof2lnd_map  = 'unset'
   character(len=CX)   :: rof2ocn_fmap = 'unset'
+  character(len=CX)   :: wav2ocn_smap = 'unset'
 
   logical             :: mapuv_with_cart3d              ! Map U/V vector wind fields from ATM to OCN/ICE by rotating in Cartesian 3D space and then back
   logical             :: flds_i2o_per_cat               ! Ice thickness category fields passed to OCN

--- a/mediator/esmFldsExchange_cesm_mod.F90
+++ b/mediator/esmFldsExchange_cesm_mod.F90
@@ -18,7 +18,7 @@ module esmFldsExchange_cesm_mod
   ! index        : destination component index that merging will occur to
   ! fldname      : field name in mediator export field bundle for destination component
   ! mrg_from     : source component index that will contribute to the merge
-  ! mrg_field    : field name fom source component field bundle that will be used in merge
+  ! mrg_fld      : field name fom source component field bundle that will be used in merge
   ! mrg_type     : one of ['copy', 'copy_with_weights', 'sum', 'sum_with_weights', 'merge']
   ! mrg_fracname : if mrg_type is copy_with_weights or merge -
   !                fraction name in fraction field bundle to use in merge
@@ -135,6 +135,7 @@ contains
     character(len=CL)   :: ice_mesh_name
     character(len=CL)   :: ocn_mesh_name
     character(len=CL)   :: cvalue
+    character(len=CS)   :: mrgfld_source
     logical             :: wav_coupling_to_cice
     logical             :: ocn2glc_coupling
     character(len=*) , parameter   :: subname=' (esmFldsExchange_cesm) '
@@ -2233,93 +2234,73 @@ contains
        call addfld_to(compocn, 'Forr_rofi_glc')
        call addfld_to(compocn, 'Flrr_flood')
     else
-       if ( fldchk(is_local%wrap%FBExp(compocn), 'Foxx_rofl' , rc=rc)) then
-          ! liquid from river and possibly flood from river to ocean
-          if (fldchk(is_local%wrap%FBImp(comprof, comprof), 'Forr_rofl' , rc=rc)) then
-             if (trim(rof2ocn_liq_rmap) == 'unset') then
-                call addmap_from(comprof, 'Forr_rofl', compocn, mapconsd, 'one', 'unset')
-             else
-                call addmap_from(comprof, 'Forr_rofl', compocn, map_rof2ocn_liq, 'none', rof2ocn_liq_rmap)
-             end if
-             if (fldchk(is_local%wrap%FBImp(comprof, comprof), 'Flrr_flood', rc=rc)) then
-                call addmap_from(comprof, 'Flrr_flood', compocn, mapconsd, 'one', rof2ocn_map)
-                call addmrg_to(compocn, 'Foxx_rofl', mrg_from=comprof, mrg_fld='Forr_rofl:Flrr_flood', mrg_type='sum')
-             else
-                call addmrg_to(compocn, 'Foxx_rofl', mrg_from=comprof, mrg_fld='Forr_rofl', mrg_type='sum')
-             end if
+      ! Liquid runoff from land and glc - mapping
+      if (fldchk(is_local%wrap%FBImp(comprof, comprof), 'Forr_rofl' , rc=rc)) then
+        if ( fldchk(is_local%wrap%FBExp(compocn), 'Foxx_rofl' , rc=rc)) then
+          if (trim(rof2ocn_liq_rmap) == 'unset') then
+            call addmap_from(comprof, 'Forr_rofl', compocn, mapconsd, 'one', 'unset')
+          else
+            call addmap_from(comprof, 'Forr_rofl', compocn, map_rof2ocn_liq, 'none', rof2ocn_liq_rmap)
           end if
-       end if
-       if ( fldchk(is_local%wrap%FBExp(compocn), 'Foxx_rofi' , rc=rc)) then
-          ! ice from river to ocean
-          if (fldchk(is_local%wrap%FBImp(comprof, comprof), 'Forr_rofi' , rc=rc)) then
-             if (trim(rof2ocn_ice_rmap) == 'unset') then
-                call addmap_from(comprof, 'Forr_rofi', compocn, mapconsd, 'one', 'unset')
-             else
-                call addmap_from(comprof, 'Forr_rofi', compocn, map_rof2ocn_ice, 'none', rof2ocn_ice_rmap)
-             end if
-             call addmrg_to(compocn, 'Foxx_rofi', mrg_from=comprof, mrg_fld='Forr_rofi', mrg_type='sum')
+        end if
+      end if
+      if (fldchk(is_local%wrap%FBImp(comprof, comprof), 'Flrr_flood', rc=rc)) then
+        if ( fldchk(is_local%wrap%FBExp(compocn), 'Foxx_rofl' , rc=rc)) then
+          call addmap_from(comprof, 'Flrr_flood', compocn, mapconsd, 'one', rof2ocn_map)
+        end if
+      end if
+      if ( fldchk(is_local%wrap%FBImp(comprof, comprof), 'Forr_rofl_glc', rc=rc)) then
+        if (fldchk(is_local%wrap%FBExp(compocn), 'Forr_rofl_glc', rc=rc) .or. &
+            fldchk(is_local%wrap%FBExp(compocn), 'Foxx_rofl', rc=rc)) then
+          if (trim(rof2ocn_liq_rmap) == 'unset') then
+            call addmap_from(comprof, 'Forr_rofl_glc', compocn, mapconsd, 'one', 'unset')
+          else
+            call addmap_from(comprof, 'Forr_rofl_glc', compocn, map_rof2ocn_liq, 'none', rof2ocn_liq_rmap)
           end if
-       end if
+        end if
+      end if
 
-       if ( fldchk(is_local%wrap%FBExp(compocn), 'Forr_rofl_glc' , rc=rc) .and. &
-            fldchk(is_local%wrap%FBImp(comprof, comprof), 'Forr_rofl_glc', rc=rc)) then
-         if (trim(rof2ocn_liq_rmap) == 'unset') then
-           call addmap_from(comprof, 'Forr_rofl_glc', compocn, mapconsd, 'one', 'unset')
-         else
-           call addmap_from(comprof, 'Forr_rofl_glc', compocn, map_rof2ocn_liq, 'none', rof2ocn_liq_rmap)
-         end if
-         call addmrg_to(compocn, 'Foxx_rofl_glc', mrg_from=comprof, mrg_fld='Forr_rofl_glc', mrg_type='copy')
-       end if
+      ! Liquid runoff from land and glc - merging
+      if ( fldchk(is_local%wrap%FBExp(compocn), 'Foxx_rofl' , rc=rc)) then
+        mrgfld_source = 'Forr_rofl'
+        if (fldchk(is_local%wrap%FBImp(comprof, comprof), 'Flrr_flood', rc=rc)) then
+          mrgfld_source = trim(mrgfld_source) //':Flrr_flood'
+        end if
+        if (fldchk(is_local%wrap%FBImp(comprof, comprof), 'Forr_rofl_glc', rc=rc)) then
+          mrgfld_source = trim(mrgfld_source) //':Forr_rofl_glc'
+        end if
+        call addmrg_to(compocn, 'Foxx_rofl', mrg_from=comprof, mrg_fld=trim(mrgfld_source), mrg_type='sum')
+      end if
 
-       if ( fldchk(is_local%wrap%FBExp(compocn), 'Forr_rofi_glc' , rc=rc) .and. &
-            fldchk(is_local%wrap%FBImp(comprof, comprof), 'Forr_rofi_glc', rc=rc)) then
-         if (trim(rof2ocn_ice_rmap) == 'unset') then
-           call addmap_from(comprof, 'Forr_rofi_glc', compocn, mapconsd, 'one', 'unset')
-         else
-           call addmap_from(comprof, 'Forr_rofo_glc', compocn, map_rof2ocn_liq, 'none', rof2ocn_liq_rmap)
-         end if
-         call addmrg_to(compocn, 'Foxx_rofl_glc', mrg_from=comprof, mrg_fld='Forr_rofi_glc', mrg_type='copy')
-       end if
-    end if
+      ! Frozen runoff from land and glc - mapping
+      if (fldchk(is_local%wrap%FBImp(comprof, comprof), 'Forr_rofi' , rc=rc)) then
+        if ( fldchk(is_local%wrap%FBExp(compocn), 'Foxx_rofi' , rc=rc)) then
+          if (trim(rof2ocn_ice_rmap) == 'unset') then
+            call addmap_from(comprof, 'Forr_rofi', compocn, mapconsd, 'one', 'unset')
+          else
+            call addmap_from(comprof, 'Forr_rofi', compocn, map_rof2ocn_ice, 'none', rof2ocn_ice_rmap)
+          end if
+        end if
+      end if
+      if ( fldchk(is_local%wrap%FBImp(comprof, comprof), 'Forr_rofi_glc', rc=rc)) then
+        if (fldchk(is_local%wrap%FBExp(compocn), 'Forr_rofi_glc', rc=rc) .or. &
+            fldchk(is_local%wrap%FBExp(compocn), 'Foxx_rofi', rc=rc)) then
+          if (trim(rof2ocn_ice_rmap) == 'unset') then
+            call addmap_from(comprof, 'Forr_rofi_glc', compocn, mapconsd, 'one', 'unset')
+          else
+            call addmap_from(comprof, 'Forr_rofi_glc', compocn, map_rof2ocn_ice, 'none', rof2ocn_ice_rmap)
+          end if
+        end if
+      end if
 
-    if (flds_wiso) then
-       if (phase == 'advertise') then
-          call addfld_from(comprof, 'Forr_rofl_wiso')
-          call addfld_from(comprof, 'Forr_rofi_wiso')
-          call addfld_to(compocn, 'Foxx_rofl_wiso')
-          call addfld_to(compocn, 'Foxx_rofi_wiso')
-          call addfld_to(compocn, 'Flrr_flood_wiso')
-       else
-          if ( fldchk(is_local%wrap%FBExp(compocn), 'Foxx_rofl_wiso' , rc=rc)) then
-             ! liquid from river and possibly flood from river to ocean
-             if (fldchk(is_local%wrap%FBImp(comprof, comprof), 'Forr_rofl_wiso' , rc=rc)) then
-                if (trim(rof2ocn_liq_rmap) == 'unset') then
-                   call addmap_from(comprof, 'Forr_rofl_wiso', compocn, mapconsd, 'none', 'unset')
-                else
-                   call addmap_from(comprof, 'Forr_rofl_wiso', compocn, map_rof2ocn_liq, 'none', rof2ocn_liq_rmap)
-                end if
-                if (fldchk(is_local%wrap%FBImp(comprof, comprof), 'Flrr_flood_wiso', rc=rc)) then
-                   call addmap_from(comprof, 'Flrr_flood_wiso', compocn, mapconsd, 'one', rof2ocn_map)
-                   call addmrg_to(compocn, 'Foxx_rofl_wiso', &
-                        mrg_from=comprof, mrg_fld='Forr_rofl:Flrr_flood', mrg_type='sum')
-                else
-                   call addmrg_to(compocn, 'Foxx_rofl_wiso', &
-                        mrg_from=comprof, mrg_fld='Forr_rofl', mrg_type='sum')
-                end if
-             end if
-          end if
-          if ( fldchk(is_local%wrap%FBExp(compocn), 'Foxx_rofi_wiso' , rc=rc)) then
-             ! ice from river to ocean
-             if (fldchk(is_local%wrap%FBImp(comprof, comprof), 'Forr_rofi_wiso' , rc=rc)) then
-                if (trim(rof2ocn_ice_rmap) == 'unset') then
-                   call addmap_from(comprof, 'Forr_rofi_wiso', compocn, mapconsd, 'none', 'unset')
-                else
-                   call addmap_from(comprof, 'Forr_rofi_wiso', compocn, map_rof2ocn_ice, 'none', rof2ocn_ice_rmap)
-                end if
-                call addmrg_to(compocn, 'Foxx_rofi_wiso', mrg_from=comprof, mrg_fld='Forr_rofi', mrg_type='sum')
-             end if
-          end if
-       end if
+      ! Frozen runoff from land and glc - merging
+      if ( fldchk(is_local%wrap%FBExp(compocn), 'Foxx_rofi' , rc=rc)) then
+        mrgfld_source = 'Forr_rofi'
+        if (fldchk(is_local%wrap%FBImp(comprof, comprof), 'Forr_rofi_glc', rc=rc)) then
+          mrgfld_source = trim(mrgfld_source) //':Forr_rofi_glc'
+        end if
+        call addmrg_to(compocn, 'Foxx_rofi', mrg_from=comprof, mrg_fld=trim(mrgfld_source), mrg_type='sum')
+      end if
     end if
 
     !-----------------------------

--- a/mediator/esmFldsExchange_cesm_mod.F90
+++ b/mediator/esmFldsExchange_cesm_mod.F90
@@ -29,8 +29,6 @@ module esmFldsExchange_cesm_mod
 
   ! currently required mapping files
   character(len=CX)   :: glc2ice_rmap     ='unset'
-  character(len=CX)   :: glc2ocn_liq_rmap ='unset'
-  character(len=CX)   :: glc2ocn_ice_rmap ='unset'
   character(len=CX)   :: rof2ocn_fmap     ='unset'
   character(len=CX)   :: rof2ocn_ice_rmap ='unset'
   character(len=CX)   :: rof2ocn_liq_rmap ='unset'
@@ -76,7 +74,7 @@ contains
     use med_internalstate_mod , only : compice, comprof, compwav, compglc, ncomps
     use med_internalstate_mod , only : mapbilnr, mapconsf, mapconsd, mappatch, mappatch_uv3d, mapbilnr_nstod
     use med_internalstate_mod , only : mapfcopy, mapnstod, mapnstod_consd, mapnstod_consf
-    use med_internalstate_mod , only : map_glc2ocn_ice, map_glc2ocn_liq, map_rof2ocn_ice, map_rof2ocn_liq
+    use med_internalstate_mod , only : map_rof2ocn_ice, map_rof2ocn_liq
     use esmFlds               , only : addfld_ocnalb => med_fldList_addfld_ocnalb
     use esmFlds               , only : addfld_aoflux => med_fldList_addfld_aoflux
     use esmFlds               , only : addmap_aoflux => med_fldList_addmap_aoflux
@@ -152,20 +150,12 @@ contains
        call NUOPC_CompAttributeGet(gcomp, name='atm2ocn_map', value=atm2ocn_map,  rc=rc)
        if (chkerr(rc,__LINE__,u_FILE_u)) return
        if (maintask) write(logunit, '(a)') trim(subname)//'atm2ocn_map = '// trim(atm2ocn_map)
-       call NUOPC_CompAttributeGet(gcomp, name='glc2ocn_liq_rmapname', value=glc2ocn_liq_rmap,  rc=rc)
-       if (chkerr(rc,__LINE__,u_FILE_u)) return
-       if (maintask) write(logunit, '(a)') trim(subname)//'glc2ocn_liq_rmapname = '// trim(glc2ocn_liq_rmap)
-       call NUOPC_CompAttributeGet(gcomp, name='glc2ocn_ice_rmapname', value=glc2ocn_ice_rmap,  rc=rc)
-       if (chkerr(rc,__LINE__,u_FILE_u)) return
-       if (maintask) write(logunit, '(a)') trim(subname)//'glc2ocn_ice_rmapname = '// trim(glc2ocn_ice_rmap)
        call NUOPC_CompAttributeGet(gcomp, name='wav2ocn_smapname', value=wav2ocn_smap,  rc=rc)
        if (chkerr(rc,__LINE__,u_FILE_u)) return
        if (maintask) write(logunit, '(a)') trim(subname)//'wav2ocn_smapname = '// trim(wav2ocn_smap)
-
        call NUOPC_CompAttributeGet(gcomp, name='rof2ocn_fmapname', value=rof2ocn_fmap,  rc=rc)
        if (chkerr(rc,__LINE__,u_FILE_u)) return
        if (maintask) write(logunit, '(a)') trim(subname)//'rof2ocn_fmapname = '// trim(rof2ocn_fmap)
-
        call NUOPC_CompAttributeGet(gcomp, name='rof2ocn_liq_rmapname', value=rof2ocn_liq_rmap,  rc=rc)
        if (chkerr(rc,__LINE__,u_FILE_u)) return
        if (maintask) write(logunit, '(a)') trim(subname)//'rof2ocn_liq_rmapname = '// trim(rof2ocn_liq_rmap)
@@ -2187,7 +2177,7 @@ contains
     end if
 
     !-----------------------------
-    ! to ocn: liquid runoff from rof and glc components
+    ! to ocn: liquid runoff from rof components
     ! to ocn: frozen runoff flux from rof and glc components
     ! to ocn: waterflux back to ocn due to flooding from rof
     !-----------------------------
@@ -2196,15 +2186,9 @@ contains
        ! Note that Flrr_flood below needs to be added to
        ! fldlistFr(comprof) in order to be mapped correctly but the ocean
        ! does not receive it so it is advertised but it will! not be connected
-       do ns = 1, is_local%wrap%num_icesheets
-          call addfld_from(compglc(ns), 'Fogg_rofl')
-       end do
        call addfld_from(comprof, 'Forr_rofl')
        call addfld_to(compocn, 'Foxx_rofl')
        call addfld_to(compocn, 'Flrr_flood')
-       do ns = 1, is_local%wrap%num_icesheets
-          call addfld_from(compglc(ns), 'Fogg_rofi')
-       end do
        call addfld_from(comprof, 'Forr_rofi')
        call addfld_to(compocn, 'Foxx_rofi')
     else
@@ -2223,14 +2207,6 @@ contains
                 call addmrg_to(compocn, 'Foxx_rofl', mrg_from=comprof, mrg_fld='Forr_rofl', mrg_type='sum')
              end if
           end if
-          ! liquid from glc to ocean
-          do ns = 1, is_local%wrap%num_icesheets
-             if (fldchk(is_local%wrap%FBImp(compglc(ns), compglc(ns)), 'Fogg_rofl' , rc=rc)) then
-                ! TODO: this custom map needs to be different for every ice sheet - how will this be handled?
-                call addmap_from(compglc(ns), 'Fogg_rofl', compocn, map_glc2ocn_liq, 'one' , glc2ocn_liq_rmap)
-                call addmrg_to(compocn, 'Foxx_rofl', mrg_from=compglc(ns), mrg_fld='Fogg_rofl', mrg_type='sum')
-             end if
-          end do
        end if
        if ( fldchk(is_local%wrap%FBExp(compocn), 'Foxx_rofi' , rc=rc)) then
           ! ice from river to ocean
@@ -2242,30 +2218,16 @@ contains
              end if
              call addmrg_to(compocn, 'Foxx_rofi', mrg_from=comprof, mrg_fld='Forr_rofi', mrg_type='sum')
           end if
-          ! ice from glc to ocean
-          do ns = 1, is_local%wrap%num_icesheets
-             if (fldchk(is_local%wrap%FBImp(compglc(ns), compglc(ns)), 'Fogg_rofi' , rc=rc)) then
-                ! TODO: this custom map needs to be different for every ice sheet - how will this be handled?
-                call addmap_from(compglc(ns), 'Fogg_rofi', compocn, map_glc2ocn_ice, 'one', glc2ocn_ice_rmap)
-                call addmrg_to(compocn, 'Foxx_rofi', mrg_from=compglc(ns), mrg_fld='Fogg_rofi', mrg_type='sum')
-             end if
-          end do
        end if
     end if
 
     if (flds_wiso) then
        if (phase == 'advertise') then
-          do ns = 1, is_local%wrap%num_icesheets
-             call addfld_from(compglc(ns), 'Fogg_rofl_wiso')
-          end do
           call addfld_from(comprof, 'Forr_rofl_wiso')
-          call addfld_to(compocn, 'Foxx_rofl_wiso')
-          call addfld_to(compocn, 'Flrr_flood_wiso')
-          do ns = 1, is_local%wrap%num_icesheets
-             call addfld_from(compglc(ns), 'Fogg_rofi_wiso')
-          end do
           call addfld_from(comprof, 'Forr_rofi_wiso')
+          call addfld_to(compocn, 'Foxx_rofl_wiso')
           call addfld_to(compocn, 'Foxx_rofi_wiso')
+          call addfld_to(compocn, 'Flrr_flood_wiso')
        else
           if ( fldchk(is_local%wrap%FBExp(compocn), 'Foxx_rofl_wiso' , rc=rc)) then
              ! liquid from river and possibly flood from river to ocean
@@ -2284,15 +2246,6 @@ contains
                         mrg_from=comprof, mrg_fld='Forr_rofl', mrg_type='sum')
                 end if
              end if
-             ! liquid from glc to ocean
-             do ns = 1, is_local%wrap%num_icesheets
-                if (fldchk(is_local%wrap%FBImp(compglc(ns), compglc(ns)), 'Fogg_rofl_wiso' , rc=rc)) then
-                   ! TODO: this custom map needs to be different for every ice sheet - how will this be handled?
-                   call addmap_from(compglc(ns), 'Fogg_rofl_wiso', compocn, map_glc2ocn_liq, 'one' , glc2ocn_liq_rmap)
-                   call addmrg_to(compocn, 'Foxx_rofl_wiso', &
-                        mrg_from=compglc(ns), mrg_fld='Fogg_rofl_wiso', mrg_type='sum')
-                end if
-             end do
           end if
           if ( fldchk(is_local%wrap%FBExp(compocn), 'Foxx_rofi_wiso' , rc=rc)) then
              ! ice from river to ocean
@@ -2304,15 +2257,6 @@ contains
                 end if
                 call addmrg_to(compocn, 'Foxx_rofi_wiso', mrg_from=comprof, mrg_fld='Forr_rofi', mrg_type='sum')
              end if
-             ! ice from glc to ocean
-             do ns = 1, is_local%wrap%num_icesheets
-                if (fldchk(is_local%wrap%FBImp(compglc(ns), compglc(ns)), 'Fogg_rofi_wiso' , rc=rc)) then
-                   ! TODO: this custom map needs to be different for every ice sheet - how will this be handled?
-                   call addmap_from(compglc(ns), 'Fogg_rofi_wiso', compocn, map_glc2ocn_ice, 'one', glc2ocn_ice_rmap)
-                   call addmrg_to(compocn, 'Foxx_rofi_wiso', &
-                        mrg_from=compglc(ns), mrg_fld='Fogg_rofi_wiso', mrg_type='sum')
-                end if
-             end do
           end if
        end if
     end if
@@ -3091,6 +3035,36 @@ contains
     !=====================================================================
 
     ! ---------------------------------------------------------------------
+    ! to rof: liquid and ice from glc
+    ! ---------------------------------------------------------------------
+    ! Note: we are assuming that the rof mesh has a mask of one everywhere
+    ! TODO: should the following have fractional mapping?
+    do ns = 1, is_local%wrap%num_icesheets
+       if (fldchk(is_local%wrap%FBImp(compglc(ns), compglc(ns)), 'Fgrg_rofl' , rc=rc)) then
+          call addmap_from(compglc(ns), 'Fgrg_rofl', comprof, mapconsd, 'one' , 'unset')
+          ! Custom merge in med_phases_prep_rof
+       end if
+       if (fldchk(is_local%wrap%FBImp(compglc(ns), compglc(ns)), 'Fgrg_rofi' , rc=rc)) then
+          call addmap_from(compglc(ns), 'Fgrg_rofi', comprof, mapconsd, 'one', 'unset')
+          ! Custom merge in med_phases_prep_rof
+       end if
+    end do
+
+    ! ---------------------------------------------------------------------
+    ! to rof: liquid and ice from glc
+    ! ---------------------------------------------------------------------
+    do ns = 1, is_local%wrap%num_icesheets
+       if (fldchk(is_local%wrap%FBImp(compglc(ns), compglc(ns)), 'Fgrg_rofl_wiso' , rc=rc)) then
+          call addmap_from(compglc(ns), 'Fgrg_rofl_wiso', comprof, mapconsd, 'one' , 'unset')
+          ! TODO: implement custom merge
+       end if
+       if (fldchk(is_local%wrap%FBImp(compglc(ns), compglc(ns)), 'Fgrg_rofi_wiso' , rc=rc)) then
+          call addmap_from(compglc(ns), 'Fgrg_rofi_wiso', comprof, mapconsd, 'one', 'unset')
+          ! TODO: implement custom merge
+       end if
+    end do
+
+    ! ---------------------------------------------------------------------
     ! to rof: water flux from land (liquid surface)
     ! ---------------------------------------------------------------------
     if (phase == 'advertise') then
@@ -3206,7 +3180,7 @@ contains
     !-----------------------------
     ! to glc: from ocn
     !-----------------------------
-    if (ocn2glc_coupling) then
+    if (is_local%wrap%ocn2glc_coupling) then
        if (phase == 'advertise') then
           call addfld_from(compocn, 'So_t_depth')
           call addfld_from(compocn, 'So_s_depth')

--- a/mediator/fd_cesm.yaml
+++ b/mediator/fd_cesm.yaml
@@ -585,6 +585,22 @@
      # Note that the fields sent from glc->med do NOT have elevation classes,
      # but the fields from med->lnd are broken into multiple elevation classes
      #
+     - standard_name: Fgrg_rofi
+       canonical_units: kg m-2 s-1
+       description: glc import tomed - glacier frozen_runoff_flux_to_ocean
+     #
+     - standard_name: Fgrg_rofi_wiso
+       canonical_units: kg m-2 s-1
+       description: glc import to med - glacier_frozen_runoff_flux_to_ocean for 16O, 18O, HDO
+     #
+     - standard_name: Fgrg_rofl
+       canonical_units: kg m-2 s-1
+       description: glc import to med - glacier liquid runoff flux to ocean
+     #
+     - standard_name: Fgrg_rofl_wiso
+       canonical_units: kg m-2 s-1
+       description: glc import to med - glacier_frozen_runoff_flux_to_ocean for 16O, 18O, HDO
+     #
      - standard_name: Figg_rofi
        canonical_units: kg m-2 s-1
        description: glc import to med - glc frozen runoff_iceberg flux to ice
@@ -634,22 +650,6 @@
      - standard_name: Sg_topo_elev
        canonical_units: m
        description: glc export from med (elevation classes 1->glc_nec)
-     #
-     - standard_name: Fogg_rofi
-       canonical_units: kg m-2 s-1
-       description: glc export from med - glacier_frozen_runoff_flux_to_ocean
-     #
-     - standard_name: Fogg_rofi_wiso
-       canonical_units: kg m-2 s-1
-       description: glc export from med - glacier_frozen_runoff_flux_to_ocean for 16O, 18O, HDO
-     #
-     - standard_name: Fogg_rofl
-       canonical_units: kg m-2 s-1
-       description: glc export from med - glacier liquid runoff flux to ocean
-     #
-     - standard_name: Fogg_rofl_wiso
-       canonical_units: kg m-2 s-1
-       description: glc export from med - glacier_frozen_runoff_flux_to_ocean for 16O, 18O, HDO
      #
      #-----------------------------------
      # section: ice import to med

--- a/mediator/fd_cesm.yaml
+++ b/mediator/fd_cesm.yaml
@@ -1172,6 +1172,10 @@
        canonical_units: kg m-2 s-1
        description: river export to ocean - water flux due to runoff (frozen)
      #
+     - standard_name: Forr_rofi_glc
+       canonical_units: kg m-2 s-1
+       description: river export to ocean - water flux due to runoff originating from glc (frozen)
+     #
      - standard_name: Forr_rofi_wiso
        canonical_units: kg m-2 s-1
        description: river import to med - water flux due to runoff (frozen) for 16O, 18O, HDO
@@ -1180,29 +1184,13 @@
        canonical_units: kg m-2 s-1
        description: river import to med - water flux due to runoff (liquid)
      #
+     - standard_name: Forr_rofl_glc
+       canonical_units: kg m-2 s-1
+       description: river import to med - water flux due to runoff originating from glc (liquid)
+     #
      - standard_name: Forr_rofl_wiso
        canonical_units: kg m-2 s-1
        description: river import to med - water flux due to runoff (frozen) for 16O, 18O, HDO
-     #
-     - standard_name: Firr_rofi
-       canonical_units: kg m-2 s-1
-       description: river export - water flux into sea ice due to runoff (frozen)
-     #
-     - standard_name: Firr_rofi_wiso
-       canonical_units: kg m-2 s-1
-       description: river export - water flux into sea ice due to runoff (frozen) for 16O, 18O, HDO
-     #
-     #-----------------------------------
-     # section: river export from med (computed in med)
-     #-----------------------------------
-     #
-     - standard_name: Fixx_rofi
-       canonical_units: kg m-2 s-1
-       description: frozen runoff to ice from river and lnd-ice
-     #
-     - standard_name: Fixx_rofi_wiso
-       canonical_units: kg m-2 s-1
-       description: frozen runoff to ice from river and lnd-ice for 16O, 18O, HDO
      #
      #-----------------------------------
      # section: wav import to med

--- a/mediator/med_diag_mod.F90
+++ b/mediator/med_diag_mod.F90
@@ -1352,9 +1352,9 @@ contains
 
     do ns = 1,is_local%wrap%num_icesheets
        areas => is_local%wrap%mesh_info(compglc(ns))%areas
-       call diag_glc(is_local%wrap%FBImp(compglc(ns),compglc(ns)), 'Fogg_rofl', f_watr_roff, ic, areas, budget_local, minus=.true., rc=rc)
+       call diag_glc(is_local%wrap%FBImp(compglc(ns),compglc(ns)), 'Fgrg_rofl', f_watr_roff, ic, areas, budget_local, minus=.true., rc=rc)
        if (ChkErr(rc,__LINE__,u_FILE_u)) return
-       call diag_glc(is_local%wrap%FBImp(compglc(ns),compglc(ns)), 'Fogg_rofi', f_watr_ioff, ic, areas, budget_local, minus=.true., rc=rc)
+       call diag_glc(is_local%wrap%FBImp(compglc(ns),compglc(ns)), 'Fgrg_rofi', f_watr_ioff, ic, areas, budget_local, minus=.true., rc=rc)
        if (ChkErr(rc,__LINE__,u_FILE_u)) return
        call diag_glc(is_local%wrap%FBImp(compglc(ns),compglc(ns)), 'Figg_rofi', f_watr_ioff, ic, areas, budget_local, minus=.true., rc=rc)
        if (ChkErr(rc,__LINE__,u_FILE_u)) return

--- a/mediator/med_diag_mod.F90
+++ b/mediator/med_diag_mod.F90
@@ -1197,8 +1197,15 @@ contains
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
     call diag_rof(is_local%wrap%FBImp(comprof,comprof), 'Forr_rofi' , f_watr_ioff, ic, areas, budget_local, minus=.true., rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
-    call diag_rof(is_local%wrap%FBImp(comprof,comprof), 'Firr_rofi' , f_watr_ioff, ic, areas, budget_local, minus=.true., rc=rc)
-    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+
+    if ( fldbun_fldchk(is_local%wrap%FBImp(comprof,comprof), 'Forr_rofl_glc', rc=rc)) then
+      call diag_rof(is_local%wrap%FBImp(comprof,comprof), 'Forr_rofi_glc' , f_watr_roff, ic, areas, budget_local, minus=.true., rc=rc)
+      if (ChkErr(rc,__LINE__,u_FILE_u)) return
+    end if
+    if ( fldbun_fldchk(is_local%wrap%FBImp(comprof,comprof), 'Forr_rofi_glc', rc=rc)) then
+      call diag_rof(is_local%wrap%FBImp(comprof,comprof), 'Forr_rofi_glc' , f_watr_ioff, ic, areas, budget_local, minus=.true., rc=rc)
+      if (ChkErr(rc,__LINE__,u_FILE_u)) return
+    end if
 
     if (flds_wiso) then
        call diag_rof_wiso(is_local%wrap%FBExp(comprof), 'Forr_flood_wiso', &
@@ -1231,6 +1238,14 @@ contains
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
     call diag_rof(is_local%wrap%FBExp(comprof), 'Flrl_rofi'  , f_watr_ioff, ic, areas, budget_local, rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
+    if (fldbun_fldchk(is_local%wrap%FBExp(comprof), 'Fgrg_rofl', rc=rc)) then
+      call diag_rof(is_local%wrap%FBExp(comprof), 'Fgrg_rofl'  , f_watr_roff, ic, areas, budget_local, rc=rc)
+      if (ChkErr(rc,__LINE__,u_FILE_u)) return
+    end if
+    if (fldbun_fldchk(is_local%wrap%FBExp(comprof), 'Fgrg_rofi', rc=rc)) then
+      call diag_rof(is_local%wrap%FBExp(comprof), 'Fgrg_rofi'  , f_watr_ioff, ic, areas, budget_local, rc=rc)
+      if (ChkErr(rc,__LINE__,u_FILE_u)) return
+    end if
 
     if (flds_wiso) then
        call diag_rof_wiso(is_local%wrap%FBExp(comprof), 'Flrl_rofl_wiso', &
@@ -1533,10 +1548,20 @@ contains
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
     call diag_ocn(is_local%wrap%FBExp(compocn), 'Faxa_snow' , f_watr_snow   , ic, areas, sfrac, budget_local, rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
+
     call diag_ocn(is_local%wrap%FBExp(compocn), 'Foxx_rofl' , f_watr_roff   , ic, areas, sfrac, budget_local, rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
     call diag_ocn(is_local%wrap%FBExp(compocn), 'Foxx_rofi' , f_watr_ioff   , ic, areas, sfrac, budget_local, rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
+
+    if ( fldbun_fldchk(is_local%wrap%FBExp(compocn), 'Forr_rofl_glc' , rc=rc)) then
+      call diag_ocn(is_local%wrap%FBExp(compocn), 'Forr_rofl_glc' , f_watr_roff   , ic, areas, sfrac, budget_local, rc=rc)
+      if (ChkErr(rc,__LINE__,u_FILE_u)) return
+    end if
+    if ( fldbun_fldchk(is_local%wrap%FBExp(compocn), 'Forr_rofi_glc' , rc=rc)) then
+      call diag_ocn(is_local%wrap%FBExp(compocn), 'Forr_rofi_glc' , f_watr_ioff   , ic, areas, sfrac, budget_local, rc=rc)
+      if (ChkErr(rc,__LINE__,u_FILE_u)) return
+    end if
 
     if (flds_wiso) then
        call diag_ocn_wiso(is_local%wrap%FBMed_aoflux_o, 'Faox_evap_wiso', &
@@ -1893,8 +1918,6 @@ contains
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
     call diag_ice_send(is_local%wrap%FBExp(compice), 'Faxa_snow', f_watr_snow, areas, lats, ifrac, budget_local, rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
-    call diag_ice_send(is_local%wrap%FBExp(compice), 'Fixx_rofi', f_watr_ioff, areas, lats, ifrac, budget_local, rc=rc)
-    if (ChkErr(rc,__LINE__,u_FILE_u)) return
 
     if ( fldbun_fldchk(is_local%wrap%FBExp(compice), 'Fioo_q', rc=rc)) then
        call fldbun_getdata1d(is_local%wrap%FBExp(compice), 'Fioo_q', data, rc=rc)
@@ -1913,14 +1936,12 @@ contains
 
     ic = c_inh_send
     budget_local(f_heat_latf,ic,ip) = -budget_local(f_watr_snow,ic,ip)*shr_const_latice
-    budget_local(f_heat_ioff,ic,ip) = -budget_local(f_watr_ioff,ic,ip)*shr_const_latice
     if (trim(budget_table_version) == 'v0') then
        budget_local(f_watr_frz ,ic,ip) =  budget_local(f_heat_frz ,ic,ip)*HFLXtoWFLX
     end if
 
     ic = c_ish_send
     budget_local(f_heat_latf,ic,ip) = -budget_local(f_watr_snow,ic,ip)*shr_const_latice
-    budget_local(f_heat_ioff,ic,ip) = -budget_local(f_watr_ioff,ic,ip)*shr_const_latice
     if (trim(budget_table_version) == 'v0') then
        budget_local(f_watr_frz ,ic,ip) =  budget_local(f_heat_frz ,ic,ip)*HFLXtoWFLX
     end if

--- a/mediator/med_internalstate_mod.F90
+++ b/mediator/med_internalstate_mod.F90
@@ -451,9 +451,6 @@ contains
     med_coupling_allowed(compice,compocn) = .true.
     med_coupling_allowed(comprof,compocn) = .true.
     med_coupling_allowed(compwav,compocn) = .true.
-    do ns = 1,is_local%wrap%num_icesheets
-       med_coupling_allowed(compglc(ns),compocn) = .true.
-    end do
 
     ! to ice
     med_coupling_allowed(compatm,compice) = .true.
@@ -466,6 +463,9 @@ contains
 
     ! to river
     med_coupling_allowed(complnd,comprof) = .true.
+    do ns = 1,is_local%wrap%num_icesheets
+       med_coupling_allowed(compglc(ns),comprof) = .true.
+    end do
 
     ! to wave
     med_coupling_allowed(compatm,compwav) = .true.

--- a/mediator/med_phases_post_glc_mod.F90
+++ b/mediator/med_phases_post_glc_mod.F90
@@ -154,6 +154,7 @@ contains
     !---------------------------------------
     ! glc->rof mapping
     !---------------------------------------
+
     if (glc2rof_coupling) then
        do ns = 1,is_local%wrap%num_icesheets
           if (is_local%wrap%med_coupling_active(compglc(ns),comprof)) then

--- a/mediator/med_phases_post_glc_mod.F90
+++ b/mediator/med_phases_post_glc_mod.F90
@@ -68,7 +68,7 @@ module med_phases_post_glc_mod
 
   logical :: cism_evolve = .false.
   logical :: glc2lnd_coupling = .false.
-  logical :: glc2ocn_coupling = .false.
+  logical :: glc2rof_coupling = .false.
   logical :: glc2ice_coupling = .false.
 
   character(*) , parameter :: u_FILE_u = &
@@ -120,8 +120,8 @@ contains
        end do
        ! determine if there will be any glc to ocn coupling
        do ns = 1,is_local%wrap%num_icesheets
-          if (is_local%wrap%med_coupling_active(compglc(ns),compocn)) then
-             glc2ocn_coupling = .true.
+          if (is_local%wrap%med_coupling_active(compglc(ns),comprof)) then
+             glc2rof_coupling = .true.
              exit
           end if
        end do
@@ -134,7 +134,7 @@ contains
        end do
        if (maintask) then
           write(logunit,'(a,L1)') trim(subname) // 'glc2lnd_coupling is ',glc2lnd_coupling
-          write(logunit,'(a,L1)') trim(subname) // 'glc2ocn_coupling is ',glc2ocn_coupling
+          write(logunit,'(a,L1)') trim(subname) // 'glc2rof_coupling is ',glc2rof_coupling
           write(logunit,'(a,L1)') trim(subname) // 'glc2ice_coupling is ',glc2ice_coupling
        end if
 
@@ -152,19 +152,18 @@ contains
     end if
 
     !---------------------------------------
-    ! glc->ocn mapping
-    ! merging with rof->ocn fields is done in med_phases_prep_ocn
+    ! glc->rof mapping
     !---------------------------------------
-    if (glc2ocn_coupling) then
+    if (glc2rof_coupling) then
        do ns = 1,is_local%wrap%num_icesheets
-          if (is_local%wrap%med_coupling_active(compglc(ns),compocn)) then
+          if (is_local%wrap%med_coupling_active(compglc(ns),comprof)) then
              call med_map_field_packed( &
                   FBSrc=is_local%wrap%FBImp(compglc(ns),compglc(ns)), &
-                  FBDst=is_local%wrap%FBImp(compglc(ns),compocn), &
+                  FBDst=is_local%wrap%FBImp(compglc(ns),comprof), &
                   FBFracSrc=is_local%wrap%FBFrac(compglc(ns)), &
-                  field_normOne=is_local%wrap%field_normOne(compglc(ns),compocn,:), &
-                  packed_data=is_local%wrap%packed_data(compglc(ns),compocn,:), &
-                  routehandles=is_local%wrap%RH(compglc(ns),compocn,:), rc=rc)
+                  field_normOne=is_local%wrap%field_normOne(compglc(ns),comprof,:), &
+                  packed_data=is_local%wrap%packed_data(compglc(ns),comprof,:), &
+                  routehandles=is_local%wrap%RH(compglc(ns),comprof,:), rc=rc)
              if (ChkErr(rc,__LINE__,u_FILE_u)) return
           end if
        end do

--- a/mediator/med_phases_prep_rof_mod.F90
+++ b/mediator/med_phases_prep_rof_mod.F90
@@ -61,7 +61,7 @@ module med_phases_prep_rof_mod
   type(ESMF_FieldBundle), public :: FBlndAccum2rof_l
   type(ESMF_FieldBundle), public :: FBlndAccum2rof_r
 
-  character(len=9) :: fldnames_fr_glc(2) = (/'Frgg_rofl', 'Frgg_rofi')
+  character(len=9) :: fldnames_fr_glc(2) = (/'Fgrg_rofl', 'Fgrg_rofi'/)
 
   character(*)    , parameter :: u_FILE_u = &
        __FILE__
@@ -386,13 +386,19 @@ contains
        if (is_local%wrap%med_coupling_active(compglc(ns),comprof)) then
           do nf = 1,size(fldnames_fr_glc)
              call fldbun_getdata1d(is_local%wrap%FBImp(compglc(ns),comprof), &
-                  trim(fldnames_fr_glc(nf)), dataptr_out, rc)
+                  trim(fldnames_fr_glc(nf)), dataptr_in, rc)
              call fldbun_getdata1d(is_local%wrap%FBExp(comprof), &
-                  trim(fldnames_fr_glc(nf)), dataptr_in , rc)
-             dataptr_out(:) = dataptr_in():
+                  trim(fldnames_fr_glc(nf)), dataptr_out , rc)
+             ! Determine export data
+             if (ns == 1) then
+                dataptr_out(:) = dataptr_in(:)
+             else
+                dataptr_out(:) = dataptr_out(:) + dataptr_in(:)
+             end if
           end do
        end if
     end do
+
 
     ! Check for nans in fields export to rof
     call FB_check_for_nans(is_local%wrap%FBExp(comprof), maintask, logunit, rc=rc)

--- a/mediator/med_phases_prep_rof_mod.F90
+++ b/mediator/med_phases_prep_rof_mod.F90
@@ -12,7 +12,7 @@ module med_phases_prep_rof_mod
 
   use med_kind_mod          , only : CX=>SHR_KIND_CX, CS=>SHR_KIND_CS, CL=>SHR_KIND_CL, R8=>SHR_KIND_R8
   use ESMF                  , only : ESMF_FieldBundle, ESMF_Field
-  use med_internalstate_mod , only : complnd, comprof, mapconsf, mapconsd, mapfcopy
+  use med_internalstate_mod , only : complnd, compglc, comprof, mapconsf, mapfcopy
   use med_internalstate_mod , only : InternalState, maintask, logunit
   use med_constants_mod     , only : dbug_flag        => med_constants_dbug_flag
   use med_constants_mod     , only : czero            => med_constants_czero
@@ -60,6 +60,8 @@ module med_phases_prep_rof_mod
   integer               , public :: lndAccum2rof_cnt
   type(ESMF_FieldBundle), public :: FBlndAccum2rof_l
   type(ESMF_FieldBundle), public :: FBlndAccum2rof_r
+
+  character(len=9) :: fldnames_fr_glc(2) = (/'Frgg_rofl', 'Frgg_rofi')
 
   character(*)    , parameter :: u_FILE_u = &
        __FILE__
@@ -276,11 +278,11 @@ contains
 
     ! local variables
     type(InternalState)       :: is_local
-    integer                   :: n
+    integer                   :: n,ns,nf
     integer                   :: count
     logical                   :: exists
-    real(r8), pointer         :: dataptr(:)
-    real(r8), pointer         :: dataptr1d(:)
+    real(r8), pointer         :: dataptr_in(:)
+    real(r8), pointer         :: dataptr_out(:)
     type(ESMF_Field)          :: lfield
     type(med_fldList_type), pointer :: fldList
     character(len=*),parameter  :: subname='(med_phases_prep_rof_mod: med_phases_prep_rof)'
@@ -319,12 +321,12 @@ contains
        if (exists) then
           call ESMF_FieldBundleGet(FBlndAccum2rof_l, fieldName=trim(lnd2rof_flds(n)), field=lfield, rc=rc)
           if (chkerr(rc,__LINE__,u_FILE_u)) return
-          call field_getdata1d(lfield, dataptr1d, rc=rc)
+          call field_getdata1d(lfield, dataptr_out, rc=rc)
           if (chkerr(rc,__LINE__,u_FILE_u)) return
           if (count == 0) then
-             dataptr1d(:) = czero
+             dataptr_out(:) = czero
           else
-             dataptr1d(:) = dataptr1d(:) / real(count, r8)
+             dataptr_out(:) = dataptr_out(:) / real(count, r8)
           end if
        end if
     end do
@@ -359,12 +361,12 @@ contains
        if (chkerr(rc,__LINE__,u_FILE_u)) return
     else
        ! This will ensure that no irrig is sent from the land
-       call fldbun_getdata1d(FBlndAccum2rof_r, irrig_flux_field, dataptr, rc)
-       dataptr(:) = czero
+       call fldbun_getdata1d(FBlndAccum2rof_r, irrig_flux_field, dataptr_out, rc)
+       dataptr_out(:) = czero
     end if
 
     !---------------------------------------
-    ! auto merges to create FBExp(comprof) - assumes that all data is coming from FBlndAccum2rof_r
+    ! create FBExp(comprof)
     !---------------------------------------
 
     if (dbug_flag > 1) then
@@ -373,9 +375,24 @@ contains
        if (chkerr(rc,__LINE__,u_FILE_u)) return
     end if
 
+    ! data coming from FBlndAccum2rof_r
     call med_merge_auto(compsrc=complnd, FBout=is_local%wrap%FBExp(comprof), &
          FBfrac=is_local%wrap%FBFrac(comprof), FBin=FBlndAccum2rof_r, fldListTo=fldList, rc=rc)
     if (chkerr(rc,__LINE__,u_FILE_u)) return
+
+    ! custom merge for glc->rof
+    ! glc->rof is mapped in med_phases_post_glc
+    do ns = 1,is_local%wrap%num_icesheets
+       if (is_local%wrap%med_coupling_active(compglc(ns),comprof)) then
+          do nf = 1,size(fldnames_fr_glc)
+             call fldbun_getdata1d(is_local%wrap%FBImp(compglc(ns),comprof), &
+                  trim(fldnames_fr_glc(nf)), dataptr_out, rc)
+             call fldbun_getdata1d(is_local%wrap%FBExp(comprof), &
+                  trim(fldnames_fr_glc(nf)), dataptr_in , rc)
+             dataptr_out(:) = dataptr_in():
+          end do
+       end if
+    end do
 
     ! Check for nans in fields export to rof
     call FB_check_for_nans(is_local%wrap%FBExp(comprof), maintask, logunit, rc=rc)
@@ -402,9 +419,9 @@ contains
        if (exists) then
           call ESMF_FieldBundleGet(FBlndAccum2rof_l, fieldName=trim(lnd2rof_flds(n)), field=lfield, rc=rc)
           if (chkerr(rc,__LINE__,u_FILE_u)) return
-          call field_getdata1d(lfield, dataptr1d, rc=rc)
+          call field_getdata1d(lfield, dataptr_out, rc=rc)
           if (chkerr(rc,__LINE__,u_FILE_u)) return
-          dataptr1d(:) = czero
+          dataptr_out(:) = czero
        end if
     end do
 


### PR DESCRIPTION
### Description of changes

### Specific notes
- This implements the GLC->OCN coupling by having GLC send the runoff ice and liquid fluxes to MOSART which are then routed directly to the outlet points and then mapped to the ocean using the nearest-neighbor plus smoothing custom files.
- The code to map from GLC->ICE has been removed since there is no current code to implement this at the current time.

Contributors other than yourself, if any: None

CMEPS Issues Fixed: None

Are changes expected to change answers?  Only for fully coupled compsets with active CISM and a greenland ice sheet, otherwise bfb

Any User Interface Changes? The following namelist variables and associated xml variables have been removed
ocn2glc_levels, glc2ocn_liq_rmapname, glc2ocn_ice_rmapname
GLC2ICE_RMAPNAME, GLC2OCN_LIQ_RMAPNAME, GLC2OCN_ICE_RMAPNAME

The following xml variables have been removed from config_component.xml since the only allowed values are idmap or unset which are now set in the namelist_definition_drv.xml file
```xml
  <entry id="ROF2OCN_FMAPNAME">
  <entry id="GLC2ICE_RMAPNAME">
  <entry id="GLC2OCN_LIQ_RMAPNAME">
  <entry id="GLC2OCN_ICE_RMAPNAME">
  <entry id="OCN2WAV_SMAPNAME">
  <entry id="ICE2WAV_SMAPNAME">
  <entry id="WAV2OCN_SMAPNAME">
```

### Testing performed
Using cesm2_3_beta17 checkout with the following changes:
- cmeps
  - branch = feature/cism2mosart
  - repo_url = https://github.com/mvertens/CMEPS.git
- cism 
  - branch = feature/cism2mosart
  - repo_url = https://github.com/mvertens/CISM-wrapper
- mosart
  - branch = feature/cism2mosart
  - repo_url = https://github.com/mvertens/MOSART

Verified that the following was bfb with cesm2_3_beta17 baseline
SMS_Ld2.f09_t232.B1850MOM.derecho_intel.mom-bcompset
Verified that the following had answer changes with cesm2_3_beta17 baselines (as expected)
SMS_Ld5.f09_g17.B1850G.derecho_intel.allactive-cism-test_coupling

Note that the 