### PR TITLE
Simplify logic for glc_renormalize_smb

### DIFF
--- a/cime_config/buildnml
+++ b/cime_config/buildnml
@@ -98,7 +98,7 @@ def _create_drv_namelists(case, infile, confdir, nmlgen, files):
     else:
         config["single_column"] = "false"
 
-    # needed for determining the run sequence as well as glc_renormalize_smb
+    # needed for determining the run sequence
     config["COMP_ATM"] = case.get_value("COMP_ATM")
     config["COMP_ICE"] = case.get_value("COMP_ICE")
     config["COMP_GLC"] = case.get_value("COMP_GLC")

--- a/cime_config/namelist_definition_drv.xml
+++ b/cime_config/namelist_definition_drv.xml
@@ -843,32 +843,26 @@
     <type>char</type>
     <category>control</category>
     <group>MED_attributes</group>
-    <valid_values>on,off,on_if_glc_coupled_fluxes</valid_values>
+    <valid_values>on,off</valid_values>
     <desc>
       Whether to renormalize the surface mass balance (smb) sent from lnd to glc so that the
       global integral on the glc grid agrees with the global integral on the lnd grid.
 
-      Unlike most fluxes, smb is remapped with bilinear rather than conservative mapping weights,
-      so this option is needed for conservation. However, conservation is not required in many
-      cases, since we often run glc as a diagnostic (one-way-coupled) component.
+      Unlike most fluxes, smb is remapped with bilinear rather than conservative mapping
+      weights, so this option is needed for conservation. However, this can be turned off
+      in non-fully-coupled configurations where conservation isn't important (e.g.,
+      glc-only configurations - T compsets) to avoid the global correction that comes with
+      this renormalization.
 
       Allowable values are:
-      'on': always do this renormalization
-      'off': never do this renormalization (see WARNING below)
-      'on_if_glc_coupled_fluxes': Determine at runtime whether to do this renormalization.
-         Does the renormalization if we're running a two-way-coupled glc that sends fluxes
-         to other components (which is the case where we need conservation).
-         Does NOT do the renormalization if we're running a one-way-coupled glc, or if
-         we're running a glc-only compset (T compsets).
-         (In these cases, conservation is not important.)
+      'on': do this renormalization
+      'off': do not do this renormalization; note that this will break conservation so
+         typically should not be used in fully-coupled cases
 
-      Only used if running with a prognostic GLC component.
-
-      WARNING: Setting this to 'off' will break conservation when running with an
-      evolving, two-way-coupled glc.
+      Only used if running with a GLC component.
     </desc>
     <values>
-      <value>on_if_glc_coupled_fluxes</value>
+      <value>on</value>
       <value COMP_LND="xlnd">off</value>
     </values>
   </entry>

--- a/doc/source/addendum/req_attributes_cesm.rst
+++ b/doc/source/addendum/req_attributes_cesm.rst
@@ -101,24 +101,19 @@ Mediator land-ice component attribtes
   Whether to renormalize the surface mass balance (smb) sent from lnd to glc so that the
   global integral on the glc grid agrees with the global integral on the lnd grid.
 
-  Unlike most fluxes, smb is remapped with bilinear rather than conservative mapping weights,
-  so this option is needed for conservation. However, conservation is not required in many
-  cases, since we often run glc as a diagnostic (one-way-coupled) component.
+  Unlike most fluxes, smb is remapped with bilinear rather than conservative mapping
+  weights, so this option is needed for conservation. However, this can be turned off in
+  non-fully-coupled configurations where conservation isn't important (e.g., glc-only
+  configurations - T compsets) to avoid the global correction that comes with this
+  renormalization.
 
   Allowable values are:
-  ``on``: always do this renormalization
+  ``on``: do this renormalization
 
-  ``off``: never do this renormalization (see WARNING below)
+  ``off``: do not do this renormalization; note that this will break conservation so
+  typically should not be used in fully-coupled cases
 
