### PR TITLE
gnu reports an error if this unused variable is not allocated

### DIFF
--- a/mediator/med_phases_aofluxes_mod.F90
+++ b/mediator/med_phases_aofluxes_mod.F90
@@ -1604,6 +1604,10 @@ end subroutine med_aofluxes_map_ogrid2xgrid_input
        if (add_gusts) then
           call fldbun_getfldptr(fldbun_a, 'Faxa_rainc', aoflux_in%rainc, xgrid=xgrid, rc=rc)
           if (chkerr(rc,__LINE__,u_FILE_u)) return
+       else
+          ! rainc is not used without add_gusts but some compilers complain about the unallocated pointer
+          ! in the subroutine interface
+          allocate(aoflux_in%rainc(1))
        end if
     end if
 


### PR DESCRIPTION
### Description of changes
Add an allocate for the rainc variable which is only use if add_gusts is enabled.
### Specific notes

Contributors other than yourself, if any:

CMEPS Issues Fixed (include github issue #):

Are changes expected to change answers? bfb

Any User Interface Changes (namelist or namelist defaults changes)? No

### Testing performed SMS_D_Ln9.f19_f19_mg17.F2000climo.derecho_gnu.cam-outfrq9s.
Please describe the tests along with the target model and machine(s) 
If possible, please also added hashes that were used in the testing

