### PR TITLE
Add trigrid capability - ability to run atm and lnd on separate grids

### DIFF
--- a/mediator/esmFldsExchange_cesm_mod.F90
+++ b/mediator/esmFldsExchange_cesm_mod.F90
@@ -20,7 +20,7 @@ module esmFldsExchange_cesm_mod
   !--------------------------------------
 
   use med_kind_mod          , only : CX=>SHR_KIND_CX, CS=>SHR_KIND_CS, CL=>SHR_KIND_CL, R8=>SHR_KIND_R8
-  use med_internalstate_mod , only : logunit, maintask
+  use med_internalstate_mod , only : logunit, maintask, samegrid_atmlnd
 
   implicit none
   public
@@ -45,7 +45,6 @@ module esmFldsExchange_cesm_mod
   character(len=CX)   :: ice2atm_map='unset'
   character(len=CX)   :: ocn2atm_map='unset'
   character(len=CX)   :: lnd2atm_map='unset'
-  character(len=CX)   :: lnd2rof_map='unset'
   character(len=CX)   :: rof2lnd_map='unset'
   character(len=CX)   :: atm2wav_map='unset'
 
@@ -56,8 +55,6 @@ module esmFldsExchange_cesm_mod
   logical             :: flds_co2c                      ! Pass CO2 from ATM to surface (OCN/LND) and back from them to ATM
   logical             :: flds_wiso                      ! Pass water isotop fields
   logical             :: flds_r2l_stream_channel_depths ! Pass channel depths from ROF to LND
-
-  logical             :: samegrid_al                    ! true=>atm and lnd are on the same grid
 
   character(*), parameter :: u_FILE_u = &
        __FILE__
@@ -178,11 +175,6 @@ contains
        if (chkerr(rc,__LINE__,u_FILE_u)) return
        if (maintask) write(logunit, '(a)') trim(subname)//'rof2ocn_ice_rmapname = '// trim(rof2ocn_ice_rmap)
 
-       ! mapping to rof
-       call NUOPC_CompAttributeGet(gcomp, name='lnd2rof_map', value=lnd2rof_map,  rc=rc)
-       if (chkerr(rc,__LINE__,u_FILE_u)) return
-       if (maintask) write(logunit, '(a)') trim(subname)//'lnd2rof_map = '// trim(lnd2rof_map)
-
        ! mapping to wav
        call NUOPC_CompAttributeGet(gcomp, name='atm2wav_map', value=atm2wav_map, rc=rc)
        if (chkerr(rc,__LINE__,u_FILE_u)) return
@@ -231,9 +223,9 @@ contains
        call NUOPC_CompAttributeGet(gcomp, name='ATM_DOMAIN_MESH', value=lnd_mesh, rc=rc)
        if (ChkErr(rc,__LINE__,u_FILE_u)) return
        if (trim(atm_mesh) == trim(lnd_mesh)) then
-          samegrid_al = .true.
+          samegrid_atmlnd = .true.
        else
-          samegrid_al = .false.
+          samegrid_atmlnd = .false.
        end if
 
        ! write diagnostic output
@@ -1169,7 +1161,7 @@ contains
        if (fldchk(is_local%wrap%FBexp(compatm), 'Faxx_taux', rc=rc)) then
           if ( fldchk(is_local%wrap%FBImp(complnd,complnd), 'Fall_taux', rc=rc)) then
              call addmap_from(complnd , 'Fall_taux', compatm, mapconsf, 'lfrin', lnd2atm_map)
-             if (samegrid_al) then
+             if (samegrid_atmlnd) then
                 mrg_fracname_lnd='lfrac'
              else
                 mrg_fracname_lnd='lfrin'
@@ -1201,7 +1193,7 @@ contains
        if (fldchk(is_local%wrap%FBexp(compatm), 'Faxx_tauy', rc=rc)) then
           if ( fldchk(is_local%wrap%FBImp(complnd,complnd), 'Fall_tauy', rc=rc)) then
              call addmap_from(complnd , 'Fall_tauy', compatm, mapconsf, 'lfrin', lnd2atm_map)
-             if (samegrid_al) then
+             if (samegrid_atmlnd) then
                 mrg_fracname_lnd='lfrac'
              else
                 mrg_fracname_lnd='lfrin'
@@ -1233,7 +1225,7 @@ contains
        if (fldchk(is_local%wrap%FBexp(compatm), 'Faxx_lat', rc=rc)) then
           if ( fldchk(is_local%wrap%FBImp(complnd,complnd), 'Fall_lat', rc=rc)) then
              call addmap_from(complnd , 'Fall_lat', compatm, mapconsf, 'lfrin', lnd2atm_map)
-             if (samegrid_al) then
+             if (samegrid_atmlnd) then
                 mrg_fracname_lnd='lfrac'
              else
                 mrg_fracname_lnd='lfrin'
@@ -1265,7 +1257,7 @@ contains
        if (fldchk(is_local%wrap%FBexp(compatm), 'Faxx_sen', rc=rc)) then
           if ( fldchk(is_local%wrap%FBImp(complnd,complnd), 'Fall_sen', rc=rc)) then
              call addmap_from(complnd , 'Fall_sen', compatm, mapconsf, 'lfrin', lnd2atm_map)
-             if (samegrid_al) then
+             if (samegrid_atmlnd) then
                 mrg_fracname_lnd='lfrac'
              else
                 mrg_fracname_lnd='lfrin'
@@ -1297,7 +1289,7 @@ contains
        if (fldchk(is_local%wrap%FBexp(compatm), 'Faxx_evap', rc=rc)) then
           if ( fldchk(is_local%wrap%FBImp(complnd,complnd), 'Fall_evap', rc=rc)) then
              call addmap_from(complnd , 'Fall_evap', compatm, mapconsf, 'lfrin', lnd2atm_map)
-             if (samegrid_al) then
+             if (samegrid_atmlnd) then
                 mrg_fracname_lnd='lfrac'
              else
                 mrg_fracname_lnd='lfrin'
@@ -1329,7 +1321,7 @@ contains
        if (fldchk(is_local%wrap%FBexp(compatm), 'Faxx_lwup', rc=rc)) then
           if ( fldchk(is_local%wrap%FBImp(complnd,complnd), 'Fall_lwup', rc=rc)) then
              call addmap_from(complnd , 'Fall_lwup', compatm, mapconsf, 'lfrin', lnd2atm_map)
-             if (samegrid_al) then
+             if (samegrid_atmlnd) then
                 mrg_fracname_lnd='lfrac'
              else
                 mrg_fracname_lnd='lfrin'
@@ -1362,7 +1354,7 @@ contains
           if (fldchk(is_local%wrap%FBexp(compatm), 'Faxx_evap_wiso', rc=rc)) then
              if ( fldchk(is_local%wrap%FBImp(complnd,complnd), 'Fall_evap_wiso', rc=rc)) then
                 call addmap_from(complnd , 'Fall_evap_wiso', compatm, mapconsf, 'lfrin', lnd2atm_map)
-                if (samegrid_al) then
+                if (samegrid_atmlnd) then
                    mrg_fracname_lnd='lfrac'
                 else
                    mrg_fracname_lnd='lfrin'
@@ -1623,7 +1615,7 @@ contains
        if ( fldchk(is_local%wrap%FBImp(complnd, complnd), 'Fall_voc', rc=rc) .and. &
             fldchk(is_local%wrap%FBExp(compatm)         , 'Fall_voc', rc=rc)) then
           call addmap_from(complnd, 'Fall_voc', compatm, mapconsf, 'one', atm2lnd_map)
-          if (samegrid_al) then
+          if (samegrid_atmlnd) then
              mrg_fracname_lnd='lfrac'
           else
              mrg_fracname_lnd='lfrin'
@@ -1644,7 +1636,7 @@ contains
        if ( fldchk(is_local%wrap%FBImp(complnd, complnd), 'Fall_fire', rc=rc) .and. &
             fldchk(is_local%wrap%FBExp(compatm)         , 'Fall_fire', rc=rc)) then
           call addmap_from(complnd, 'Fall_fire', compatm, mapconsf, 'one', lnd2atm_map)
-          if (samegrid_al) then
+          if (samegrid_atmlnd) then
              mrg_fracname_lnd='lfrac'
           else
              mrg_fracname_lnd='lfrin'
@@ -3165,8 +3157,8 @@ contains
     else
        if ( fldchk(is_local%wrap%FBImp(complnd, complnd), 'Flrl_rofsur', rc=rc) .and. &
             fldchk(is_local%wrap%FBExp(comprof)         , 'Flrl_rofsur', rc=rc)) then
-          call addmap_from(complnd, 'Flrl_rofsur', comprof, mapconsf, 'lfrin', lnd2rof_map)
-          if (samegrid_al) then
+          call addmap_from(complnd, 'Flrl_rofsur', comprof, mapconsf, 'lfrin', 'unset')
+          if (samegrid_atmlnd) then
              mrg_fracname_lnd = 'lfrac'
           else
              mrg_fracname_lnd = 'lfrin'
@@ -3185,8 +3177,8 @@ contains
     else
        if ( fldchk(is_local%wrap%FBImp(complnd, complnd), 'Flrl_rofi', rc=rc) .and. &
             fldchk(is_local%wrap%FBExp(comprof)         , 'Flrl_rofi', rc=rc)) then
-          call addmap_from(complnd, 'Flrl_rofi', comprof, mapconsf, 'lfrin', lnd2rof_map)
-          if (samegrid_al) then
+          call addmap_from(complnd, 'Flrl_rofi', comprof, mapconsf, 'lfrin', 'unset')
+          if (samegrid_atmlnd) then
              mrg_fracname_lnd = 'lfrac'
           else
              mrg_fracname_lnd = 'lfrin'
@@ -3205,8 +3197,8 @@ contains
     else
        if ( fldchk(is_local%wrap%FBImp(complnd, complnd), 'Flrl_rofgwl', rc=rc) .and. &
             fldchk(is_local%wrap%FBExp(comprof)         , 'Flrl_rofgwl', rc=rc)) then
-          call addmap_from(complnd, 'Flrl_rofgwl', comprof, mapconsf, 'lfrin', lnd2rof_map)
-          if (samegrid_al) then
+          call addmap_from(complnd, 'Flrl_rofgwl', comprof, mapconsf, 'lfrin', 'unset')
+          if (samegrid_atmlnd) then
              mrg_fracname_lnd = 'lfrac'
           else
              mrg_fracname_lnd = 'lfrin'
