### PR TITLE
nan was picked up in pslv field on first pass

### DIFF
--- a/mediator/med_methods_mod.F90
+++ b/mediator/med_methods_mod.F90
@@ -2609,6 +2609,7 @@ contains
     do index=1,fieldCount
        call med_methods_FB_getNameN(FB, index, fieldname, rc)
        if (chkerr(rc,__LINE__,u_FILE_u)) return
+
        call ESMF_FieldBundleGet(FB, fieldName=fieldname, field=field, rc=rc)
        if (chkerr(rc,__LINE__,u_FILE_u)) return
        call ESMF_FieldGet(field, rank=fieldrank, name=fieldname, rc=rc)
@@ -2632,9 +2633,8 @@ contains
     if (nanfound) then
        call ESMF_LogWrite('ABORTING JOB', ESMF_LOGMSG_ERROR, line=__LINE__, file=u_FILE_u)
        rc = ESMF_FAILURE
-       return
     end if
-
+    
   end subroutine med_methods_FB_check_for_nans
 
   !-----------------------------------------------------------------------------

--- a/mediator/med_phases_prep_ocn_mod.F90
+++ b/mediator/med_phases_prep_ocn_mod.F90
@@ -266,6 +266,7 @@ contains
     ! local variables
     type(InternalState)        :: is_local
     integer                    :: ncnt
+    logical, save              :: first_call = .true.
     character(len=*),parameter :: subname='(med_phases_prep_ocn_avg)'
     !---------------------------------------
 
@@ -306,9 +307,10 @@ contains
        if (ChkErr(rc,__LINE__,u_FILE_u)) return
 
        ! Check for nans in fields export to ocn
-       call FB_check_for_nans(is_local%wrap%FBExp(compocn), maintask, logunit, rc=rc)
-       if (ChkErr(rc,__LINE__,u_FILE_u)) return
-
+       if(.not. first_call) then
+          call FB_check_for_nans(is_local%wrap%FBExp(compocn), maintask, logunit, rc=rc)
+          if (ChkErr(rc,__LINE__,u_FILE_u)) return
+       endif
        ! zero accumulator
        is_local%wrap%ExpAccumOcnCnt = 0
        call FB_reset(is_local%wrap%FBExpAccumOcn, value=czero, rc=rc)
@@ -320,6 +322,7 @@ contains
        call ESMF_LogWrite(trim(subname)//": done", ESMF_LOGMSG_INFO)
     end if
     call t_stopf('MED:'//subname)
+    first_call = .false.
 
   end subroutine med_phases_prep_ocn_avg
 


### PR DESCRIPTION
### Description of changes
Skip nan test in med_phases_prep_ocn_mod.F90 on first pass.   This is to avoid detecting nan's in the as yet undefined pslv field passed from atm.

### Specific notes

Contributors other than yourself, if any:

CMEPS Issues Fixed (include github issue #):

Are changes expected to change answers? (specify if bfb, different at roundoff, more substantial) 

Any User Interface Changes (namelist or namelist defaults changes)?

### Testing performed
Please describe the tests along with the target model and machine(s) 
If possible, please also added hashes that were used in the testing
The test that found this error was SMS_D_Ld2.ne30pg3_t232.BMT1850.derecho_gnu.allactive-defaultio
in cesm3_0_beta02.  I first tried to make the change in atm_import_export.F90 in the cam nuopc interface code, but that didn't seem to work.  


