### PR TITLE
Remove negative runoff

### DIFF
--- a/cime_config/namelist_definition_drv.xml
+++ b/cime_config/namelist_definition_drv.xml
@@ -872,6 +872,17 @@
       <value COMP_LND="xlnd">off</value>
     </values>
   </entry>
+  <entry id="remove_negative_runoff">
+    <type>logical</type>
+    <category>control</category>
+    <group>MED_attributes</group>
+    <desc>
+      If true, remove negative runoff by downweighting all positive runoff globally.
+    </desc>
+    <values>
+      <value>.true.</value>
+    </values>
+  </entry>
 
   <entry id="info_debug" modify_via_xml="INFO_DBUG">
     <type>integer</type>

--- a/mediator/med.F90
+++ b/mediator/med.F90
@@ -1622,7 +1622,7 @@ contains
     use med_phases_post_lnd_mod , only : med_phases_post_lnd
     use med_phases_post_glc_mod , only : med_phases_post_glc
     use med_phases_post_ocn_mod , only : med_phases_post_ocn
-    use med_phases_post_rof_mod , only : med_phases_post_rof
+    use med_phases_post_rof_mod , only : med_phases_post_rof_init, med_phases_post_rof
     use med_phases_post_wav_mod , only : med_phases_post_wav
     use med_phases_ocnalb_mod   , only : med_phases_ocnalb_run
     use med_phases_aofluxes_mod , only : med_phases_aofluxes_init_fldbuns
@@ -1922,6 +1922,10 @@ contains
       !---------------------------------------
       if (is_local%wrap%med_coupling_active(comprof,complnd)) then
          call med_phases_prep_rof_init(gcomp, rc=rc)
+         if (ChkErr(rc,__LINE__,u_FILE_u)) return
+      end if
+      if (is_local%wrap%comp_present(comprof)) then
+         call med_phases_post_rof_init(gcomp, rc=rc)
          if (ChkErr(rc,__LINE__,u_FILE_u)) return
       end if
       !---------------------------------------

--- a/mediator/med_phases_post_rof_mod.F90
+++ b/mediator/med_phases_post_rof_mod.F90
@@ -120,6 +120,7 @@ contains
     real(r8), pointer   :: data_orig(:)
     real(r8), pointer   :: data_copy(:)
     integer             :: n
+    logical             :: exists
     character(len=*), parameter :: subname='(med_phases_post_rof)'
     !---------------------------------------
 
@@ -144,8 +145,12 @@ contains
 
     if (remove_negative_runoff) then
       do n = 1, size(fields_to_remove_negative_runoff)
-        call med_phases_post_rof_remove_negative_runoff(gcomp, fields_to_remove_negative_runoff(n), rc)
+        call ESMF_FieldBundleGet(FBrof_r, fieldName=trim(fields_to_remove_negative_runoff(n)), isPresent=exists, rc=rc)
         if (ChkErr(rc,__LINE__,u_FILE_u)) return
+        if (exists) then
+          call med_phases_post_rof_remove_negative_runoff(gcomp, fields_to_remove_negative_runoff(n), rc)
+          if (ChkErr(rc,__LINE__,u_FILE_u)) return
+        end if
       end do
     end if
 

--- a/mediator/med_phases_post_rof_mod.F90
+++ b/mediator/med_phases_post_rof_mod.F90
@@ -2,10 +2,26 @@ module med_phases_post_rof_mod
 
   ! Post rof phase, if appropriate, map initial rof->lnd, rof->ocn, rof->ice
 
+  use NUOPC_Mediator        , only : NUOPC_MediatorGet
+  use ESMF                  , only : ESMF_Clock, ESMF_ClockIsCreated
+  use ESMF                  , only : ESMF_LogWrite, ESMF_LOGMSG_INFO, ESMF_LOGMSG_ERROR, ESMF_SUCCESS, ESMF_FAILURE
+  use ESMF                  , only : ESMF_GridComp, ESMF_GridCompGet
+  use ESMF                  , only : ESMF_VM, ESMF_VMAllreduce, ESMF_REDUCE_SUM
+  use med_kind_mod          , only : CX=>SHR_KIND_CX, CS=>SHR_KIND_CS, CL=>SHR_KIND_CL, R8=>SHR_KIND_R8
+  use med_internalstate_mod , only : complnd, compocn, compice, comprof
+  use med_internalstate_mod , only : InternalState, maintask, logunit
+  use med_utils_mod         , only : chkerr    => med_utils_ChkErr
+  use med_constants_mod     , only : dbug_flag => med_constants_dbug_flag
+  use med_phases_history_mod, only : med_phases_history_write_comp
+  use med_map_mod           , only : med_map_field_packed
+  use med_methods_mod       , only : fldbun_getdata1d => med_methods_FB_getdata1d
+  use perf_mod              , only : t_startf, t_stopf
+
   implicit none
   private
 
