### PR TITLE
this call is no longer needed and removing it fully removes the mct l…

### DIFF
--- a/cesm/driver/esm.F90
+++ b/cesm/driver/esm.F90
@@ -796,7 +796,6 @@ contains
 #ifndef NO_MPI2
     use mpi          , only : MPI_COMM_NULL, mpi_comm_size
 #endif
-    use m_MCTWorld   , only : mct_world_init => init
 
 #ifdef MED_PRESENT
     use med_internalstate_mod , only : med_id
@@ -1163,9 +1162,6 @@ contains
        if (chkerr(rc,__LINE__,u_FILE_u)) return
 
     enddo
-
-    call mct_world_init(componentCount+1, GLOBAL_COMM, comms, comps)
-
 
     deallocate(petlist, comms, comps, comp_iamin, comp_comm_iam)
 


### PR DESCRIPTION
this call is no longer needed and removing it fully removes the mct library from cesm.   
### Description of changes
remove call to mpi_init
### Specific notes

Contributors other than yourself, if any:

CMEPS Issues Fixed (include github issue #):

Are changes expected to change answers? (specify if bfb, different at roundoff, more substantial) 

Any User Interface Changes (namelist or namelist defaults changes)?

### Testing performed
Please describe the tests along with the target model and machine(s) 
If possible, please also added hashes that were used in the testing

