### PR TITLE
fix bug in med_diag_mod for ice runoff 

### DIFF
--- a/cime_config/config_component_cesm.xml
+++ b/cime_config/config_component_cesm.xml
@@ -537,10 +537,10 @@
     <default_value>FALSE</default_value>
     <values match="last">
       <value compset="DATM.*_POP\d">TRUE</value>
-      <value compset="DATM.*_MOM\d">TRUE</value>
+      <value compset="DATM.*_MOM">TRUE</value>
       <value compset="DATM.*_BLOM\d">TRUE</value>
       <value compset="CAM.*_MOM\d">TRUE</value>
-      <value compset="CAM.*_BLOM\d">TRUE</value>
+      <value compset="CAM.*_BLOM">TRUE</value>
       <value compset="CAM.*_POP\d">TRUE</value>
       <value compset="CAM.*_DOCN%SOM">TRUE</value>
     </values>

--- a/mediator/esmFldsExchange_cesm_mod.F90
+++ b/mediator/esmFldsExchange_cesm_mod.F90
@@ -3016,16 +3016,14 @@ contains
     !----------------------------------------------------------
     ! to wav: ice thickness from ice
     !----------------------------------------------------------
-    if (wav_coupling_to_cice) then
-       if (phase == 'advertise') then
-          call addfld_from(compice, 'Si_thick')
-          call addfld_to(compwav, 'Si_thick')
-       else
-          if (fldchk(is_local%wrap%FBexp(compwav)         , 'Si_thick', rc=rc) .and. &
-              fldchk(is_local%wrap%FBImp(compice,compice ), 'Si_thick', rc=rc)) then
-             call addmap_from(compice, 'Si_thick', compwav, mapbilnr, 'one', ice2wav_map)
-             call addmrg_to(compwav, 'Si_thick', mrg_from=compice, mrg_fld='Si_thick', mrg_type='copy')
-          end if
+    if (phase == 'advertise') then
+       call addfld_from(compice, 'Si_thick')
+       call addfld_to(compwav, 'Si_thick')
+    else
+       if ( fldchk(is_local%wrap%FBexp(compwav)         , 'Si_thick', rc=rc) .and. &
+            fldchk(is_local%wrap%FBImp(compice,compice ), 'Si_thick', rc=rc)) then
+          call addmap_from(compice, 'Si_thick', compwav, mapbilnr, 'one', ice2wav_map)
+          call addmrg_to(compwav, 'Si_thick', mrg_from=compice, mrg_fld='Si_thick', mrg_type='copy')
        end if
     end if
     !----------------------------------------------------------

--- a/mediator/med_diag_mod.F90
+++ b/mediator/med_diag_mod.F90
@@ -1204,7 +1204,7 @@ contains
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
 
     if ( fldbun_fldchk(is_local%wrap%FBImp(comprof,comprof), 'Forr_rofl_glc', rc=rc)) then
-      call diag_rof(is_local%wrap%FBImp(comprof,comprof), 'Forr_rofi_glc' , f_watr_roff, ic, areas, budget_local, minus=.true., rc=rc)
+      call diag_rof(is_local%wrap%FBImp(comprof,comprof), 'Forr_rofl_glc' , f_watr_roff, ic, areas, budget_local, minus=.true., rc=rc)
       if (ChkErr(rc,__LINE__,u_FILE_u)) return
     end if
     if ( fldbun_fldchk(is_local%wrap%FBImp(comprof,comprof), 'Forr_rofi_glc', rc=rc)) then

--- a/mediator/med_diag_mod.F90
+++ b/mediator/med_diag_mod.F90
@@ -150,8 +150,6 @@ module med_diag_mod
   integer :: f_heat_cond     = unset_index ! heat : heat content of evaporation
   integer :: f_heat_rofl     = unset_index ! heat : heat content of liquid runoff
   integer :: f_heat_rofi     = unset_index ! heat : heat content of ice runoff