-  ``on_if_glc_coupled_fluxes``: Determine at runtime whether to do this renormalization.
-  Does the renormalization if we're running a two-way-coupled glc that sends fluxes
-  to other components (which is the case where we need conservation).
-  Does NOT do the renormalization if we're running a one-way-coupled glc, or if
-  we're running a glc-only compset (T compsets).
-  (In these cases, conservation is not important.)
-  Only used if running with a prognostic GLC component.
-  WARNING: Setting this to 'off' will break conservation when running with an
-  evolving, two-way-coupled glc.
+  Only used if running with a GLC component.
 
 **glc_avg_period**
   Period at which coupler averages fields sent to GLC (the land-ice component).

--- a/mediator/med_phases_prep_glc_mod.F90
+++ b/mediator/med_phases_prep_glc_mod.F90
@@ -135,7 +135,6 @@ contains
     type(ESMF_Mesh)     :: mesh_o
     type(ESMF_Field)    :: lfield
     character(len=CS)   :: glc_renormalize_smb
-    logical             :: glc_coupled_fluxes
     integer             :: ungriddedUBound_output(1) ! currently the size must equal 1 for rank 2 fieldds
     character(len=*),parameter  :: subname=' (med_phases_prep_glc_init) '
     !---------------------------------------
@@ -234,25 +233,11 @@ contains
        call NUOPC_CompAttributeGet(gcomp, name='glc_renormalize_smb', value=glc_renormalize_smb, rc=rc)
        if (chkerr(rc,__LINE__,u_FILE_u)) return
 
-       ! TODO: talk to Bill Sacks to determine if this is the correct logic
-       glc_coupled_fluxes = is_local%wrap%med_coupling_active(compglc(1),complnd)
-       ! Note glc_coupled_fluxes should be false in the no_evolve cases
-       ! Goes back to the zero-gcm fluxes variable - if zero-gcm fluxes is true than do not renormalize
-       ! The user can set this to true in an evolve cases
-
        select case (glc_renormalize_smb)
        case ('on')
           smb_renormalize = .true.
        case ('off')
           smb_renormalize = .false.
-       case ('on_if_glc_coupled_fluxes')
-          if (.not. glc_coupled_fluxes) then
-             ! Do not renormalize if med_coupling_active is not true for compglc->complnd
-             ! In this case, conservation is not important
-             smb_renormalize = .false.
-          else
-             smb_renormalize = .true.
-          end if
        case default
           write(logunit,*) subname,' ERROR: unknown value for glc_renormalize_smb: ', trim(glc_renormalize_smb)
           call ESMF_LogWrite(trim(subname)//' ERROR: unknown value for glc_renormalize_smb: '// trim(glc_renormalize_smb), &


### PR DESCRIPTION
### Description of changes

Remove the glc_renormalize_smb option on_if_glc_coupled_fluxes. This had been the default. Change the default to 'on'. This maintains consistent behavior between different configurations.

### Specific notes

Contributors other than yourself, if any:

CMEPS Issues Fixed (include github issue #): Resolves ESCOMP/CMEPS#133

Are changes expected to change answers? YES: changes answers by greater than roundoff for T compsets (active GLC with DLND) (now SMB is remapped with renormalization for T compsets by default); answers should be bit-for-bit in all other configurations (unless there is some configuration/combination that I'm not thinking of...)

Any User Interface Changes (namelist or namelist defaults changes)? Removes `on_if_glc_coupled_fluxes` option to `glc_renormalize_smb`

### Testing performed
Please describe the tests along with the target model and machine(s) 
If possible, please also added hashes that were used in the testing

Tested in the context of `cesm3_0_beta02`: ran:
- SMS_Ld5.f10_f10_ais8gris4_mg37.I1850Clm50SpGag.derecho_intel.cism-test_coupling
- SMS_Ld5.f10_f10_mg37.1850_DATM%GSWP3v1_CLM50%SP_SICE_SOCN_MOSART_DGLC%NOEVOLVE_SWAV.derecho_intel [Like an I compset but with DGLC%NOEVOLVE]
- SMS_Ly2.f09_g17_gris20.T1850Gg.derecho_intel

All tests passed; the T compset test changed answers as expected but the other two were bit-for-bit.