### PR TITLE
fix problem with no coupler file written at restart interval

### DIFF
--- a/cime_config/runseq/driver_config.py
+++ b/cime_config/runseq/driver_config.py
@@ -79,10 +79,12 @@ class DriverConfig(dict):
                     glc_coupling_time = 86400
         elif (comp_glc == 'dglc'):
             glc_coupling_time = coupling_times["glc_cpl_dt"]
-            stop_option = case.get_value('STOP_OPTION')
-            stop_n = case.get_value('STOP_N')
-            if stop_option == 'nsteps':
-                glc_coupling_time = stop_n*coupling_times["atm_cpl_dt"]
+            is_test = case.get_value("TEST")
+            if not is_test:
+                stop_option = case.get_value('STOP_OPTION')
+                if stop_option == 'nsteps':
+                    stop_n = case.get_value('STOP_N')
+                    glc_coupling_time = stop_n*coupling_times["atm_cpl_dt"]
         elif (comp_glc == 'xglc'):
             glc_coupling_time = coupling_times["glc_cpl_dt"]
         else:


### PR DESCRIPTION
### Description of changes
fix problem with no coupler file written at restart interval

### Specific notes
In the following test ERP_Ln9.ne30pg3_ne30pg3_mtn14.NF1850.betzy_intel.cam-outfrq9
where the compset is 1850_CAM%DEV%LT%NORESM%CAMoslo_CLM51%SP_CICE%PRES_DOCN%DOM_MOSART_DGLC%NOEVOLVE_SWAV_SESP
the glc coupling interval is forced to be the atm coupling interval (i.e. 48) but at the same time the run sequence is forced to be that glc is only called at the end of the run sequence. With this fix - the forcing is removed and there is no longer a descrepancy between the glc coupling interval and the run sequence. This now fixes the ERP test where the compset has DGLC%NOEVOLVE.

Contributors other than yourself, if any: None

CMEPS Issues Fixed: 

Are changes expected to change answers? should be bfb

Any User Interface Changes (namelist or namelist defaults changes)? the run sequence will be different for tests

### Testing performed
Verified that  ERP_Ln9.ne30pg3_ne30pg3_mtn14.NF1850.betzy_intel.cam-outfrq9 now works
