### PR TITLE
Add marbl

### DIFF
--- a/cime_config/config_component_cesm.xml
+++ b/cime_config/config_component_cesm.xml
@@ -111,8 +111,6 @@
       <value compset="_DATM%CPLHIST.+BLOM%ECO">CO2A</value>
       <value compset="^OMIP_DATM%IAF.*_MOM6%[^_]*MARBL">CO2A</value>
       <value compset="^OMIP_DATM%JRA.*_MOM6%[^_]*MARBL">CO2A</value>
-      <value compset="^OMIP_DATM%IAF.*_POP2%[^_]*ECO">CO2A</value>
-      <value compset="^OMIP_DATM%JRA.*_POP2%[^_]*ECO">CO2A</value>
       <value compset="HIST.*_DATM.*_CLM">CO2A</value>
       <value compset="SSP.*_DATM.*_CLM">CO2A</value>
       <value compset="_BGC%BPRP">CO2C</value>
@@ -238,15 +236,12 @@
       <!-- =================================================== -->
       <!-- C compsets -->
       <!-- =================================================== -->
-      <value compset="_DATM.*_DICE.*_POP2">24</value>
       <value compset="_DATM.*_DICE.*_MOM6">24</value>
       <value compset="_DATM.*_DICE.*_BLOM">24</value>
       <!-- NOTE: currently a NUOPC runseqence cannot be generated with the ATM_NCPL < OCN_NCPL -->
       <!-- =================================================== -->
       <!-- G compsets -->
       <!-- =================================================== -->
-      <value compset="_DATM.*_SLND.*_CICE.*_POP2">24</value>
-      <value compset="_DATM.*_SLND.*_CICE.*_POP2" grid="oi%tx0.1v3">144</value>
       <value compset="_DATM.*_SLND.*_CICE.*_MOM6">24</value>
       <value compset="_DATM.*_SLND.*_CICE.*_BLOM">24</value>
       <value compset="_DATM.*_CICE.*_DOCN">24</value>
@@ -332,11 +327,6 @@
     <values match="last">
       <value compset="_MOM6">24</value>
       <value compset="_BLOM">24</value>
-      <value compset="_POP2" grid="oi%gx3v7">1</value>
-      <value compset="_POP2" grid="oi%gx1v6">24</value>
-      <value compset="_POP2" grid="oi%gx1v7">24</value>
-      <value compset="_POP2" grid="oi%tx0.1v2">48</value>
-      <value compset="_POP2" grid="oi%tx0.1v3">48</value>
       <value compset="_DLND.*_CISM\d">1</value>
       <value compset="_NEMO">24</value>
     </values>
@@ -388,7 +378,6 @@
     <type>integer</type>
     <default_value>8</default_value>
     <values match="last">
-      <value compset="_DATM.*_POP2.*_DROF" grid="oi%gx3v7">1</value>
       <value compset="_DATM.*_MOM6.*_DROF"        >$ATM_NCPL</value>
       <value compset="_DATM.*_BLOM.*_DROF"        >$ATM_NCPL</value>
       <value compset="_DATM.*_DOCN%SOM"           >$ATM_NCPL</value>
@@ -477,11 +466,8 @@
     <default_value>TIGHT</default_value>
     <values match="last">
       <value compset="_DATM.*_DOCN%SOM"               >OPTION2</value>
-      <value compset="_POP2"                          >OPTION2</value>
       <value compset="_MOM6"                          >OPTION1</value>
       <value compset="_BLOM"                          >OPTION1</value>
-      <value compset="_POP2" grid="oi%gx1v6"          >OPTION1</value>
-      <value compset="_POP2" grid="oi%gx1v7"          >OPTION1</value>
       <value compset="_DATM%NYF.*_SLND.*_DICE.*_DOCN"	>OPTION2</value>
       <value compset="_XATM.*_XLND.*_XICE.*_XOCN"     >OPTION2</value>
       <value compset="_SOCN"                          >OPTION2</value>
@@ -558,8 +544,6 @@
     <values match="last">
       <value compset="^2000">367.0</value>
       <value compset="DATM.*_MOM6%[^_]*MARBL">284.317</value>
-      <value compset="DATM.*_POP2%[^_]*ECO">284.317</value>
-      <value compset="DATM.*_POP2%[^_]*ECOCESM20">284.7</value>
     </values>
     <group>run_co2</group>
     <file>env_run.xml</file>

--- a/cime_config/config_component_cesm.xml
+++ b/cime_config/config_component_cesm.xml
@@ -109,6 +109,8 @@
       <value compset="_DATM">none</value>
       <value compset="_DATM%CPLHIST.+POP\d">CO2A</value>
       <value compset="_DATM%CPLHIST.+BLOM%ECO">CO2A</value>
+      <value compset="^OMIP_DATM%IAF.*_MOM6%[^_]*MARBL">CO2A</value>
+      <value compset="^OMIP_DATM%JRA.*_MOM6%[^_]*MARBL">CO2A</value>
       <value compset="^OMIP_DATM%IAF.*_POP2%[^_]*ECO">CO2A</value>
       <value compset="^OMIP_DATM%JRA.*_POP2%[^_]*ECO">CO2A</value>
       <value compset="HIST.*_DATM.*_CLM">CO2A</value>
@@ -496,6 +498,7 @@
     <default_value>284.7</default_value>
     <values match="last">
       <value compset="^2000">367.0</value>
+      <value compset="DATM.*_MOM6%[^_]*MARBL">284.317</value>
       <value compset="DATM.*_POP2%[^_]*ECO">284.317</value>
       <value compset="DATM.*_POP2%[^_]*ECOCESM20">284.7</value>
     </values>


### PR DESCRIPTION
### Description of changes

Update CESM component environment variables when turning MARBL tracers on changes expected default values.
Also removed default values that are based on having POP2 as the ocean component since it is no longer available.

### Specific notes

Want `CCSM_BGC=CO2A` and `CCSM_CO2_PPMV=284.317` when MOM6 is configured with MARBL tracers.

Contributors other than yourself, if any:

CMEPS Issues Fixed (include github issue #):

Are changes expected to change answers? This is technically bit-for-bit since it will not change answers unless MARBL is turned on and there are currently no tests with MARBL active.

Any User Interface Changes (namelist or namelist defaults changes)?

### Testing performed

I've run `aux_mom` with these changes, and confirmed bfb in non-MARBL configurations.
