### PR TITLE
Declare cnt variable needed with ESMF_AWARE_THREADING

### DIFF
--- a/cesm/driver/esm.F90
+++ b/cesm/driver/esm.F90
@@ -877,6 +877,9 @@ contains
     character(len=5)               :: inst_suffix
     character(CL)                  :: cvalue
     logical                        :: found_comp
+#ifdef ESMF_AWARE_THREADING
+    integer                        :: cnt
+#endif
     integer :: rank, nprocs, ierr
     character(len=*), parameter    :: subname = "(esm_pelayout.F90:esm_init_pelayout)"
     !---------------------------------------


### PR DESCRIPTION
### Description of changes

This was mistakenly removed in 4d9073d8 when cleaning up unused variables.

### Specific notes

Contributors other than yourself, if any:

CMEPS Issues Fixed (include github issue #): Resolves ESCOMP/CMEPS#482

Are changes expected to change answers? no

Any User Interface Changes (namelist or namelist defaults changes)? no

### Testing performed
Please describe the tests along with the target model and machine(s) 
If possible, please also added hashes that were used in the testing

Tested the build of `SMS_D_Ld1_P8x1.f10_f10_mg37.I2000Clm50BgcCropQianRs.green_gnu.clm-default` (on my Mac), in the context of CTSM at ctsm5.2.007, with ESMF_AWARE_THREADING=TRUE.