@@ -3225,8 +3217,8 @@ contains
     else
        if ( fldchk(is_local%wrap%FBImp(complnd, complnd), 'Flrl_rofsub', rc=rc) .and. &
             fldchk(is_local%wrap%FBExp(comprof)         , 'Flrl_rofsub', rc=rc)) then
-          call addmap_from(complnd, 'Flrl_rofsub', comprof, mapconsf, 'lfrac', lnd2rof_map)
-          if (samegrid_al) then
+          call addmap_from(complnd, 'Flrl_rofsub', comprof, mapconsf, 'lfrac', 'unset')
+          if (samegrid_atmlnd) then
              mrg_fracname_lnd = 'lfrac'
           else
              mrg_fracname_lnd = 'lfrin'
@@ -3245,8 +3237,8 @@ contains
     else
        if ( fldchk(is_local%wrap%FBImp(complnd, complnd), 'Flrl_irrig', rc=rc) .and. &
             fldchk(is_local%wrap%FBExp(comprof)         , 'Flrl_irrig', rc=rc)) then
-          call addmap_from(complnd, 'Flrl_irrig', comprof, mapconsf, 'lfrac', lnd2rof_map)
-          if (samegrid_al) then
+          call addmap_from(complnd, 'Flrl_irrig', comprof, mapconsf, 'lfrac', 'unset')
+          if (samegrid_atmlnd) then
              mrg_fracname_lnd = 'lfrac'
           else
              mrg_fracname_lnd = 'lfrin'

--- a/mediator/esmFldsExchange_cesm_mod.F90
+++ b/mediator/esmFldsExchange_cesm_mod.F90
@@ -1684,37 +1684,65 @@ contains
        call addfld_from(compocn, 'Faoo_fco2_ocn')
        call addfld_to(compatm, 'Faoo_fco2_ocn')
     else
-       if ( fldchk(is_local%wrap%FBImp(compocn,compocn), 'Faoo_co2_ocn', rc=rc) .and. &
-            fldchk(is_local%wrap%FBexp(compatm)        , 'Faoo_co2_ocn', rc=rc)) then
+       if ( fldchk(is_local%wrap%FBImp(compocn,compocn), 'Faoo_fco2_ocn', rc=rc) .and. &
+            fldchk(is_local%wrap%FBexp(compatm)        , 'Faoo_fco2_ocn', rc=rc)) then
           call addmap_from(compocn, 'Faoo_fco2_ocn', compatm, mapconsd, 'one', ocn2atm_map)
           ! custom merge in med_phases_prep_atm
        end if
     end if
 
     !-----------------------------------------------------------------------------
-    ! to atm: dms from ocean
+    ! to atm: surface flux of dms from ocean
     !-----------------------------------------------------------------------------
     if (phase == 'advertise') then
-       call addfld_from(compocn, 'Faoo_dms_ocn')
-       call addfld_to(compatm, 'Faoo_dms_ocn')
+       call addfld_from(compocn, 'Faoo_fdms_ocn')
+       call addfld_to(compatm, 'Faoo_fdms_ocn')
     else
-       if ( fldchk(is_local%wrap%FBImp(compocn,compocn), 'Faoo_dms_ocn', rc=rc) .and. &
-            fldchk(is_local%wrap%FBexp(compatm)        , 'Faoo_dms_ocn', rc=rc)) then
-          call addmap_from(compocn, 'Faoo_dms_ocn', compocn, mapconsd, 'one', ocn2atm_map)
+       if ( fldchk(is_local%wrap%FBImp(compocn,compocn), 'Faoo_fdms_ocn', rc=rc) .and. &
+            fldchk(is_local%wrap%FBexp(compatm)        , 'Faoo_fdms_ocn', rc=rc)) then
+          call addmap_from(compocn, 'Faoo_fdms_ocn', compocn, mapconsd, 'one', ocn2atm_map)
           ! custom merge in med_phases_prep_atm
        end if
     end if
 
     !-----------------------------------------------------------------------------
-    ! to atm: bromoform from ocean
+    ! to atm: surface flux of bromoform from ocean
     !-----------------------------------------------------------------------------
     if (phase == 'advertise') then
-       call addfld_from(compocn, 'Faoo_bromo_ocn')
-       call addfld_to(compatm, 'Faoo_bromo_ocn')
+       call addfld_from(compocn, 'Faoo_fbrf_ocn')
+       call addfld_to(compatm, 'Faoo_fbrf_ocn')
     else
-       if ( fldchk(is_local%wrap%FBImp(compocn,compocn), 'Faoo_bromo_ocn', rc=rc) .and. &
-            fldchk(is_local%wrap%FBexp(compatm)        , 'Faoo_bromo_ocn', rc=rc)) then
-          call addmap_from(compocn, 'Faoo_bromo_ocn', compocn, mapconsd, 'one', ocn2atm_map)
+       if ( fldchk(is_local%wrap%FBImp(compocn,compocn), 'Faoo_fbrf_ocn', rc=rc) .and. &
+            fldchk(is_local%wrap%FBexp(compatm)        , 'Faoo_fbrf_ocn', rc=rc)) then
+          call addmap_from(compocn, 'Faoo_fbrf_ocn', compocn, mapconsd, 'one', ocn2atm_map)
+          ! custom merge in med_phases_prep_atm
+       end if
+    end if
+
+    !-----------------------------------------------------------------------------
+    ! to atm: surface flux of n2o from ocean
+    !-----------------------------------------------------------------------------
+    if (phase == 'advertise') then
+       call addfld_from(compocn, 'Faoo_fn2o_ocn')
+       call addfld_to(compatm, 'Faoo_fn2o_ocn')
+    else
+       if ( fldchk(is_local%wrap%FBImp(compocn,compocn), 'Faoo_fn2o_ocn', rc=rc) .and. &
+            fldchk(is_local%wrap%FBexp(compatm)        , 'Faoo_fn2o_ocn', rc=rc)) then
+          call addmap_from(compocn, 'Faoo_fn2o_ocn', compocn, mapconsd, 'one', ocn2atm_map)
+          ! custom merge in med_phases_prep_atm
+       end if
+    end if
+
+    !-----------------------------------------------------------------------------
+    ! to atm: surface flux of nh3 from ocean
+    !-----------------------------------------------------------------------------
+    if (phase == 'advertise') then
+       call addfld_from(compocn, 'Faoo_fnh3_ocn')
+       call addfld_to(compatm, 'Faoo_fnh3_ocn')
+    else
+       if ( fldchk(is_local%wrap%FBImp(compocn,compocn), 'Faoo_fnh3_ocn', rc=rc) .and. &
+            fldchk(is_local%wrap%FBexp(compatm)        , 'Faoo_fnh3_ocn', rc=rc)) then
+          call addmap_from(compocn, 'Faoo_fnh3_ocn', compocn, mapconsd, 'one', ocn2atm_map)
           ! custom merge in med_phases_prep_atm
        end if
     end if

--- a/mediator/esmFldsExchange_cesm_mod.F90
+++ b/mediator/esmFldsExchange_cesm_mod.F90
@@ -1560,7 +1560,7 @@ contains
     else
        if ( fldchk(is_local%wrap%FBImp(complnd, complnd), 'Fall_voc', rc=rc) .and. &
             fldchk(is_local%wrap%FBExp(compatm)         , 'Fall_voc', rc=rc)) then
-          call addmap_from(complnd, 'Fall_voc', compatm, mapconsf, 'one', atm2lnd_map)
+          call addmap_from(complnd, 'Fall_voc', compatm, mapconsf, map_fracname_lnd2atm, atm2lnd_map)
           call addmrg_to(compatm, 'Fall_voc', &
                mrg_from=complnd, mrg_fld='Fall_voc', mrg_type='merge', mrg_fracname=mrg_fracname_lnd2atm_flux)
        end if
@@ -1577,7 +1577,7 @@ contains
        if ( fldchk(is_local%wrap%FBImp(complnd, complnd), 'Fall_fire', rc=rc) .and. &
             fldchk(is_local%wrap%FBExp(compatm)         , 'Fall_fire', rc=rc)) then
 
-          call addmap_from(complnd, 'Fall_fire', compatm, mapconsf, 'one', lnd2atm_map)
+          call addmap_from(complnd, 'Fall_fire', compatm, mapconsf, map_fracname_lnd2atm, lnd2atm_map)
           call addmrg_to(compatm, 'Fall_fire', &
                mrg_from=complnd, mrg_fld='Fall_fire', mrg_type='merge', mrg_fracname=mrg_fracname_lnd2atm_flux)
        end if
@@ -1589,7 +1589,7 @@ contains
     else
        if ( fldchk(is_local%wrap%FBImp(complnd, complnd), 'Sl_fztop', rc=rc) .and. &
             fldchk(is_local%wrap%FBExp(compatm)         , 'Sl_fztop', rc=rc)) then
-          call addmap_from(complnd, 'Sl_fztop', compatm, mapconsf, 'one', lnd2atm_map)
+          call addmap_from(complnd, 'Sl_fztop', compatm, mapconsf, map_fracname_lnd2atm, lnd2atm_map)
           call addmrg_to(compatm, 'Sl_fztop', mrg_from=complnd, mrg_fld='Sl_fztop', mrg_type='copy')
        end if
     end if
@@ -1603,7 +1603,7 @@ contains
     else
        if ( fldchk(is_local%wrap%FBImp(complnd, complnd), 'Sl_ddvel', rc=rc) .and. &
             fldchk(is_local%wrap%FBExp(compatm)         , 'Sl_ddvel', rc=rc)) then
-          call addmap_from(complnd, 'Sl_ddvel', compatm, mapconsf, 'one', lnd2atm_map)
+          call addmap_from(complnd, 'Sl_ddvel', compatm, mapconsf, map_fracname_lnd2atm, lnd2atm_map)
           call addmrg_to(compatm, 'Sl_ddvel', mrg_from=complnd, mrg_fld='Sl_ddvel', mrg_type='copy')
        end if
     end if

--- a/mediator/esmFldsExchange_cesm_mod.F90
+++ b/mediator/esmFldsExchange_cesm_mod.F90
@@ -233,6 +233,12 @@ contains
 
        ! write diagnostic output
        if (maintask) then