-  integer :: f_heat_rofl_glc = unset_index ! heat : heat content of liquid glc runoff
-  integer :: f_heat_rofi_glc = unset_index ! heat : heat content of ice glc runoff
 
   integer :: f_watr_frz      = unset_index ! water: freezing
   integer :: f_watr_melt     = unset_index ! water: melting
@@ -332,16 +330,14 @@ contains
        f_heat_beg = f_heat_frz      ! field  first index for heat
        f_heat_end = f_heat_sen      ! field  last  index for heat
     else if (trim(budget_table_version) == 'v1') then
-       call add_to_budget_diag(budget_diags%fields, f_heat_rain    ,'hrain'     ) ! field  heat : enthalpy of rain
-       call add_to_budget_diag(budget_diags%fields, f_heat_snow    ,'hsnow'     ) ! field  heat : enthalpy of snow
-       call add_to_budget_diag(budget_diags%fields, f_heat_evap    ,'hevap'     ) ! field  heat : enthalpy of evaporation
-       call add_to_budget_diag(budget_diags%fields, f_heat_cond    ,'hcond'     ) ! field  heat : enthalpy of evaporation
-       call add_to_budget_diag(budget_diags%fields, f_heat_rofl    ,'hrofl'     ) ! field  heat : enthalpy of liquid runoff
-       call add_to_budget_diag(budget_diags%fields, f_heat_rofi    ,'hrofi'     ) ! field  heat : enthalpy of ice runoff
-       call add_to_budget_diag(budget_diags%fields, f_heat_rofl_glc,'hrofl_glc' ) ! field  heat : enthalpy of liquid glc runoff
-       call add_to_budget_diag(budget_diags%fields, f_heat_rofi_glc,'hrofi_glc' ) ! field  heat : enthalpy of ice glc runoff
+       call add_to_budget_diag(budget_diags%fields, f_heat_rain  ,'hrain'       ) ! field  heat : enthalpy of rain
+       call add_to_budget_diag(budget_diags%fields, f_heat_snow  ,'hsnow'       ) ! field  heat : enthalpy of snow
+       call add_to_budget_diag(budget_diags%fields, f_heat_evap  ,'hevap'       ) ! field  heat : enthalpy of evaporation
+       call add_to_budget_diag(budget_diags%fields, f_heat_cond  ,'hcond'       ) ! field  heat : enthalpy of evaporation
+       call add_to_budget_diag(budget_diags%fields, f_heat_rofl  ,'hrofl'       ) ! field  heat : enthalpy of liquid runoff
+       call add_to_budget_diag(budget_diags%fields, f_heat_rofi  ,'hrofi'       ) ! field  heat : enthalpy of ice runoff
        f_heat_beg = f_heat_frz      ! field  first index for heat
-       f_heat_end = f_heat_rofi_glc ! field  last  index for heat
+       f_heat_end = f_heat_rofi     ! field  last  index for heat
     end if
 
     ! -----------------------------------------
