### PR TITLE
Fix aux history files for use_float=.true.

### DIFF
--- a/mediator/med.F90
+++ b/mediator/med.F90
@@ -2154,14 +2154,13 @@ contains
              end if
              is_local%wrap%nx(n1) = nint(real_nx)
              is_local%wrap%ny(n1) = nint(real_ny)
-          endif
-          if (is_local%wrap%comp_present(n1)) then
+
              write(msgString,'(3i8)') is_local%wrap%nx(n1), is_local%wrap%ny(n1), is_local%wrap%ntile(n1)
+             call ESMF_LogWrite(trim(subname)//":"//trim(compname(n1))//":"//trim(msgString), ESMF_LOGMSG_INFO)
              if (maintask) then
                 write(logunit,'(a)') 'global nx,ny,ntile sizes for '//trim(compname(n1))//":"//trim(msgString)
              end if
-             call ESMF_LogWrite(trim(subname)//":"//trim(compname(n1))//":"//trim(msgString), ESMF_LOGMSG_INFO)
-          endif
+          end if
        end do
        if (maintask) write(logunit,*)
 

--- a/mediator/med_io_mod.F90
+++ b/mediator/med_io_mod.F90
@@ -870,15 +870,21 @@ contains
 
     ng = maxval(maxIndexPTile)
     if (tiles) then
-      lnx = nx
-      lny = ny
-      lntile = ng/(lnx*lny)
-      write(tmpstr,*) subname, 'ng,lnx,lny,lntile = ',ng,lnx,lny,lntile
-      call ESMF_LogWrite(trim(tmpstr), ESMF_LOGMSG_INFO)
-      if (lntile /= ntile) then
-         call ESMF_LogWrite(trim(subname)//' ERROR: grid2d size and ntile are not consistent ', ESMF_LOGMSG_INFO)
-         call ESMF_Finalize(endflag=ESMF_END_ABORT)
-      endif
+       if (luse_float) then
+          lnx = ntile*ny*nx
+          lny = 1
+          lntile = 1
+       else
+          lnx = nx
+          lny = ny
+          lntile = ng/(lnx*lny)
+          write(tmpstr,*) subname, 'ng,lnx,lny,lntile = ',ng,lnx,lny,lntile
+          call ESMF_LogWrite(trim(tmpstr), ESMF_LOGMSG_INFO)
+          if (lntile /= ntile) then
+             call ESMF_LogWrite(trim(subname)//' ERROR: grid2d size and ntile are not consistent ', ESMF_LOGMSG_INFO)
+             call ESMF_Finalize(endflag=ESMF_END_ABORT)
+          endif
+       end if
     else
       lnx = ng
       lny = 1
@@ -902,7 +908,7 @@ contains
       if (tiles) then
        rcode = pio_def_dim(io_file, trim(lpre)//'_nx', lnx, dimid3(1))
        rcode = pio_def_dim(io_file, trim(lpre)//'_ny', lny, dimid3(2))
-       rcode = pio_def_dim(io_file, trim(lpre)//'_ntile', ntile, dimid3(3))
+       rcode = pio_def_dim(io_file, trim(lpre)//'_ntile', lntile, dimid3(3))
        if (present(nt)) then
           dimid4(1:3) = dimid3
           rcode = pio_inq_dimid(io_file, 'time', dimid4(4))

--- a/mediator/med_io_mod.F90
+++ b/mediator/med_io_mod.F90
@@ -870,30 +870,28 @@ contains
 
     ng = maxval(maxIndexPTile)
     if (tiles) then
-       if (luse_float) then
-          lnx = ntile*ny*nx
-          lny = 1
-          lntile = 1
-       else
-          lnx = nx
-          lny = ny
-          lntile = ng/(lnx*lny)
-          write(tmpstr,*) subname, 'ng,lnx,lny,lntile = ',ng,lnx,lny,lntile
+       lnx = ng
+       lny = 1
+       lntile = 1
+       if (nx > 0) lnx = nx
+       if (ny > 0) lny = ny
+       if (ntile > 0) lntile = ntile
+       write(tmpstr,*) subname, 'ng,lnx,lny,lntile = ',ng,lnx,lny,lntile
+       call ESMF_LogWrite(trim(tmpstr), ESMF_LOGMSG_INFO)
+       if (lnx*lny*lntile /= ng) then
+          write(tmpstr,*) subname,' ERROR: grid size not consistent ',ng,lnx,lny,lntile
           call ESMF_LogWrite(trim(tmpstr), ESMF_LOGMSG_INFO)
-          if (lntile /= ntile) then
-             call ESMF_LogWrite(trim(subname)//' ERROR: grid2d size and ntile are not consistent ', ESMF_LOGMSG_INFO)
-             call ESMF_Finalize(endflag=ESMF_END_ABORT)
-          endif
+          call ESMF_Finalize(endflag=ESMF_END_ABORT)
        end if
     else
-      lnx = ng
-      lny = 1
-      if (nx > 0) lnx = nx
-      if (ny > 0) lny = ny
-      if (lnx*lny /= ng) then
-         write(tmpstr,*) subname,' WARNING: grid2d size not consistent ',ng,lnx,lny
-         call ESMF_LogWrite(trim(tmpstr), ESMF_LOGMSG_INFO)
-      endif
+       lnx = ng
+       lny = 1
+       if (nx > 0) lnx = nx
+       if (ny > 0) lny = ny
+       if (lnx*lny /= ng) then
+          write(tmpstr,*) subname,' WARNING: grid2d size not consistent ',ng,lnx,lny
+          call ESMF_LogWrite(trim(tmpstr), ESMF_LOGMSG_INFO)
+       endif
     end if
     deallocate(minIndexPTile, maxIndexPTile)
 

--- a/mediator/med_io_mod.F90
+++ b/mediator/med_io_mod.F90
@@ -1029,9 +1029,9 @@ contains
           if (luse_float) then
              call pio_initdecomp(io_subsystem, pio_real, (/lnx,lny/), dof, iodesc)
           else
-          call pio_initdecomp(io_subsystem, pio_double, (/lnx,lny/), dof, iodesc)
+             call pio_initdecomp(io_subsystem, pio_double, (/lnx,lny/), dof, iodesc)
           end if
-         !call pio_writedof(lpre, (/lnx,lny/), int(dof,kind=PIO_OFFSET_KIND), mpicom)
+          !call pio_writedof(lpre, (/lnx,lny/), int(dof,kind=PIO_OFFSET_KIND), mpicom)
        end if
        deallocate(dof)
 
@@ -1065,16 +1065,16 @@ contains
                    call pio_setframe(io_file,varid,frame)
 
                    if (luse_float) then
-                   if (gridToFieldMap(1) == 1) then
+                      if (gridToFieldMap(1) == 1) then
                          call pio_write_darray(io_file, varid, iodesc, real(fldptr2(:,n),r4), rcode, fillval=real(lfillvalue,r4))
                       else if (gridToFieldMap(1) == 2) then
                          call pio_write_darray(io_file, varid, iodesc, real(fldptr2(n,:),r4), rcode, fillval=real(lfillvalue,r4))
                       end if
                    else
                       if (gridToFieldMap(1) == 1) then
-                      call pio_write_darray(io_file, varid, iodesc, fldptr2(:,n), rcode, fillval=lfillvalue)
-                   else if (gridToFieldMap(1) == 2) then
-                      call pio_write_darray(io_file, varid, iodesc, fldptr2(n,:), rcode, fillval=lfillvalue)
+                         call pio_write_darray(io_file, varid, iodesc, fldptr2(:,n), rcode, fillval=lfillvalue)
+                      else if (gridToFieldMap(1) == 2) then
+                         call pio_write_darray(io_file, varid, iodesc, fldptr2(n,:), rcode, fillval=lfillvalue)
                       end if
                    end if
                 end do
@@ -1087,7 +1087,7 @@ contains
                 if (luse_float) then
                    call pio_write_darray(io_file, varid, iodesc, real(fldptr1,r4), rcode, fillval=real(lfillvalue,r4))
                 else
-                call pio_write_darray(io_file, varid, iodesc, fldptr1, rcode, fillval=lfillvalue)
+                   call pio_write_darray(io_file, varid, iodesc, fldptr1, rcode, fillval=lfillvalue)
                 end if
              end if  ! end if rank is 2 or 1 or 0
 
@@ -1100,7 +1100,7 @@ contains
        if (luse_float) then
           call pio_write_darray(io_file, varid, iodesc, real(ownedElemCoords_x,r4), rcode, fillval=real(lfillvalue,r4))
        else
-       call pio_write_darray(io_file, varid, iodesc, ownedElemCoords_x, rcode, fillval=lfillvalue)
+          call pio_write_darray(io_file, varid, iodesc, ownedElemCoords_x, rcode, fillval=lfillvalue)
        end if
 
        rcode = pio_inq_varid(io_file, trim(coordvarnames(2)), varid)
@@ -1108,7 +1108,7 @@ contains
        if (luse_float) then
           call pio_write_darray(io_file, varid, iodesc, real(ownedElemCoords_y,r4), rcode, fillval=real(lfillvalue,r4))
        else
-       call pio_write_darray(io_file, varid, iodesc, ownedElemCoords_y, rcode, fillval=lfillvalue)
+          call pio_write_darray(io_file, varid, iodesc, ownedElemCoords_y, rcode, fillval=lfillvalue)
        end if
        call pio_syncfile(io_file)
        call pio_freedecomp(io_file, iodesc)

--- a/mediator/med_phases_history_mod.F90
+++ b/mediator/med_phases_history_mod.F90
@@ -1062,6 +1062,7 @@ contains
     logical                 :: enable_auxfile
     character(CL)           :: time_units        ! units of time variable
     integer                 :: nx,ny             ! global grid size
+    integer                 :: ntile             ! number of tiles for tiled domain eg CSG
     logical                 :: write_now         ! if true, write time sample to file
     real(r8)                :: time_val          ! time coordinate output
     real(r8)                :: time_bnds(2)      ! time bounds output
@@ -1268,6 +1269,7 @@ contains
           ! Set shorthand variables
           nx = is_local%wrap%nx(compid)
           ny = is_local%wrap%ny(compid)
+          ntile = is_local%wrap%ntile(compid)
 
           ! Increment number of time samples on file
           auxcomp%files(nf)%nt = auxcomp%files(nf)%nt + 1
@@ -1303,7 +1305,7 @@ contains
              call med_io_write(auxcomp%files(nf)%io_file, is_local%wrap%FBimp(compid,compid), &
                   whead(1), wdata(1), nx, ny, nt=auxcomp%files(nf)%nt, &
                   pre=trim(compname(compid))//'Imp', flds=auxcomp%files(nf)%flds, &
-                  use_float=.true., rc=rc)
+                  use_float=.true., ntile=ntile, rc=rc)
              if (ChkErr(rc,__LINE__,u_FILE_u)) return
 
              ! end definition phase
@@ -1318,14 +1320,14 @@ contains
           if (auxcomp%files(nf)%doavg) then
              call med_io_write(auxcomp%files(nf)%io_file, auxcomp%files(nf)%FBaccum, whead(2), wdata(2), nx, ny, &
                   nt=auxcomp%files(nf)%nt, pre=trim(compname(compid))//'Imp', flds=auxcomp%files(nf)%flds, &
-                  use_float=.true.,rc=rc)
+                  use_float=.true., ntile=ntile, rc=rc)
              if (ChkErr(rc,__LINE__,u_FILE_u)) return
              call med_methods_FB_reset(auxcomp%files(nf)%FBaccum, value=czero, rc=rc)
              if (ChkErr(rc,__LINE__,u_FILE_u)) return
           else
              call med_io_write(auxcomp%files(nf)%io_file, is_local%wrap%FBimp(compid,compid), whead(2), wdata(2), nx, ny, &
                   nt=auxcomp%files(nf)%nt, pre=trim(compname(compid))//'Imp', flds=auxcomp%files(nf)%flds, &
-                  use_float=.true.,rc=rc)
+                  use_float=.true., ntile=ntile, rc=rc)
              if (ChkErr(rc,__LINE__,u_FILE_u)) return
           end if
 

--- a/mediator/med_phases_history_mod.F90
+++ b/mediator/med_phases_history_mod.F90
@@ -357,11 +357,13 @@ contains
              end if
              if (ESMF_FieldBundleIsCreated(is_local%wrap%FBMed_ocnalb_a,rc=rc)) then
                 call med_io_write(io_file, is_local%wrap%FBMed_ocnalb_a, whead(m), wdata(m), &
-                     is_local%wrap%nx(compatm), is_local%wrap%ny(compatm), nt=1, pre='Med_alb_atm', rc=rc)
+                     is_local%wrap%nx(compatm), is_local%wrap%ny(compatm), nt=1, pre='Med_alb_atm', &
+                     ntile=is_local%wrap%ntile(compatm), rc=rc)
              end if
              if (ESMF_FieldBundleIsCreated(is_local%wrap%FBMed_aoflux_a,rc=rc)) then
                 call med_io_write(io_file, is_local%wrap%FBMed_aoflux_a, whead(m), wdata(m), &
-                     is_local%wrap%nx(compatm), is_local%wrap%ny(compatm), nt=1, pre='Med_aoflux_atm', rc=rc)
+                     is_local%wrap%nx(compatm), is_local%wrap%ny(compatm), nt=1, pre='Med_aoflux_atm', &
+                     ntile=is_local%wrap%ntile(compatm), rc=rc)
              end if
 
           end do ! end of loop over whead/wdata m index phases
@@ -495,7 +497,8 @@ contains
              end if
              if (ESMF_FieldBundleIsCreated(is_local%wrap%FBMed_aoflux_a,rc=rc)) then
                 call med_io_write(instfiles(compmed)%io_file, is_local%wrap%FBMed_aoflux_a, whead(m), wdata(m), &
-                     is_local%wrap%nx(compatm), is_local%wrap%ny(compatm), nt=1, pre='Med_aoflux_atm', rc=rc)
+                     is_local%wrap%nx(compatm), is_local%wrap%ny(compatm), nt=1, pre='Med_aoflux_atm', &
+                     ntile=is_local%wrap%ntile(compatm), rc=rc)
              end if
 
              ! If appropriate - write ocn albedos computed in mediator
@@ -505,7 +508,8 @@ contains
              end if
              if (ESMF_FieldBundleIsCreated(is_local%wrap%FBMed_ocnalb_a,rc=rc)) then
                 call med_io_write(instfiles(compmed)%io_file, is_local%wrap%FBMed_ocnalb_a, whead(m), wdata(m), &
-                     is_local%wrap%nx(compatm), is_local%wrap%ny(compatm), nt=1, pre='Med_alb_atm', rc=rc)
+                     is_local%wrap%nx(compatm), is_local%wrap%ny(compatm), nt=1, pre='Med_alb_atm', &
+                     ntile=is_local%wrap%ntile(compatm), rc=rc)
              end if
           end do ! end of loop over m
 
@@ -1313,13 +1317,15 @@ contains
           ! Write data variables for time nt
           if (auxcomp%files(nf)%doavg) then
              call med_io_write(auxcomp%files(nf)%io_file, auxcomp%files(nf)%FBaccum, whead(2), wdata(2), nx, ny, &
-                  nt=auxcomp%files(nf)%nt, pre=trim(compname(compid))//'Imp', flds=auxcomp%files(nf)%flds, rc=rc)
+                  nt=auxcomp%files(nf)%nt, pre=trim(compname(compid))//'Imp', flds=auxcomp%files(nf)%flds, &
+                  use_float=.true.,rc=rc)
              if (ChkErr(rc,__LINE__,u_FILE_u)) return
              call med_methods_FB_reset(auxcomp%files(nf)%FBaccum, value=czero, rc=rc)
              if (ChkErr(rc,__LINE__,u_FILE_u)) return
           else
              call med_io_write(auxcomp%files(nf)%io_file, is_local%wrap%FBimp(compid,compid), whead(2), wdata(2), nx, ny, &
-                  nt=auxcomp%files(nf)%nt, pre=trim(compname(compid))//'Imp', flds=auxcomp%files(nf)%flds, rc=rc)
+                  nt=auxcomp%files(nf)%nt, pre=trim(compname(compid))//'Imp', flds=auxcomp%files(nf)%flds, &
+                  use_float=.true.,rc=rc)
              if (ChkErr(rc,__LINE__,u_FILE_u)) return
           end if
 


### PR DESCRIPTION
### Description of changes

Fixes aux history output to correctly implement ``use_float = .true.``.
For UFS, fixes mediator history write for ocnalb_a and aoflux_a FBs when ATM is a CSG or regional (single tiled) domain.
Fixes garbled print message for global scalar dimensions when component exists but NState does not

CMEPS Issues Fixed (include github issue #):
- fixes #430 

Are changes expected to change answers? (specify if bfb, different at roundoff, more substantial) 

Aux history files generated with the current code and with ``use_float=.true.`` would be expected to be different. UFS currently has no comparison case for aux history files.

Any User Interface Changes (namelist or namelist defaults changes)?

No

### Testing performed

Using UFS, instantaneous and average aux history files for OCN were generated for two cases: current code ([ce9cfe2](https://github.com/ESCOMP/CMEPS/commit/ce9cfe287907720f1cf159e1f9aff68865a75c5a)) with ``use_float=.false.`` hardwired and with this feature branch. The file output was compared using ``cprnc -m r4file r8file``. All fields were reported as B4B, and 10 fields were marked as different data types.