+          write(logunit,'(a)'   ) ' flds_co2a: prognostic and diagnostic CO2 at lowest atm level is sent to lnd and ocn'
+          write(logunit,'(a)'   ) ' flds_co2b: prognostic and diagnostic CO2 at lowest atm level is sent to lnd and ocn'
+          write(logunit,'(a)'   ) '            and surface flux of CO2 from lnd is sent back to atm'
+          write(logunit,'(a)'   ) ' flds_co2c: prognostic and diagnostic CO2 at lowest atm level is sent to lnd and ocn'
+          write(logunit,'(a)'   ) '            and surface flux of CO2 from lnd is sent back to atm'
+          write(logunit,'(a)'   ) '            and surface flux of CO2 from ocn is sent back to atm'
           write(logunit,'(a,l7)') trim(subname)//' flds_co2a                       = ',flds_co2a
           write(logunit,'(a,l7)') trim(subname)//' flds_co2b                       = ',flds_co2b
           write(logunit,'(a,l7)') trim(subname)//' flds_co2c                       = ',flds_co2c
@@ -1607,9 +1613,9 @@ contains
     else
        if ( fldchk(is_local%wrap%FBImp(complnd, complnd), 'Fall_voc', rc=rc) .and. &
             fldchk(is_local%wrap%FBExp(compatm)         , 'Fall_voc', rc=rc)) then
-          call addmap_from(complnd, 'Fall_voc', compatm, mapconsf, map_fracname_lnd2atm, lnd2atm_map
+          call addmap_from(complnd, 'Fall_voc', compatm, mapconsf, map_fracname_lnd2atm, lnd2atm_map)
           call addmrg_to(compatm, 'Fall_voc', &
-               mrg_from=complnd, mrg_fld='Fall_voc', mrg_type='merge', mrg_fracname=mrg_fracname_lnd2atm_flux)
+               mrg_from=complnd, mrg_fld='Fall_voc', mrg_type='copy_with_weights', mrg_fracname=mrg_fracname_lnd2atm_flux)
        end if
     end if
 
@@ -1625,7 +1631,7 @@ contains
             fldchk(is_local%wrap%FBExp(compatm)         , 'Fall_fire', rc=rc)) then
           call addmap_from(complnd, 'Fall_fire', compatm, mapconsf, 'lfrin', lnd2atm_map)
           call addmrg_to(compatm, 'Fall_fire', &
-               mrg_from=complnd, mrg_fld='Fall_fire', mrg_type='merge', mrg_fracname=mrg_fracname_lnd2atm_flux)
+               mrg_from=complnd, mrg_fld='Fall_fire', mrg_type='copy_with_weights', mrg_fracname=mrg_fracname_lnd2atm_flux)
        end if
     end if
     ! 'wild fire plume height'
@@ -1636,7 +1642,8 @@ contains
        if ( fldchk(is_local%wrap%FBImp(complnd, complnd), 'Sl_fztop', rc=rc) .and. &
             fldchk(is_local%wrap%FBExp(compatm)         , 'Sl_fztop', rc=rc)) then
           call addmap_from(complnd, 'Sl_fztop', compatm, mapconsf, map_fracname_lnd2atm, lnd2atm_map)
-          call addmrg_to(compatm, 'Sl_fztop', mrg_from=complnd, mrg_fld='Sl_fztop', mrg_type='copy')
+          call addmrg_to(compatm, 'Sl_fztop', &
+               mrg_from=complnd, mrg_fld='Sl_fztop', mrg_type='copy')
        end if
     end if
 

--- a/mediator/esmFldsExchange_cesm_mod.F90
+++ b/mediator/esmFldsExchange_cesm_mod.F90
@@ -57,6 +57,8 @@ module esmFldsExchange_cesm_mod
   logical             :: flds_wiso                      ! Pass water isotop fields
   logical             :: flds_r2l_stream_channel_depths ! Pass channel depths from ROF to LND
 
+  logical             :: samegrid_al                    ! true=>atm and lnd are on the same grid
+
   character(*), parameter :: u_FILE_u = &
        __FILE__
 
@@ -98,6 +100,9 @@ contains
     character(len=CL)   :: cvalue
     logical             :: wav_coupling_to_cice
     logical             :: ocn2glc_coupling
+    character(len=CL)   :: atm_mesh
+    character(len=CL)   :: lnd_mesh
+    character(len=CS)   :: mrg_fracname_lnd
     character(len=*) , parameter   :: subname=' (esmFldsExchange_cesm) '
     !--------------------------------------
 
@@ -219,6 +224,17 @@ contains
        call NUOPC_CompAttributeGet(gcomp, name='flds_r2l_stream_channel_depths', value=cvalue, rc=rc)
        if (ChkErr(rc,__LINE__,u_FILE_u)) return
        read(cvalue,*) flds_r2l_stream_channel_depths
+
+       ! determine if atm and lnd have the same mesh
+       call NUOPC_CompAttributeGet(gcomp, name='ATM_DOMAIN_MESH', value=atm_mesh, rc=rc)
+       if (ChkErr(rc,__LINE__,u_FILE_u)) return
+       call NUOPC_CompAttributeGet(gcomp, name='ATM_DOMAIN_MESH', value=lnd_mesh, rc=rc)
+       if (ChkErr(rc,__LINE__,u_FILE_u)) return
+       if (trim(atm_mesh) == trim(lnd_mesh)) then
+          samegrid_al = .true.
+       else
+          samegrid_al = .false.
+       end if
 
        ! write diagnostic output
        if (maintask) then
@@ -1153,8 +1169,13 @@ contains
        if (fldchk(is_local%wrap%FBexp(compatm), 'Faxx_taux', rc=rc)) then
           if ( fldchk(is_local%wrap%FBImp(complnd,complnd), 'Fall_taux', rc=rc)) then
              call addmap_from(complnd , 'Fall_taux', compatm, mapconsf, 'lfrin', lnd2atm_map)
+             if (samegrid_al) then
+                mrg_fracname_lnd='lfrac'
+             else
+                mrg_fracname_lnd='lfrin'
+             end if
              call addmrg_to(compatm , 'Faxx_taux', &
-                  mrg_from=complnd, mrg_fld='Fall_taux', mrg_type='merge', mrg_fracname='lfrac')
+                  mrg_from=complnd, mrg_fld='Fall_taux', mrg_type='merge', mrg_fracname=mrg_fracname_lnd)
           end if
           if (fldchk(is_local%wrap%FBImp(compice,compice), 'Faii_taux', rc=rc)) then
              call addmap_from(compice , 'Faii_taux', compatm, mapconsf, 'ifrac', ice2atm_map)
@@ -1180,8 +1201,13 @@ contains
        if (fldchk(is_local%wrap%FBexp(compatm), 'Faxx_tauy', rc=rc)) then
           if ( fldchk(is_local%wrap%FBImp(complnd,complnd), 'Fall_tauy', rc=rc)) then
              call addmap_from(complnd , 'Fall_tauy', compatm, mapconsf, 'lfrin', lnd2atm_map)
+             if (samegrid_al) then
+                mrg_fracname_lnd='lfrac'
+             else
+                mrg_fracname_lnd='lfrin'
+             end if
              call addmrg_to(compatm , 'Faxx_tauy', &
-                  mrg_from=complnd, mrg_fld='Fall_tauy', mrg_type='merge', mrg_fracname='lfrac')
+                  mrg_from=complnd, mrg_fld='Fall_tauy', mrg_type='merge', mrg_fracname=mrg_fracname_lnd)
           end if
           if (fldchk(is_local%wrap%FBImp(compice,compice), 'Faii_tauy', rc=rc)) then
              call addmap_from(compice , 'Faii_tauy', compatm, mapconsf, 'ifrac', ice2atm_map)
@@ -1207,8 +1233,13 @@ contains
        if (fldchk(is_local%wrap%FBexp(compatm), 'Faxx_lat', rc=rc)) then
           if ( fldchk(is_local%wrap%FBImp(complnd,complnd), 'Fall_lat', rc=rc)) then
              call addmap_from(complnd , 'Fall_lat', compatm, mapconsf, 'lfrin', lnd2atm_map)
+             if (samegrid_al) then
+                mrg_fracname_lnd='lfrac'
+             else
+                mrg_fracname_lnd='lfrin'
+             end if
              call addmrg_to(compatm , 'Faxx_lat', &
-                  mrg_from=complnd, mrg_fld='Fall_lat', mrg_type='merge', mrg_fracname='lfrac')
+                  mrg_from=complnd, mrg_fld='Fall_lat', mrg_type='merge', mrg_fracname=mrg_fracname_lnd)
           end if
           if (fldchk(is_local%wrap%FBImp(compice,compice), 'Faii_lat', rc=rc)) then
              call addmap_from(compice , 'Faii_lat', compatm, mapconsf, 'ifrac', ice2atm_map)
@@ -1234,8 +1265,13 @@ contains
        if (fldchk(is_local%wrap%FBexp(compatm), 'Faxx_sen', rc=rc)) then
           if ( fldchk(is_local%wrap%FBImp(complnd,complnd), 'Fall_sen', rc=rc)) then
              call addmap_from(complnd , 'Fall_sen', compatm, mapconsf, 'lfrin', lnd2atm_map)
+             if (samegrid_al) then
+                mrg_fracname_lnd='lfrac'
+             else
+                mrg_fracname_lnd='lfrin'
+             end if
              call addmrg_to(compatm , 'Faxx_sen', &
-                  mrg_from=complnd, mrg_fld='Fall_sen', mrg_type='merge', mrg_fracname='lfrac')
+                  mrg_from=complnd, mrg_fld='Fall_sen', mrg_type='merge', mrg_fracname=mrg_fracname_lnd)
           end if
           if (fldchk(is_local%wrap%FBImp(compice,compice), 'Faii_sen', rc=rc)) then
              call addmap_from(compice , 'Faii_sen', compatm, mapconsf, 'ifrac', ice2atm_map)
@@ -1261,8 +1297,13 @@ contains
        if (fldchk(is_local%wrap%FBexp(compatm), 'Faxx_evap', rc=rc)) then
           if ( fldchk(is_local%wrap%FBImp(complnd,complnd), 'Fall_evap', rc=rc)) then
              call addmap_from(complnd , 'Fall_evap', compatm, mapconsf, 'lfrin', lnd2atm_map)
+             if (samegrid_al) then
+                mrg_fracname_lnd='lfrac'
+             else
+                mrg_fracname_lnd='lfrin'
+             end if
              call addmrg_to(compatm , 'Faxx_evap', &
-                  mrg_from=complnd, mrg_fld='Fall_evap', mrg_type='merge', mrg_fracname='lfrac')
+                  mrg_from=complnd, mrg_fld='Fall_evap', mrg_type='merge', mrg_fracname=mrg_fracname_lnd)
           end if
           if (fldchk(is_local%wrap%FBImp(compice,compice), 'Faii_evap', rc=rc)) then
              call addmap_from(compice , 'Faii_evap', compatm, mapconsf, 'ifrac', ice2atm_map)