@@ -1365,12 +1361,25 @@ contains
     call ESMF_GridCompGetInternalState(gcomp, is_local, rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
 
+    ! TODO: will the following be correct if there is more than 1 ice sheet ???
+
+    !-------------------------------
+    ! from mediator to glc
+    !-------------------------------
+
+    ic = c_glc_send
+    ip = period_inst
+
+    do ns = 1,is_local%wrap%num_icesheets
+       areas => is_local%wrap%mesh_info(compglc(ns))%areas
+       call diag_glc(is_local%wrap%FBImp(compglc(ns),compglc(ns)), 'Flgl_qice', f_watr_ioff, ic, areas, budget_local, rc=rc)
+       if (ChkErr(rc,__LINE__,u_FILE_u)) return
+    end do
 
     !-------------------------------
     ! from glc to mediator
     !-------------------------------
 
-    ! TODO: this will not be correct if there is more than 1 ice sheet
     ic = c_glc_recv
     ip = period_inst
 
@@ -1604,10 +1613,6 @@ contains
     call diag_ocn(is_local%wrap%FBExp(compocn), 'Foxx_hrofl', f_heat_rofl , ic, areas, sfrac, budget_local, rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
     call diag_ocn(is_local%wrap%FBExp(compocn), 'Foxx_hrofi', f_heat_rofi , ic, areas, sfrac, budget_local, rc=rc)
-    if (ChkErr(rc,__LINE__,u_FILE_u)) return
-    call diag_ocn(is_local%wrap%FBExp(compocn), 'Foxx_hrofl_glc', f_heat_rofl_glc, ic, areas, sfrac, budget_local, rc=rc)
-    if (ChkErr(rc,__LINE__,u_FILE_u)) return
-    call diag_ocn(is_local%wrap%FBExp(compocn), 'Foxx_hrofi_glc', f_heat_rofi_glc , ic, areas, sfrac, budget_local, rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
 
     budget_local(f_heat_latf,ic,ip) = -budget_local(f_watr_snow,ic,ip)*shr_const_latice

--- a/mediator/med_diag_mod.F90
+++ b/mediator/med_diag_mod.F90
@@ -1361,21 +1361,6 @@ contains
     call ESMF_GridCompGetInternalState(gcomp, is_local, rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
 
-    ! TODO: will the following be correct if there is more than 1 ice sheet ???
-
-    !-------------------------------
-    ! from mediator to glc
-    !-------------------------------
-
-    ic = c_glc_send
-    ip = period_inst
-
-    do ns = 1,is_local%wrap%num_icesheets
-       areas => is_local%wrap%mesh_info(compglc(ns))%areas
-       call diag_glc(is_local%wrap%FBImp(compglc(ns),compglc(ns)), 'Flgl_qice', f_watr_ioff, ic, areas, budget_local, rc=rc)
-       if (ChkErr(rc,__LINE__,u_FILE_u)) return
-    end do
-
     !-------------------------------
     ! from glc to mediator
     !-------------------------------


### PR DESCRIPTION
### Description of changes
fix bug in med_diag_mod for handling ice runoff to and from dglc and also added capability to 
send sea-ice thickness from CICE to WW3. This will only happen if both CICE and WW3 advertise these fields.

### Specific notes

the following change was made in med_diag_mod.F90
```F90
old:
if ( fldbun_fldchk(is_local%wrap%FBImp(comprof,comprof), 'Forr_rofl_glc', rc=rc)) then
  call diag_rof(is_local%wrap%FBImp(comprof,comprof), 'Forr_rofi_glc' , f_watr_roff, ic, areas, budget_local, minus=.true., rc=rc)
endif
```
```F90
new:
if ( fldbun_fldchk(is_local%wrap%FBImp(comprof,comprof), 'Forr_rofl_glc', rc=rc)) then 
  call diag_rof(is_local%wrap%FBImp(comprof,comprof), 'Forr_rofl_glc' , f_watr_roff, ic, areas, budget_local, minus=.true., rc=rc)
end if
```

Contributors other than yourself, if any: @billsacks (who found this issue)

CMEPS Issues Fixed: None

Are changes expected to change answers? bfb

Any User Interface Changes (namelist or namelist defaults changes)? No

### Testing performed
Ran the following  noresm configuration for 7 years

```
GRID: a%ne30np4.pg3_l%ne30np4.pg3_oi%tnx1v4_r%r05_w%null_z%null_g%gris4_m%tnx1v4
COMPSET: 1850_CAM%DEV%LT%NORESM%CAMoslo_CLM51%SP_CICE_BLOM%ECO_MOSART_DGLC%NOEVOLVE_SWAV_SESP
```
and obtained budgets that  looked acceptable.
<img width="1229" alt="Screenshot 2024-08-11 at 7 48 25 PM" src="https://github.com/user-attachments/assets/09068793-cd7d-4174-841b-62b56832d730">