-  public :: med_phases_post_rof
+  public  :: med_phases_post_rof
+  private :: med_phases_post_rof_remove_negative_runoff
 
   character(*) , parameter :: u_FILE_u = &
        __FILE__
@@ -15,19 +31,6 @@ contains
 !================================================================================================
 
   subroutine med_phases_post_rof(gcomp, rc)
-
-    use NUOPC_Mediator        , only : NUOPC_MediatorGet
-    use ESMF                  , only : ESMF_Clock, ESMF_ClockIsCreated
-    use ESMF                  , only : ESMF_LogWrite, ESMF_LOGMSG_INFO, ESMF_LOGMSG_ERROR, ESMF_SUCCESS, ESMF_FAILURE
-    use ESMF                  , only : ESMF_GridComp, ESMF_GridCompGet
-    use med_kind_mod          , only : CX=>SHR_KIND_CX, CS=>SHR_KIND_CS, CL=>SHR_KIND_CL, R8=>SHR_KIND_R8
-    use med_internalstate_mod , only : complnd, compocn, compice, comprof
-    use med_utils_mod         , only : chkerr    => med_utils_ChkErr
-    use med_constants_mod     , only : dbug_flag => med_constants_dbug_flag
-    use med_internalstate_mod , only : InternalState
-    use med_phases_history_mod, only : med_phases_history_write_comp
-    use med_map_mod           , only : med_map_field_packed
-    use perf_mod              , only : t_startf, t_stopf
 
     ! input/output variables
     type(ESMF_GridComp)  :: gcomp