@@ -1288,8 +1329,13 @@ contains
        if (fldchk(is_local%wrap%FBexp(compatm), 'Faxx_lwup', rc=rc)) then
           if ( fldchk(is_local%wrap%FBImp(complnd,complnd), 'Fall_lwup', rc=rc)) then
              call addmap_from(complnd , 'Fall_lwup', compatm, mapconsf, 'lfrin', lnd2atm_map)
+             if (samegrid_al) then
+                mrg_fracname_lnd='lfrac'
+             else
+                mrg_fracname_lnd='lfrin'
+             end if
              call addmrg_to(compatm , 'Faxx_lwup', &
-                  mrg_from=complnd, mrg_fld='Fall_lwup', mrg_type='merge', mrg_fracname='lfrac')
+                  mrg_from=complnd, mrg_fld='Fall_lwup', mrg_type='merge', mrg_fracname=mrg_fracname_lnd)
           end if
           if (fldchk(is_local%wrap%FBImp(compice,compice), 'Faii_lwup', rc=rc)) then
              call addmap_from(compice , 'Faii_lwup', compatm, mapconsf, 'ifrac', ice2atm_map)
@@ -1316,8 +1362,13 @@ contains
           if (fldchk(is_local%wrap%FBexp(compatm), 'Faxx_evap_wiso', rc=rc)) then
              if ( fldchk(is_local%wrap%FBImp(complnd,complnd), 'Fall_evap_wiso', rc=rc)) then
                 call addmap_from(complnd , 'Fall_evap_wiso', compatm, mapconsf, 'lfrin', lnd2atm_map)
+                if (samegrid_al) then
+                   mrg_fracname_lnd='lfrac'
+                else
+                   mrg_fracname_lnd='lfrin'
+                end if
                 call addmrg_to(compatm , 'Faxx_evap_wiso', &
-                     mrg_from=complnd, mrg_fld='Fall_evap_wiso', mrg_type='merge', mrg_fracname='lfrac')
+                     mrg_from=complnd, mrg_fld='Fall_evap_wiso', mrg_type='merge', mrg_fracname=mrg_fracname_lnd)
              end if
              if (fldchk(is_local%wrap%FBImp(compice,compice), 'Faii_evap_wiso', rc=rc)) then
                 call addmap_from(compice , 'Faii_evap_wiso', compatm, mapconsf, 'ifrac', ice2atm_map)
@@ -1532,8 +1583,9 @@ contains
           call addmrg_to(compatm, 'Sl_snowh', mrg_from=complnd, mrg_fld='Sl_snowh', mrg_type='copy')
        end if
     end if
+
     ! ---------------------------------------------------------------------
-    ! CARMA fields (volumetric soil water)
+    ! atm atm: CARMA fields (volumetric soil water) from land
     !-----------------------------------------------------------------------------
     if (phase == 'advertise') then
        call addfld_from(complnd, 'Sl_soilw')
@@ -1545,6 +1597,7 @@ contains
           call addmrg_to(compatm, 'Sl_soilw', mrg_from=complnd, mrg_fld='Sl_soilw', mrg_type='copy')
        end if
     end if
+
     ! ---------------------------------------------------------------------
     ! to atm: dust fluxes from land (4 sizes)
     ! ---------------------------------------------------------------------
@@ -1559,6 +1612,7 @@ contains
                mrg_from=complnd, mrg_fld='Fall_flxdst', mrg_type='copy_with_weights', mrg_fracname='lfrac')
        end if
     end if
+
     !-----------------------------------------------------------------------------
     ! to atm: MEGAN emissions fluxes from land
     !-----------------------------------------------------------------------------
@@ -1569,10 +1623,16 @@ contains
        if ( fldchk(is_local%wrap%FBImp(complnd, complnd), 'Fall_voc', rc=rc) .and. &
             fldchk(is_local%wrap%FBExp(compatm)         , 'Fall_voc', rc=rc)) then
           call addmap_from(complnd, 'Fall_voc', compatm, mapconsf, 'one', atm2lnd_map)
+          if (samegrid_al) then
+             mrg_fracname_lnd='lfrac'
+          else
+             mrg_fracname_lnd='lfrin'
+          end if
           call addmrg_to(compatm, 'Fall_voc', &
-               mrg_from=complnd, mrg_fld='Fall_voc', mrg_type='merge', mrg_fracname='lfrac')
+               mrg_from=complnd, mrg_fld='Fall_voc', mrg_type='merge', mrg_fracname=mrg_fracname_lnd)
        end if
     end if
+
     !-----------------------------------------------------------------------------
     ! to atm: fire emissions fluxes from land
     !-----------------------------------------------------------------------------
@@ -1584,8 +1644,13 @@ contains
        if ( fldchk(is_local%wrap%FBImp(complnd, complnd), 'Fall_fire', rc=rc) .and. &
             fldchk(is_local%wrap%FBExp(compatm)         , 'Fall_fire', rc=rc)) then
           call addmap_from(complnd, 'Fall_fire', compatm, mapconsf, 'one', lnd2atm_map)
+          if (samegrid_al) then
+             mrg_fracname_lnd='lfrac'
+          else
+             mrg_fracname_lnd='lfrin'
+          end if
           call addmrg_to(compatm, 'Fall_fire', &
-               mrg_from=complnd, mrg_fld='Fall_fire', mrg_type='merge', mrg_fracname='lfrac')
+               mrg_from=complnd, mrg_fld='Fall_fire', mrg_type='merge', mrg_fracname=mrg_fracname_lnd)
        end if
     end if
     ! 'wild fire plume height'
@@ -1599,6 +1664,7 @@ contains
           call addmrg_to(compatm, 'Sl_fztop', mrg_from=complnd, mrg_fld='Sl_fztop', mrg_type='copy')
        end if
     end if
+
     !-----------------------------------------------------------------------------
     ! to atm: dry deposition velocities from land
     !-----------------------------------------------------------------------------
@@ -3099,9 +3165,14 @@ contains
     else
        if ( fldchk(is_local%wrap%FBImp(complnd, complnd), 'Flrl_rofsur', rc=rc) .and. &
             fldchk(is_local%wrap%FBExp(comprof)         , 'Flrl_rofsur', rc=rc)) then
-          call addmap_from(complnd, 'Flrl_rofsur', comprof, mapconsf, 'lfrac', lnd2rof_map)
+          call addmap_from(complnd, 'Flrl_rofsur', comprof, mapconsf, 'lfrin', lnd2rof_map)
+          if (samegrid_al) then
+             mrg_fracname_lnd = 'lfrac'
+          else
+             mrg_fracname_lnd = 'lfrin'
+          endif
           call addmrg_to(comprof, 'Flrl_rofsur', &
-               mrg_from=complnd, mrg_fld='Flrl_rofsur', mrg_type='copy_with_weights', mrg_fracname='lfrac')
+               mrg_from=complnd, mrg_fld='Flrl_rofsur', mrg_type='copy_with_weights', mrg_fracname=mrg_fracname_lnd)
        end if
     end if
 
@@ -3114,9 +3185,14 @@ contains
     else
        if ( fldchk(is_local%wrap%FBImp(complnd, complnd), 'Flrl_rofi', rc=rc) .and. &
             fldchk(is_local%wrap%FBExp(comprof)         , 'Flrl_rofi', rc=rc)) then
-          call addmap_from(complnd, 'Flrl_rofi', comprof, mapconsf, 'lfrac', lnd2rof_map)
+          call addmap_from(complnd, 'Flrl_rofi', comprof, mapconsf, 'lfrin', lnd2rof_map)
+          if (samegrid_al) then
+             mrg_fracname_lnd = 'lfrac'
+          else
+             mrg_fracname_lnd = 'lfrin'
+          endif
           call addmrg_to(comprof, 'Flrl_rofi', &
-               mrg_from=complnd, mrg_fld='Flrl_rofi', mrg_type='copy_with_weights', mrg_fracname='lfrac')
+               mrg_from=complnd, mrg_fld='Flrl_rofi', mrg_type='copy_with_weights', mrg_fracname=mrg_fracname_lnd)
        end if
     end if
 
@@ -3129,9 +3205,14 @@ contains
     else
        if ( fldchk(is_local%wrap%FBImp(complnd, complnd), 'Flrl_rofgwl', rc=rc) .and. &
             fldchk(is_local%wrap%FBExp(comprof)         , 'Flrl_rofgwl', rc=rc)) then
-          call addmap_from(complnd, 'Flrl_rofgwl', comprof, mapconsf, 'lfrac', lnd2rof_map)
+          call addmap_from(complnd, 'Flrl_rofgwl', comprof, mapconsf, 'lfrin', lnd2rof_map)
+          if (samegrid_al) then
+             mrg_fracname_lnd = 'lfrac'
+          else
+             mrg_fracname_lnd = 'lfrin'
+          endif
           call addmrg_to(comprof, 'Flrl_rofgwl', &
-               mrg_from=complnd, mrg_fld='Flrl_rofgwl', mrg_type='copy_with_weights', mrg_fracname='lfrac')
+               mrg_from=complnd, mrg_fld='Flrl_rofgwl', mrg_type='copy_with_weights', mrg_fracname=mrg_fracname_lnd)
        end if
     end if
 
@@ -3145,8 +3226,13 @@ contains
        if ( fldchk(is_local%wrap%FBImp(complnd, complnd), 'Flrl_rofsub', rc=rc) .and. &
             fldchk(is_local%wrap%FBExp(comprof)         , 'Flrl_rofsub', rc=rc)) then
           call addmap_from(complnd, 'Flrl_rofsub', comprof, mapconsf, 'lfrac', lnd2rof_map)
+          if (samegrid_al) then
+             mrg_fracname_lnd = 'lfrac'
+          else
+             mrg_fracname_lnd = 'lfrin'
+          endif
           call addmrg_to(comprof, 'Flrl_rofsub', &
-               mrg_from=complnd, mrg_fld='Flrl_rofsub', mrg_type='copy_with_weights', mrg_fracname='lfrac')
+               mrg_from=complnd, mrg_fld='Flrl_rofsub', mrg_type='copy_with_weights', mrg_fracname=mrg_fracname_lnd)
        end if
     end if
 
@@ -3160,8 +3246,13 @@ contains
        if ( fldchk(is_local%wrap%FBImp(complnd, complnd), 'Flrl_irrig', rc=rc) .and. &
             fldchk(is_local%wrap%FBExp(comprof)         , 'Flrl_irrig', rc=rc)) then
           call addmap_from(complnd, 'Flrl_irrig', comprof, mapconsf, 'lfrac', lnd2rof_map)
