### PR TITLE
make sure variables are allocated before deallocating

### DIFF
--- a/mediator/med_io_mod.F90
+++ b/mediator/med_io_mod.F90
@@ -1086,7 +1086,15 @@ contains
        call pio_syncfile(io_file)
        call pio_freedecomp(io_file, iodesc)
     endif
-    deallocate(ownedElemCoords, ownedElemCoords_x, ownedElemCoords_y)
+    if(allocated(ownedElemCoords)) then
+       deallocate(ownedElemCoords)
+    endif
+    if(allocated(ownedElemCoords_x)) then
+       deallocate(ownedElemCoords_x)
+    endif
+    if(allocated(ownedElemCoords_y)) then
+       deallocate(ownedElemCoords_y)
+    endif
 
     if (dbug_flag > 5) then
        call ESMF_LogWrite(trim(subname)//": done", ESMF_LOGMSG_INFO)


### PR DESCRIPTION
### Description of changes
Add a check to make sure variables are allocated before deallocating

### Specific notes
This came up when Cecile was trying to write a restart with the BMT compset.
Contributors other than yourself, if any:

CMEPS Issues Fixed (include github issue #):

Are changes expected to change answers? (specify if bfb, different at roundoff, more substantial) 

Any User Interface Changes (namelist or namelist defaults changes)?

### Testing performed
Please describe the tests along with the target model and machine(s) 
If possible, please also added hashes that were used in the testing