@@ -48,6 +51,11 @@ contains
 
     nullify(is_local%wrap)
     call ESMF_GridCompGetInternalState(gcomp, is_local, rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+
+    call med_phases_post_rof_remove_negative_runoff(gcomp, 'Forr_rofl', rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+    call med_phases_post_rof_remove_negative_runoff(gcomp, 'Forr_rofi', rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
 
     ! map rof to lnd
@@ -104,5 +112,139 @@ contains
     call t_stopf('MED:'//subname)
 
   end subroutine med_phases_post_rof
+
+  subroutine med_phases_post_rof_remove_negative_runoff(gcomp, field_name, rc)
+    !---------------------------------------------------------------
+    ! For one runoff field, remove negative runoff by downweighting all positive runoff to
+    ! spread the negative runoff globally.
+
+    ! input/output variables
+    type(ESMF_GridComp)  :: gcomp
+    character(len=*), intent(in) :: field_name  ! name of runoff flux field to process
+    integer, intent(out) :: rc
+
+    ! local variables
+    type(InternalState) :: is_local
+    type(ESMF_VM)       :: vm
+    real(r8), pointer   :: runoff_flux(:)  ! temporary 1d pointer
+    real(r8), pointer   :: areas(:)
+    real(r8)            :: local_positive(1), global_positive(1)
+    real(r8)            :: local_negative(1), global_negative(1)
+    real(r8)            :: global_sum
+    real(r8)            :: multiplier
+    real(r8)            :: local_positive_final(1), global_positive_final(1)
+    real(r8)            :: local_negative_final(1), global_negative_final(1)
+    real(r8)            :: global_sum_final
+    integer :: n
+
+    integer, parameter :: dbug_threshold = 20 ! threshold for writing debug information in this subroutine
+    character(len=*), parameter :: subname='(med_phases_post_rof_mod: med_phases_post_rof_remove_negative_runoff)'
+    !---------------------------------------
+
+    rc = ESMF_SUCCESS
+
+    call t_startf('MED:'//subname)
+    if (dbug_flag > dbug_threshold) then
+      call ESMF_LogWrite(trim(subname)//": called", ESMF_LOGMSG_INFO)
+    end if
+
+    nullify(is_local%wrap)
+    call ESMF_GridCompGetInternalState(gcomp, is_local, rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+
+    ! Note that we don't use rof fractions in the global sum. This is consistent with the
+    ! global budget calculations in med_diag_mod and is because the rof fractions are 1
+    ! everywhere.
+    areas => is_local%wrap%mesh_info(comprof)%areas
+
+    call fldbun_getdata1d(is_local%wrap%FBImp(comprof,comprof), trim(field_name), runoff_flux, rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+
+    local_positive(1) = 0.0_r8
+    local_negative(1) = 0.0_r8
+    do n = 1, size(runoff_flux)
+      if (runoff_flux(n) >= 0.0_r8) then
+        local_positive(1) = local_positive(1) + areas(n) * runoff_flux(n)
+      else
+        local_negative(1) = local_negative(1) + areas(n) * runoff_flux(n)
+      end if
+    end do
+
+    call ESMF_GridCompGet(gcomp, vm=vm, rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+    call ESMF_VMAllreduce(vm, senddata=local_positive, recvdata=global_positive, count=1, &
+         reduceflag=ESMF_REDUCE_SUM, rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+    call ESMF_VMAllreduce(vm, senddata=local_negative, recvdata=global_negative, count=1, &
+         reduceflag=ESMF_REDUCE_SUM, rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+    global_sum = global_positive(1) + global_negative(1)
+    if (maintask .and. dbug_flag > dbug_threshold) then
+      write(logunit,'(a)') subname//' Before correction: '//trim(field_name)
+      write(logunit,'(a,e27.17)') subname//' global_positive = ', global_positive(1)
+      write(logunit,'(a,e27.17)') subname//' global_negative = ', global_negative(1)
+      write(logunit,'(a,e27.17)') subname//' global_sum      = ', global_sum
+    end if
+
+    if (global_sum > 0.0_r8) then
+      ! There is enough positive runoff to absorb all of the negative runoff; so set
+      ! negative runoff to 0 and downweight positive runoff to conserve.
+      multiplier = global_sum/global_positive(1)
+      do n = 1, size(runoff_flux)
+        if (runoff_flux(n) > 0.0_r8) then
+          runoff_flux(n) = runoff_flux(n) * multiplier
+        else
+          runoff_flux(n) = 0.0_r8
+        end if
+      end do
+    else if (global_sum < 0.0_r8) then
+      ! There is more negative than positive runoff. Hopefully this happens rarely, if
+      ! ever; so set positive runoff to 0 and downweight negative runoff to minimize
+      ! negative runoff and conserve.
+      multiplier = global_sum/global_negative(1)
+      do n = 1, size(runoff_flux)
+        if (runoff_flux(n) < 0.0_r8) then
+          runoff_flux(n) = runoff_flux(n) * multiplier
+        else
+          runoff_flux(n) = 0.0_r8
+        end if
+      end do
+    else
+      ! global_sum == 0 - i.e., positive and negative exactly balance (very rare, unless
+      ! the fluxes are already 0 everywhere!); set all fluxes to 0 in this case.
+      do n = 1, size(runoff_flux)
+        runoff_flux(n) = 0.0_r8
+      end do
+    end if
+
+    if (dbug_flag > dbug_threshold) then
+      ! Recompute positives, negatives and total sum for output diagnostic purposes
+      local_positive_final(1) = 0.0_r8
+      local_negative_final(1) = 0.0_r8
+      do n = 1, size(runoff_flux)
+        if (runoff_flux(n) >= 0.0_r8) then
+          local_positive_final(1) = local_positive_final(1) + areas(n) * runoff_flux(n)
+        else
+          local_negative_final(1) = local_negative_final(1) + areas(n) * runoff_flux(n)
+        end if
+      end do
+      call ESMF_VMAllreduce(vm, senddata=local_positive_final, recvdata=global_positive_final, count=1, &
+           reduceflag=ESMF_REDUCE_SUM, rc=rc)
+      if (ChkErr(rc,__LINE__,u_FILE_u)) return
+      call ESMF_VMAllreduce(vm, senddata=local_negative_final, recvdata=global_negative_final, count=1, &
+           reduceflag=ESMF_REDUCE_SUM, rc=rc)
+      if (ChkErr(rc,__LINE__,u_FILE_u)) return
+      global_sum_final = global_positive_final(1) + global_negative_final(1)
+      if (maintask) then
+        write(logunit,'(a)') subname//' After correction: '//trim(field_name)
+        write(logunit,'(a,e27.17)') subname//' global_positive_final = ', global_positive_final(1)
+        write(logunit,'(a,e27.17)') subname//' global_negative_final = ', global_negative_final(1)
+        write(logunit,'(a,e27.17)') subname//' global_sum_final      = ', global_sum_final
+      end if
+    end if
+
+    call t_stopf('MED:'//subname)
+
+  end subroutine med_phases_post_rof_remove_negative_runoff
 
 end module med_phases_post_rof_mod

--- a/mediator/med_phases_post_rof_mod.F90
+++ b/mediator/med_phases_post_rof_mod.F90
@@ -40,8 +40,11 @@ module med_phases_post_rof_mod
 
   logical :: remove_negative_runoff
 
-  character(len=9), parameter :: fields_to_remove_negative_runoff(2) = &
-       ['Forr_rofl', 'Forr_rofi']
+  character(len=13), parameter :: fields_to_remove_negative_runoff(4) = &
+       ['Forr_rofl    ', &
+        'Forr_rofi    ', &
+        'Forr_rofl_glc', &
+        'Forr_rofi_glc']
 
   character(*) , parameter :: u_FILE_u = &
        __FILE__


### PR DESCRIPTION
### Description of changes

Remove negative runoff before mapping rof -> ocn by setting negative runoff to 0 and downweighting all positive runoff appropriately so that the global runoff sum is the same as before.

### Specific notes

Contributors other than yourself, if any: @mvertens 

CMEPS Issues Fixed (include github issue #):
- Resolves #405 

Are changes expected to change answers? (specify if bfb, different at roundoff, more substantial) : **Yes - changes answers substantially for runoff fields in B compsets (or other configurations with both active land/river and active ocean) (appears not to change answers in most / all other configurations)**

Any User Interface Changes (namelist or namelist defaults changes)? New namelist item: remove_negative_runoff (true by default)

### Testing performed
Tested in the context of cesm2_3_beta17

Ran a number of tests using compset `1850_CAM60_CLM50%BGC-CROP_CICE_POP2%ECO_MOSART_SGLC_WW3_SESP_BGC%BDRD` and res `f19_g17`.
- Confirmed that answers change as expected for runoff. Based on output to stdout (with dbug_flag = 21) and doing some visual spot-checks, confirmed that behavior is as expected: negative runoff is set to 0, positive is downweighted evenly globally, runoff sum (when multiplied by area) is maintained as before.
- Confirmed that, with the remove_negative_runoff flag set to false, answers are bit-for-bit with before

Also ran aux_cmeps test suite on derecho; all tests passed and were bit-for-bit except for tests that also failed in the baseline:

```
    FAIL ERS_Ld5.T62_g17.CMOM.derecho_gnu RUN time=17

    FAIL ERR_Ld5.f09_t061.B1850MOM.derecho_intel.allactive-defaultio SHAREDLIB_BUILD failed to initialize
    FAIL ERS_Ld5.f19_g17.I2000Clm51Bgc.derecho_intel.clm-default CREATE_NEWCASE
    FAIL ERS_Ld5.ne30pg3_t232.BLT1850_v0c.derecho_intel.allactive-defaultio RUN time=729

    FAIL ERP_Ln9.f09_f09_mg17.F2000climo.derecho_nvhpc.cam-outfrq9s MODEL_BUILD time=388
    FAIL ERS_Ld5.T62_g17.GMOM_JRA.derecho_nvhpc MODEL_BUILD time=559
```

I think the passing tests were bit-for-bit because they didn't include any B compset tests, and it appears that runoff is non-negative in the tests that use drof.

I also ran one nag test on izumi, which also passed and was bit-for-bit: `SMS_D_Ld5_P32.f10_f10_mg37.I2000Clm50BgcCropRtm.izumi_nag.rtm-default` (I didn't run the full aux_cmeps test suite on izumi, because I noticed that most of the izumi aux_cmeps tests failed in the baseline).