+          if (samegrid_al) then
+             mrg_fracname_lnd = 'lfrac'
+          else
+             mrg_fracname_lnd = 'lfrin'
+          endif
           call addmrg_to(comprof, 'Flrl_irrig', &
-               mrg_from=complnd, mrg_fld='Flrl_irrig', mrg_type='copy_with_weights', mrg_fracname='lfrac')
+               mrg_from=complnd, mrg_fld='Flrl_irrig', mrg_type='copy_with_weights', mrg_fracname=mrg_fracname_lnd)
        end if
     end if
 

--- a/mediator/fd_cesm.yaml
+++ b/mediator/fd_cesm.yaml
@@ -859,13 +859,21 @@
        canonical_units: moles m-2 s-1
        description: ocn import to med - surface flux of CO2 (downward positive)
      #
-     - standard_name: Faoo_dms_ocn
+     - standard_name: Faoo_fdms_ocn
        canonical_units: moles m-2 s-1
        description: ocn import to med - surface flux of DMS (downward positive)
      #
-     - standard_name: Faoo_bromo_ocn
+     - standard_name: Faoo_fbrf_ocn
        canonical_units: moles m-2 s-1
        description: ocn import to med - surface flux of Bromoform (downward positive)
+     #
+     - standard_name: Faoo_fn2o_ocn
+       canonical_units: moles m-2 s-1
+       description: ocn import to med - surface flux of N2O (downward positive)
+     #
+     - standard_name: Faoo_fnh3_ocn
+       canonical_units: moles m-2 s-1
+       description: ocn import to med - surface flux of NH3 (downward positive)
      #
      - standard_name: So_anidf
        canonical_units: 1

--- a/mediator/fd_cesm.yaml
+++ b/mediator/fd_cesm.yaml
@@ -857,11 +857,15 @@
      #
      - standard_name: Faoo_fco2_ocn
        canonical_units: moles m-2 s-1
-       description: ocn import to med
+       description: ocn import to med - surface flux of CO2 (downward positive)
      #
      - standard_name: Faoo_dms_ocn
        canonical_units: moles m-2 s-1
        description: ocn import to med - surface flux of DMS (downward positive)
+     #
+     - standard_name: Faoo_bromo_ocn
+       canonical_units: moles m-2 s-1
+       description: ocn import to med - surface flux of Bromoform (downward positive)
      #
      - standard_name: So_anidf
        canonical_units: 1

--- a/mediator/med_diag_mod.F90
+++ b/mediator/med_diag_mod.F90
@@ -27,7 +27,7 @@ module med_diag_mod
   use med_constants_mod     , only : shr_const_rearth, shr_const_pi, shr_const_latice, shr_const_latvap
   use med_constants_mod     , only : shr_const_ice_ref_sal, shr_const_ocn_ref_sal, shr_const_isspval
   use med_kind_mod          , only : CX=>SHR_KIND_CX, CS=>SHR_KIND_CS, CL=>SHR_KIND_CL, R8=>SHR_KIND_R8
-  use med_internalstate_mod , only : InternalState, logunit, maintask, diagunit
+  use med_internalstate_mod , only : InternalState, logunit, maintask, diagunit, samegrid_atmlnd
   use med_methods_mod       , only : fldbun_getdata2d => med_methods_FB_getdata2d
   use med_methods_mod       , only : fldbun_getdata1d => med_methods_FB_getdata1d
   use med_methods_mod       , only : fldbun_fldChk    => med_methods_FB_FldChk
@@ -666,8 +666,13 @@ contains
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
 
     ! Get fractions on atm mesh
