### PR TITLE
Revert "test github testing in cime PR #4631"

### DIFF
--- a/.github/workflows/srt.yml
+++ b/.github/workflows/srt.yml
@@ -91,9 +91,7 @@ jobs:
 
               sed -i".bak" "s/git@github.com:/https:\/\/github.com\//g" "${PWD}/.gitmodules"
           fi
-          git checkout fix-quiet-lockedfiles
           git submodule update --init
-
           cd ../components/cdeps
           git checkout main
           git submodule update --init


### PR DESCRIPTION
Reverts ESCOMP/CMEPS#464  This wasn't needed and should not have been merged.