### PR TITLE
variable name mismatch

### DIFF
--- a/cime_config/namelist_definition_drv.xml
+++ b/cime_config/namelist_definition_drv.xml
@@ -2308,7 +2308,7 @@
       ocn to wav state mapping file for states
     </desc>
     <values>
-      <value samegrid_ocn_wav="true">idmap</value>
+      <value samegrid_wav_ocn="true">idmap</value>
       <value>$OCN2WAV_SMAPNAME</value>
     </values>
   </entry>
@@ -2322,7 +2322,7 @@
       wav to ocn state mapping file for states
     </desc>
     <values>
-      <value samegrid_ocn_wav="true">idmap</value>
+      <value samegrid_wav_ocn="true">idmap</value>
       <value>$WAV2OCN_SMAPNAME</value>
     </values>
   </entry>


### PR DESCRIPTION

### Description of changes
buildnml was setting variable samegrid_wav_ocn but namelist_definintion_drv.xml was looking for samegrid_ocn_wav

### Specific notes

Contributors other than yourself, if any:

CMEPS Issues Fixed (include github issue #):

Are changes expected to change answers? (specify if bfb, different at roundoff, more substantial) 

Any User Interface Changes (namelist or namelist defaults changes)?

### Testing performed
Please describe the tests along with the target model and machine(s) 
If possible, please also added hashes that were used in the testing