-    call fldbun_getdata1d(is_local%wrap%FBfrac(compatm), 'lfrac', lfrac, rc=rc)
-    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+    if (samegrid_atmlnd) then
+      call fldbun_getdata1d(is_local%wrap%FBfrac(compatm), 'lfrac', lfrac, rc=rc)
+      if (ChkErr(rc,__LINE__,u_FILE_u)) return
+    else
+      call fldbun_getdata1d(is_local%wrap%FBfrac(compatm), 'lfrin', lfrac, rc=rc)
+      if (ChkErr(rc,__LINE__,u_FILE_u)) return
+    end if
     call fldbun_getdata1d(is_local%wrap%FBfrac(compatm), 'ifrac', ifrac, rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
     call fldbun_getdata1d(is_local%wrap%FBfrac(compatm), 'ofrac', ofrac, rc=rc)
@@ -986,7 +991,7 @@ contains
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
 
     ! get fractions on lnd mesh
-    call fldbun_getdata1d(is_local%wrap%FBfrac(complnd), 'lfrac', lfrac, rc=rc)
+    call fldbun_getdata1d(is_local%wrap%FBfrac(complnd), 'lfrin', lfrac, rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
 
     areas => is_local%wrap%mesh_info(complnd)%areas

--- a/mediator/med_fraction_mod.F90
+++ b/mediator/med_fraction_mod.F90
@@ -50,7 +50,7 @@ module med_fraction_mod
   !    *frac is the fraction of a particular component in the bundle.
   !
   !  in general, on every grid,
-  !              fractions_*(ifrac) + fractions_*(ofrac) + fractions_*(lfrac) = 1.0
+  !    fractions_*(ifrac) + fractions_*(ofrac) + fractions_*(lfrac) = 1.0
   !
   !  the fractions are computed fundamentally as follows (although the
   !    detailed implementation might be slightly different)

--- a/mediator/med_internalstate_mod.F90
+++ b/mediator/med_internalstate_mod.F90
@@ -234,6 +234,7 @@ contains
     integer                    :: num_icesheets
     character(len=CL)          :: atm_mesh_name
     character(len=CL)          :: lnd_mesh_name
+    logical                   :: isPresent, isSet
     character(len=*),parameter :: subname=' (internalstate init) '
     !-----------------------------------------------------------
 
@@ -241,16 +242,20 @@ contains
     call ESMF_GridCompGetInternalState(gcomp, is_local, rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
 
-
     ! determine if atm and lnd have the same mesh
     call NUOPC_CompAttributeGet(gcomp, name='mesh_atm', value=atm_mesh_name, rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
-    call NUOPC_CompAttributeGet(gcomp, name='mesh_lnd', value=lnd_mesh_name, rc=rc)
+    call NUOPC_CompAttributeGet(gcomp, name='mesh_lnd', value=lnd_mesh_name, &
+         isPresent=isPresent, isSet=isSet, rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
-    if (trim(atm_mesh_name) == trim(lnd_mesh_name)) then
-      samegrid_atmlnd = .true.
+    if (isPresent .and. isSet) then
+      if (trim(atm_mesh_name) == trim(lnd_mesh_name)) then
+        samegrid_atmlnd = .true.
+      else
+        samegrid_atmlnd = .false.
+      end if
     else
-      samegrid_atmlnd = .false.
+      samegrid_atmlnd = .true.
     end if
 
     ! See med_fraction_mod for the following definitions

--- a/mediator/med_internalstate_mod.F90
+++ b/mediator/med_internalstate_mod.F90
@@ -115,6 +115,8 @@ module med_internalstate_mod
      real(r8), pointer :: lons(:) => null()
   end type mesh_info_type
 
+  logical, public ::  samegrid_atmlnd = .true. ! true=>atm and lnd are on the same grid
+
   ! private internal state to keep instance data
   type InternalStateStruct
 

--- a/mediator/med_internalstate_mod.F90
+++ b/mediator/med_internalstate_mod.F90
@@ -245,10 +245,10 @@ contains
 
     ! determine if atm and lnd have the same mesh
     call NUOPC_CompAttributeGet(gcomp, name='mesh_atm', value=atm_mesh_name, &
-         isPresent=isPresent, isSet=isSet, rc=rc)
+         isPresent=isPresent_atm, isSet=isSet_atm, rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
     call NUOPC_CompAttributeGet(gcomp, name='mesh_lnd', value=lnd_mesh_name, &
-         isPresent=isPresent, isSet=isSet, rc=rc)
+         isPresent=isPresent_lnd, isSet=isSet_lnd, rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
 
     if ((isPresent_lnd .and. isSet_lnd) .and. (isPresent_atm .and. isSet_atm)) then

--- a/mediator/med_internalstate_mod.F90
+++ b/mediator/med_internalstate_mod.F90
@@ -265,12 +265,22 @@ contains
     else
       map_fracname_lnd2atm       = 'lfrin' ! in fraclist_a
       mrg_fracname_lnd2atm_state = 'lfrin' ! in fraclist_a
-      mrg_fracname_lnd2atm_flux  = 'lfrin' ! in fraclist_r
+      mrg_fracname_lnd2atm_flux  = 'lfrin' ! in fraclist_a
       map_fracname_lnd2rof       = 'lfrin' ! in fraclist_r
       mrg_fracname_lnd2rof       = 'lfrin' ! in fraclist_r
       map_fracname_lnd2glc       = 'lfrin' ! in fraclist_g
       mrg_fracname_lnd2rof       = 'lfrin' ! in fraclist_g
     endif
+
+    if (maintask) then
+      write(logunit,'(a,i8)') trim(subname)//'      map_fracname_lnd2atm       = '//trim(map_fracname_lnd2atm)      //' in fraclist_a'
+      write(logunit,'(a,i8)') trim(subname)//'      mrg_fracname_lnd2atm_state = '//trim(mrg_fracname_lnd2atm_state)//' in fraclist_a'
+      write(logunit,'(a,i8)') trim(subname)//'      mrg_fracname_lnd2atm_flux  = '//trim(mrg_fracname_lnd2atm_flux) //' in fraclist_a'
+      write(logunit,'(a,i8)') trim(subname)//'      map_fracname_lnd2rof       = '//trim(map_fracname_lnd2rof)      //' in fraclist_r'
+      write(logunit,'(a,i8)') trim(subname)//'      mrg_fracname_lnd2rof       = '//trim(mrg_fracname_lnd2rof)      //' in fraclist_r'
+      write(logunit,'(a,i8)') trim(subname)//'      map_fracname_lnd2glc       = '//trim(map_fracname_lnd2glc)      //' in fraclist_g'
+      write(logunit,'(a,i8)') trim(subname)//'      mrg_fracname_lnd2rof       = '//trim(mrg_fracname_lnd2rof)      //' in fraclist_g'
+    end if
 
     ! Determine if glc is present
     call NUOPC_CompAttributeGet(gcomp, name='GLC_model', value=cvalue, isPresent=isPresent, isSet=isSet, rc=rc)

--- a/mediator/med_internalstate_mod.F90
+++ b/mediator/med_internalstate_mod.F90
@@ -264,7 +264,7 @@ contains
       mrg_fracname_lnd2glc       = 'lfrac' ! in fraclist_g
     else
       map_fracname_lnd2atm       = 'lfrin' ! in fraclist_a
-      mrg_fracname_lnd2atm_state = 'lfrin' ! in fraclist_a
+      mrg_fracname_lnd2atm_state = 'lfrac' ! in fraclist_a
       mrg_fracname_lnd2atm_flux  = 'lfrin' ! in fraclist_a
       map_fracname_lnd2rof       = 'lfrin' ! in fraclist_r
       mrg_fracname_lnd2rof       = 'lfrin' ! in fraclist_r

--- a/mediator/med_internalstate_mod.F90
+++ b/mediator/med_internalstate_mod.F90
@@ -234,7 +234,8 @@ contains
     integer                    :: num_icesheets
     character(len=CL)          :: atm_mesh_name
     character(len=CL)          :: lnd_mesh_name
-    logical                   :: isPresent, isSet
+    logical                    :: isPresent_lnd, isSet_lnd
+    logical                    :: isPresent_atm, isSet_atm
     character(len=*),parameter :: subname=' (internalstate init) '
     !-----------------------------------------------------------
 
@@ -243,12 +244,14 @@ contains
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
 
     ! determine if atm and lnd have the same mesh
-    call NUOPC_CompAttributeGet(gcomp, name='mesh_atm', value=atm_mesh_name, rc=rc)
+    call NUOPC_CompAttributeGet(gcomp, name='mesh_atm', value=atm_mesh_name, &
+         isPresent=isPresent, isSet=isSet, rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
     call NUOPC_CompAttributeGet(gcomp, name='mesh_lnd', value=lnd_mesh_name, &
          isPresent=isPresent, isSet=isSet, rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
-    if (isPresent .and. isSet) then
+
+    if ((isPresent_lnd .and. isSet_lnd) .and. (isPresent_atm .and. isSet_atm)) then
       if (trim(atm_mesh_name) == trim(lnd_mesh_name)) then
         samegrid_atmlnd = .true.
       else

--- a/mediator/med_internalstate_mod.F90
+++ b/mediator/med_internalstate_mod.F90
@@ -232,8 +232,8 @@ contains
     character(len=CX)          :: msgString
     character(len=3)           :: name
     integer                    :: num_icesheets
-    character(len=CL)          :: atm_mesh
-    character(len=CL)          :: lnd_mesh
+    character(len=CL)          :: atm_mesh_name
+    character(len=CL)          :: lnd_mesh_name
     character(len=*),parameter :: subname=' (internalstate init) '
     !-----------------------------------------------------------
 
@@ -243,11 +243,11 @@ contains
 
 
     ! determine if atm and lnd have the same mesh
-    call NUOPC_CompAttributeGet(gcomp, name='ATM_DOMAIN_MESH', value=atm_mesh, rc=rc)
+    call NUOPC_CompAttributeGet(gcomp, name='mesh_atm', value=atm_mesh_name, rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
-    call NUOPC_CompAttributeGet(gcomp, name='ATM_DOMAIN_MESH', value=lnd_mesh, rc=rc)
+    call NUOPC_CompAttributeGet(gcomp, name='mesh_lnd', value=lnd_mesh_name, rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
-    if (trim(atm_mesh) == trim(lnd_mesh)) then
+    if (trim(atm_mesh_name) == trim(lnd_mesh_name)) then
       samegrid_atmlnd = .true.
     else
       samegrid_atmlnd = .false.

--- a/mediator/med_phases_prep_atm_mod.F90
+++ b/mediator/med_phases_prep_atm_mod.F90
@@ -17,7 +17,7 @@ module med_phases_prep_atm_mod
   use med_methods_mod       , only : FB_check_for_nans => med_methods_FB_check_for_nans
   use med_merge_mod         , only : med_merge_auto
   use med_map_mod           , only : med_map_field_packed
-  use med_internalstate_mod , only : InternalState, maintask, logunit
+  use med_internalstate_mod , only : InternalState, maintask, logunit, samegrid_atmlnd
   use med_internalstate_mod , only : compatm, compocn, compice, compname, coupling_mode
   use esmFlds               , only : med_fldlist_GetfldListTo, med_fldlist_type
   use perf_mod              , only : t_startf, t_stopf
@@ -183,8 +183,13 @@ contains
        if (chkerr(rc,__LINE__,u_FILE_u)) return
        call ESMF_FieldGet(lfield, farrayPtr=dataptr1, rc=rc)
        if (chkerr(rc,__LINE__,u_FILE_u)) return
-       call ESMF_FieldBundleGet(is_local%wrap%FBFrac(compatm), fieldName='lfrac', field=lfield, rc=rc)
-       if (chkerr(rc,__LINE__,u_FILE_u)) return
+       if (samegrid_atmlnd) then
+          call ESMF_FieldBundleGet(is_local%wrap%FBFrac(compatm), fieldName='lfrac', field=lfield, rc=rc)
+          if (chkerr(rc,__LINE__,u_FILE_u)) return
+       else
+          call ESMF_FieldBundleGet(is_local%wrap%FBFrac(compatm), fieldName='lfrin', field=lfield, rc=rc)
+          if (chkerr(rc,__LINE__,u_FILE_u)) return
+       end if
        call ESMF_FieldGet(lfield, farrayPtr=dataptr2, rc=rc)
        if (chkerr(rc,__LINE__,u_FILE_u)) return
        do n = 1,size(dataptr1)

--- a/mediator/med_phases_prep_atm_mod.F90
+++ b/mediator/med_phases_prep_atm_mod.F90
@@ -32,7 +32,7 @@ module med_phases_prep_atm_mod
 
   real(r8), public :: global_htot_corr(1) = 0._r8  ! enthalpy correction from med_phases_prep_ocn
 
-  character(len=14) :: fldnames_from_ocn(5) = (/'Faoo_fbrf_ocn','Faoo_fdms_ocn ','Faoo_fco2_ocn ',&
+  character(len=13) :: fldnames_from_ocn(5) = (/'Faoo_fbrf_ocn','Faoo_fdms_ocn','Faoo_fco2_ocn',&
                                                 'Faoo_fn2o_ocn','Faoo_fnh3_ocn'/)
 
   character(*), parameter :: u_FILE_u  = &
@@ -211,7 +211,7 @@ contains
     call ESMF_FieldGet(lfield, farrayPtr=ofrac, rc=rc)
     if (chkerr(rc,__LINE__,u_FILE_u)) return
 
-    do nf = 1,len(fldnames_from_ocn)
+    do nf = 1,size(fldnames_from_ocn)
       if ( FB_FldChk(is_local%wrap%FBExp(compatm)        , trim(fldnames_from_ocn(nf)), rc=rc) .and. &
            FB_FldChk(is_local%wrap%FBImp(compocn,compocn), trim(fldnames_from_ocn(nf)), rc=rc)) then
         call ESMF_FieldBundleGet(is_local%wrap%FBImp(compocn,compatm), &

--- a/mediator/med_phases_prep_atm_mod.F90
+++ b/mediator/med_phases_prep_atm_mod.F90
@@ -32,8 +32,8 @@ module med_phases_prep_atm_mod
 
   real(r8), public :: global_htot_corr(1) = 0._r8  ! enthalpy correction from med_phases_prep_ocn
 
-  character(len=14) :: fldnames_to_ocn(5) = (/'Faoo_fbrf_ocn','Faoo_fdms_ocn ','Faoo_fco2_ocn ',&
-                                              'Faoo_fn2o_ocn','Faoo_fnh3_ocn'/)
+  character(len=14) :: fldnames_from_ocn(5) = (/'Faoo_fbrf_ocn','Faoo_fdms_ocn ','Faoo_fco2_ocn ',&
+                                                'Faoo_fn2o_ocn','Faoo_fnh3_ocn'/)
 
   character(*), parameter :: u_FILE_u  = &
        __FILE__
@@ -211,21 +211,23 @@ contains
     call ESMF_FieldGet(lfield, farrayPtr=ofrac, rc=rc)
     if (chkerr(rc,__LINE__,u_FILE_u)) return
 
-    do nf = 1,len(fldnames_to_ocn)
-       if ( FB_FldChk(is_local%wrap%FBExp(compatm)        , trim(fldnames_to_ocn(nf)), rc=rc) .and. &
-            FB_FldChk(is_local%wrap%FBImp(compocn,compocn), trim(fldnames_to_ocn(nf)), rc=rc)) then
-          call ESMF_FieldBundleGet(is_local%wrap%FBImp(compocn,compatm), fieldName=trim(fldnames_to_ocn(nf)), field=lfield, rc=rc)
-          if (chkerr(rc,__LINE__,u_FILE_u)) return
-          call ESMF_FieldGet(lfield, farrayPtr=dataptr1, rc=rc)
-          if (chkerr(rc,__LINE__,u_FILE_u)) return
-          call ESMF_FieldBundleGet(is_local%wrap%FBExp(compatm), fieldName=trim(fldnames_to_ocn(nf)), field=lfield, rc=rc)
-          if (chkerr(rc,__LINE__,u_FILE_u)) return
-          call ESMF_FieldGet(lfield, farrayPtr=dataptr2, rc=rc)
-          if (chkerr(rc,__LINE__,u_FILE_u)) return
-          do n = 1,size(dataptr2)
-             dataptr2(n) = (ifrac(n) + ofrac(n)) * dataptr1(n)
-          end do
-       end if
+    do nf = 1,len(fldnames_from_ocn)
+      if ( FB_FldChk(is_local%wrap%FBExp(compatm)        , trim(fldnames_from_ocn(nf)), rc=rc) .and. &
+           FB_FldChk(is_local%wrap%FBImp(compocn,compocn), trim(fldnames_from_ocn(nf)), rc=rc)) then
+        call ESMF_FieldBundleGet(is_local%wrap%FBImp(compocn,compatm), &
+             fieldName=trim(fldnames_from_ocn(nf)), field=lfield, rc=rc)
+        if (chkerr(rc,__LINE__,u_FILE_u)) return
+        call ESMF_FieldGet(lfield, farrayPtr=dataptr1, rc=rc)
+        if (chkerr(rc,__LINE__,u_FILE_u)) return
+        call ESMF_FieldBundleGet(is_local%wrap%FBExp(compatm), &
+             fieldName=trim(fldnames_from_ocn(nf)), field=lfield, rc=rc)
+        if (chkerr(rc,__LINE__,u_FILE_u)) return
+        call ESMF_FieldGet(lfield, farrayPtr=dataptr2, rc=rc)
+        if (chkerr(rc,__LINE__,u_FILE_u)) return
+        do n = 1,size(dataptr2)
+          dataptr2(n) = (ifrac(n) + ofrac(n)) * dataptr1(n)
+        end do
+      end if
     end do
 
     ! Add enthalpy correction to sensible heat if appropriate

--- a/mediator/med_phases_prep_atm_mod.F90
+++ b/mediator/med_phases_prep_atm_mod.F90
@@ -32,7 +32,7 @@ module med_phases_prep_atm_mod
 
   real(r8), public :: global_htot_corr(1) = 0._r8  ! enthalpy correction from med_phases_prep_ocn
 
-  character(len=14) :: fldnames_to_ocn(3) = (/'Faoo_bromo_ocn','Faoo_fdms_ocn ','Faoo_fco2_ocn '
+  character(len=14) :: fldnames_to_ocn(3) = (/'Faoo_bromo_ocn','Faoo_fdms_ocn ','Faoo_fco2_ocn '/)
 
   character(*), parameter :: u_FILE_u  = &
        __FILE__
@@ -54,7 +54,7 @@ contains
     real(R8), pointer          :: dataPtr2(:)
     real(R8), pointer          :: ifrac(:)
     real(R8), pointer          :: ofrac(:)
-    integer                    :: n
+    integer                    :: n,nf
     type(med_fldlist_type), pointer :: fldList
     character(len=*),parameter :: subname='(med_phases_prep_atm)'
     !-------------------------------------------------------------------------------

--- a/mediator/med_phases_prep_atm_mod.F90
+++ b/mediator/med_phases_prep_atm_mod.F90
@@ -32,7 +32,8 @@ module med_phases_prep_atm_mod
 
   real(r8), public :: global_htot_corr(1) = 0._r8  ! enthalpy correction from med_phases_prep_ocn
 
-  character(len=14) :: fldnames_to_ocn(3) = (/'Faoo_bromo_ocn','Faoo_fdms_ocn ','Faoo_fco2_ocn '/)
+  character(len=14) :: fldnames_to_ocn(5) = (/'Faoo_fbrf_ocn','Faoo_fdms_ocn ','Faoo_fco2_ocn ',&
+                                              'Faoo_fn2o_ocn','Faoo_fnh3_ocn'/)
 
   character(*), parameter :: u_FILE_u  = &
        __FILE__

--- a/mediator/med_phases_prep_glc_mod.F90
+++ b/mediator/med_phases_prep_glc_mod.F90
@@ -814,8 +814,13 @@ contains
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
 
     ! get land fraction field on land mesh
-    call ESMF_FieldBundleGet(is_local%wrap%FBFrac(complnd), 'lfrac', field=field_lfrac_l, rc=rc)
-    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+    if (samegrid_atmlnd) then
+       call ESMF_FieldBundleGet(is_local%wrap%FBFrac(compatm), fieldName='lfrac', field=lfield_lfrac_l, rc=rc)
+       if (chkerr(rc,__LINE__,u_FILE_u)) return
+    else
+       call ESMF_FieldBundleGet(is_local%wrap%FBFrac(compatm), fieldName='lfrin', field=lfield_lfrac_l, rc=rc)
+       if (chkerr(rc,__LINE__,u_FILE_u)) return
+    end if
 
     ! map accumlated land fields to each ice sheet (normalize by the land fraction in the mapping)
     do ns = 1,is_local%wrap%num_icesheets
@@ -1149,8 +1154,13 @@ contains
     if (chkErr(rc,__LINE__,u_FILE_u)) return
 
     ! determine fraction on land grid, lfrac(:)
-    call fldbun_getdata1d(is_local%wrap%FBFrac(complnd), 'lfrac', lfrac, rc)
-    if (chkErr(rc,__LINE__,u_FILE_u)) return
+    if (samegrid_atmlnd) then
+       call fldbun_getdata1d(is_local%wrap%FBFrac(complnd), 'lfrac', lfrac, rc)
+       if (chkErr(rc,__LINE__,u_FILE_u)) return
+    else
+       call fldbun_getdata1d(is_local%wrap%FBFrac(complnd), 'lfrin', lfrac, rc)
+       if (chkErr(rc,__LINE__,u_FILE_u)) return
+    end if
 
     ! get qice_l_ec
     call fldbun_getdata2d(FBlndAccum2glc_l, trim(qice_fieldname)//'_elev', qice_l_ec, rc)

--- a/mediator/med_phases_prep_glc_mod.F90
+++ b/mediator/med_phases_prep_glc_mod.F90
@@ -22,7 +22,7 @@ module med_phases_prep_glc_mod
   use ESMF                  , only : ESMF_DYNAMICMASK, ESMF_DynamicMaskSetR8R8R8, ESMF_DYNAMICMASKELEMENTR8R8R8
   use ESMF                  , only : ESMF_FieldRegrid, ESMF_REGION_EMPTY
   use med_internalstate_mod , only : complnd, compocn,  mapbilnr, mapconsd, compname, compglc
-  use med_internalstate_mod , only : InternalState, maintask, logunit
+  use med_internalstate_mod , only : InternalState, maintask, logunit, map_fracname_lnd2glc
   use med_map_mod           , only : med_map_routehandles_init, med_map_rh_is_created
   use med_map_mod           , only : med_map_field_normalized, med_map_field
   use med_constants_mod     , only : dbug_flag        => med_constants_dbug_flag
@@ -814,13 +814,8 @@ contains
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
 
     ! get land fraction field on land mesh
-    if (samegrid_atmlnd) then
-       call ESMF_FieldBundleGet(is_local%wrap%FBFrac(compatm), fieldName='lfrac', field=lfield_lfrac_l, rc=rc)
-       if (chkerr(rc,__LINE__,u_FILE_u)) return
-    else
-       call ESMF_FieldBundleGet(is_local%wrap%FBFrac(compatm), fieldName='lfrin', field=lfield_lfrac_l, rc=rc)
-       if (chkerr(rc,__LINE__,u_FILE_u)) return
-    end if
+    call ESMF_FieldBundleGet(is_local%wrap%FBFrac(complnd), fieldName=map_fracname_lnd2glc, field=field_lfrac_l, rc=rc)
+    if (chkerr(rc,__LINE__,u_FILE_u)) return
 
     ! map accumlated land fields to each ice sheet (normalize by the land fraction in the mapping)
     do ns = 1,is_local%wrap%num_icesheets
@@ -1059,7 +1054,7 @@ contains
     real(r8) , pointer  :: frac_l_ec(:,:)  ! EC fractions (Sg_ice_covered) on land grid
     real(r8) , pointer  :: icemask_g(:)    ! icemask on glc grid
     real(r8) , pointer  :: icemask_l(:)    ! icemask on land grid
-    real(r8) , pointer  :: lfrac(:)        ! land fraction on land grid
+    real(r8) , pointer  :: lndfrac(:)      ! land fraction on land grid
     real(r8) , pointer  :: dataptr1d(:)    ! temporary 1d pointer
     integer             :: ec              ! loop index over elevation classes
     integer             :: n
@@ -1073,7 +1068,7 @@ contains
     ! renormalization factors (should be close to 1, e.g. in range 0.95 to 1.05)
     real(r8) :: accum_renorm_factor ! ratio between global accumulation on the two grids
     real(r8) :: ablat_renorm_factor ! ratio between global ablation on the two grids
-    real(r8) :: effective_area      ! grid cell area multiplied by min(lfrac,icemask_l).
+    real(r8) :: effective_area      ! grid cell area multiplied by min(lndfrac,icemask_l).
     real(r8), pointer :: area_g(:)  ! areas on glc grid
     character(len=*), parameter  :: subname=' (renormalize_smb) '
     !---------------------------------------------------------------
@@ -1153,14 +1148,9 @@ contains
     call field_getdata2d(field_frac_l_ec, frac_l_ec, rc)
     if (chkErr(rc,__LINE__,u_FILE_u)) return
 
-    ! determine fraction on land grid, lfrac(:)
-    if (samegrid_atmlnd) then
-       call fldbun_getdata1d(is_local%wrap%FBFrac(complnd), 'lfrac', lfrac, rc)
-       if (chkErr(rc,__LINE__,u_FILE_u)) return
-    else
-       call fldbun_getdata1d(is_local%wrap%FBFrac(complnd), 'lfrin', lfrac, rc)
-       if (chkErr(rc,__LINE__,u_FILE_u)) return
-    end if
+    ! determine fraction on land grid, lndfrac(:)
+    call fldbun_getdata1d(is_local%wrap%FBFrac(complnd), map_fracname_lnd2glc, lndfrac, rc)
+    if (chkErr(rc,__LINE__,u_FILE_u)) return
 
     ! get qice_l_ec
     call fldbun_getdata2d(FBlndAccum2glc_l, trim(qice_fieldname)//'_elev', qice_l_ec, rc)
@@ -1168,9 +1158,9 @@ contains
 
     local_accum_lnd(1) = 0.0_r8
     local_ablat_lnd(1) = 0.0_r8
-    do n = 1, size(lfrac)
+    do n = 1, size(lndfrac)
        ! Calculate effective area for sum -  need the mapped icemask_l
-       effective_area = min(lfrac(n), icemask_l(n)) * is_local%wrap%mesh_info(complnd)%areas(n)
+       effective_area = min(lndfrac(n), icemask_l(n)) * is_local%wrap%mesh_info(complnd)%areas(n)
        if (effective_area > 0.0_r8) then
           do ec = 1, ungriddedCount
              if (qice_l_ec(ec,n) >= 0.0_r8) then

--- a/mediator/med_phases_prep_rof_mod.F90
+++ b/mediator/med_phases_prep_rof_mod.F90
@@ -13,7 +13,7 @@ module med_phases_prep_rof_mod
   use med_kind_mod          , only : CX=>SHR_KIND_CX, CS=>SHR_KIND_CS, CL=>SHR_KIND_CL, R8=>SHR_KIND_R8
   use ESMF                  , only : ESMF_FieldBundle, ESMF_Field
   use med_internalstate_mod , only : complnd, comprof, mapconsf, mapconsd, mapfcopy
-  use med_internalstate_mod , only : InternalState, maintask, logunit
+  use med_internalstate_mod , only : InternalState, maintask, logunit, samegrid_atmlnd
   use med_constants_mod     , only : dbug_flag        => med_constants_dbug_flag
   use med_constants_mod     , only : czero            => med_constants_czero
   use med_utils_mod         , only : chkerr           => med_utils_chkerr
@@ -619,7 +619,7 @@ contains
     !     convert to a total irrigation flux on the ROF grid
     ! ------------------------------------------------------------------------
 
-    call ESMF_FieldBundleGet(is_local%wrap%FBFrac(complnd), 'lfrac', field=field_lfrac_lnd, rc=rc)
+    call ESMF_FieldBundleGet(is_local%wrap%FBFrac(complnd), 'lfrin', field=field_lfrac_lnd, rc=rc)
     if (chkerr(rc,__LINE__,u_FILE_u)) return
 
     call med_map_field_normalized(  &

--- a/mediator/med_phases_prep_rof_mod.F90
+++ b/mediator/med_phases_prep_rof_mod.F90
@@ -13,7 +13,7 @@ module med_phases_prep_rof_mod
   use med_kind_mod          , only : CX=>SHR_KIND_CX, CS=>SHR_KIND_CS, CL=>SHR_KIND_CL, R8=>SHR_KIND_R8
   use ESMF                  , only : ESMF_FieldBundle, ESMF_Field
   use med_internalstate_mod , only : complnd, comprof, mapconsf, mapconsd, mapfcopy
-  use med_internalstate_mod , only : InternalState, maintask, logunit, samegrid_atmlnd
+  use med_internalstate_mod , only : InternalState, maintask, logunit, map_fracname_lnd2rof
   use med_constants_mod     , only : dbug_flag        => med_constants_dbug_flag
   use med_constants_mod     , only : czero            => med_constants_czero
   use med_utils_mod         , only : chkerr           => med_utils_chkerr
@@ -619,7 +619,7 @@ contains
     !     convert to a total irrigation flux on the ROF grid
     ! ------------------------------------------------------------------------
 
-    call ESMF_FieldBundleGet(is_local%wrap%FBFrac(complnd), 'lfrin', field=field_lfrac_lnd, rc=rc)
+    call ESMF_FieldBundleGet(is_local%wrap%FBFrac(complnd), map_fracname_lnd2rof, field=field_lfrac_lnd, rc=rc)
     if (chkerr(rc,__LINE__,u_FILE_u)) return
 
     call med_map_field_normalized(  &

--- a/mediator/med_phases_prep_rof_mod.F90
+++ b/mediator/med_phases_prep_rof_mod.F90
@@ -12,8 +12,8 @@ module med_phases_prep_rof_mod
 
   use med_kind_mod          , only : CX=>SHR_KIND_CX, CS=>SHR_KIND_CS, CL=>SHR_KIND_CL, R8=>SHR_KIND_R8
   use ESMF                  , only : ESMF_FieldBundle, ESMF_Field
-  use med_internalstate_mod , only : complnd, compglc, comprof, mapconsd, mapfcopy
-  use med_internalstate_mod , only : InternalState, maintask, logunit, , map_fracname_lnd2rof
+  use med_internalstate_mod , only : complnd, compglc, comprof, mapconsd, mapconsf, mapfcopy
+  use med_internalstate_mod , only : InternalState, maintask, logunit, map_fracname_lnd2rof
   use med_constants_mod     , only : dbug_flag        => med_constants_dbug_flag
   use med_constants_mod     , only : czero            => med_constants_czero
   use med_utils_mod         , only : chkerr           => med_utils_chkerr
@@ -383,22 +383,26 @@ contains
     ! custom merge for glc->rof
     ! glc->rof is mapped in med_phases_post_glc
     do ns = 1,is_local%wrap%num_icesheets
-       if (is_local%wrap%med_coupling_active(compglc(ns),comprof)) then
-          do nf = 1,size(fldnames_fr_glc)
-             call fldbun_getdata1d(is_local%wrap%FBImp(compglc(ns),comprof), &
-                  trim(fldnames_fr_glc(nf)), dataptr_in, rc)
-             call fldbun_getdata1d(is_local%wrap%FBExp(comprof), &
-                  trim(fldnames_fr_glc(nf)), dataptr_out , rc)
-             ! Determine export data
-             if (ns == 1) then
-                dataptr_out(:) = dataptr_in(:)
-             else
-                dataptr_out(:) = dataptr_out(:) + dataptr_in(:)
-             end if
-          end do
-       end if
+      if (is_local%wrap%med_coupling_active(compglc(ns),comprof)) then
+        do nf = 1,size(fldnames_fr_glc)
+          if ( fldbun_fldchk(is_local%wrap%FBImp(compglc(ns),comprof), fldnames_fr_glc(nf), rc=rc) .and. &
+               fldbun_fldchk(is_local%wrap%FBExp(comprof), fldnames_fr_glc(nf), rc=rc) ) then
+            call fldbun_getdata1d(is_local%wrap%FBImp(compglc(ns),comprof), &
+                 trim(fldnames_fr_glc(nf)), dataptr_in, rc)
+            if (chkerr(rc,__LINE__,u_FILE_u)) return
+            call fldbun_getdata1d(is_local%wrap%FBExp(comprof), &
+                 trim(fldnames_fr_glc(nf)), dataptr_out , rc)
+            if (chkerr(rc,__LINE__,u_FILE_u)) return
+            ! Determine export data
+            if (ns == 1) then
+              dataptr_out(:) = dataptr_in(:)
+            else
+              dataptr_out(:) = dataptr_out(:) + dataptr_in(:)
+            end if
+          end if
+        end do
+      end if
     end do
-
 
     ! Check for nans in fields export to rof
     call FB_check_for_nans(is_local%wrap%FBExp(comprof), maintask, logunit, rc=rc)

--- a/mediator/med_phases_prep_rof_mod.F90
+++ b/mediator/med_phases_prep_rof_mod.F90
@@ -12,8 +12,8 @@ module med_phases_prep_rof_mod
 
   use med_kind_mod          , only : CX=>SHR_KIND_CX, CS=>SHR_KIND_CS, CL=>SHR_KIND_CL, R8=>SHR_KIND_R8
   use ESMF                  , only : ESMF_FieldBundle, ESMF_Field
-  use med_internalstate_mod , only : complnd, compglc, comprof, mapconsd, mapconsf, mapfcopy
-  use med_internalstate_mod , only : InternalState, maintask, logunit, map_fracname_lnd2rof
+  use med_internalstate_mod , only : complnd, compglc, comprof, mapconsf, mapfcopy
+  use med_internalstate_mod , only : InternalState, maintask, logunit
   use med_constants_mod     , only : dbug_flag        => med_constants_dbug_flag
   use med_constants_mod     , only : czero            => med_constants_czero
   use med_utils_mod         , only : chkerr           => med_utils_chkerr
@@ -23,6 +23,7 @@ module med_phases_prep_rof_mod
   use med_methods_mod       , only : fldbun_reset     => med_methods_FB_reset
   use med_methods_mod       , only : fldbun_average   => med_methods_FB_average
   use med_methods_mod       , only : field_getdata1d  => med_methods_Field_getdata1d
+  use med_methods_mod       , only : fldbun_fldchk    => med_methods_FB_fldchk
   use med_methods_mod       , only : FB_check_for_nans => med_methods_FB_check_for_nans
   use perf_mod              , only : t_startf, t_stopf
 
@@ -646,7 +647,7 @@ contains
     !     convert to a total irrigation flux on the ROF grid
     ! ------------------------------------------------------------------------
 
-    call ESMF_FieldBundleGet(is_local%wrap%FBFrac(complnd), map_fracname_lnd2rof, field=field_lfrac_lnd, rc=rc)
+    call ESMF_FieldBundleGet(is_local%wrap%FBFrac(complnd), 'lfrac', field=field_lfrac_lnd, rc=rc)
     if (chkerr(rc,__LINE__,u_FILE_u)) return
 
     call med_map_field_normalized(  &


### PR DESCRIPTION
### Description of changes
Adds capability to run the atm and lnd components on different grids

### Specific notes
- Original analysis from @billsacks: 
See section 3.2.3 in https://docs.google.com/document/d/144PZ63gwpz875U4EYEI7NuxnF__V955QJOxV9LcEAL0/edit# (starting on p. 14).

- New analysis from @billsacks :
It seems like we can get conservation in the glc mappings if we consistently use lfrin in those mappings / merges as well. @billsacks has  put some more notes here: https://docs.google.com/document/d/1Npv8njQV1SDwKn2hW35fO2GgE3ciemu4Hqfxg7ZyJKs/edit#heading=h.24mbe68cyqy7

In particular see new notes at the top level of `med_fraction_mod.F90` in this PR.

Contributors other than yourself, if any: @billsacks 

CMEPS Issues Fixed (include github issue #):

Are changes expected to change answers? bfb as long as atm/lnd are on the same grid, more substantial otherwise (simulations are being carried out for NorESM to validate this)

Any User Interface Changes? No

### Testing performed
Using a sandbox that started with cesm3_0_alpha01a and 

```
 ccs_config at tag ccs_config_cesm0.0.109
                 share at tag share1.0.19
s                 cime cime6.0.250 67ade4a156ca53f89e118be6a272aef375d0fd08 is out of sync with .gitmodules cime6.0.246
                   mct at tag MCT_2.11.0
            mpi-serial at tag MPIserial_2.5.0
                   cam at tag cam6_3_162
                   ww3 at tag ww3i_0.0.2
                   rtm at tag rtm1_0_78
                pysect at tag 3.2.2
s               mosart mosart1.1.02 e2ffe00004cc416cfc8bcfae2a949474075c1d1f is out of sync with .gitmodules feature/cism2mosart
             mizuroute at tag cesm-coupling.n02_v2.1.2_rme02
                   fms at tag fi_240516
            parallelio at tag pio2_6_2
s                cdeps cdeps1.0.37 b4b3ac5bba287d1420657e47e4bf3ee329c4594d is out of sync with .gitmodules cdeps1.0.36
s                cmeps cmeps0.14.70 b2cb575e0ef382e7d3c5bebc87fcb423dff09ce3 is out of sync with .gitmodules feature/cism2mosart
                  cice at tag cesm_cice6_4_1_10_rme01
s                 cism cismwrap_2_1_99-43-g3433977 34339777afa7b810fd4822fce1039826668b33e4 is out of sync with .gitmodules feature/cism2mosart_cesm
```

Verified that the following 2 tests worked were bfb when the trigrid branch was substituted for cmeps0.14.70
- SMS_Ld3.ne30pg3_t232.BLT1850_v0c.derecho_intel
- SMS_Ln9.f09_f09_mg17.F2000dev.derecho_intel.cam-outfrq9s_mg3

