### PR TITLE
Update XML variables for GPU configurations

### DIFF
--- a/cime_config/config_component.xml
+++ b/cime_config/config_component.xml
@@ -795,20 +795,38 @@
 
   <entry id="GPU_TYPE">
     <type>char</type>
-    <valid_values></valid_values>
-    <default_value></default_value>
+    <valid_values MACH="derecho">none,a100</valid_values>
+    <default_value>none</default_value>
     <group>build_def</group>
     <file>env_build.xml</file>
     <desc>If set will compile and submit with this gpu type enabled </desc>
   </entry>
 
-  <entry id="GPU_OFFLOAD">
-    <type>char</type>
-    <valid_values></valid_values>
-    <default_value></default_value>
+  <entry id="OPENACC_GPU_OFFLOAD">
+    <type>logical</type>
+    <valid_values>TRUE,FALSE</valid_values>
+    <default_value>FALSE</default_value>
     <group>build_def</group>
     <file>env_build.xml</file>
-    <desc>If set will compile and submit with this gpu offload method enabled </desc>
+    <desc>True=>compile the GPU code with OpenACC GPU flags </desc>
+  </entry>
+
+  <entry id="OPENMP_GPU_OFFLOAD">
+    <type>logical</type>
+    <valid_values>TRUE,FALSE</valid_values>
+    <default_value>FALSE</default_value>
+    <group>build_def</group>
+    <file>env_build.xml</file>
+    <desc>True=>compile the GPU code with OpenMP GPU flags </desc>
+  </entry>
+
+  <entry id="KOKKOS_GPU_OFFLOAD">
+    <type>logical</type>
+    <valid_values>TRUE,FALSE</valid_values>
+    <default_value>FALSE</default_value>
+    <group>build_def</group>
+    <file>env_build.xml</file>
+    <desc>True=>compile the GPU code with KOKKOS GPU target </desc>
   </entry>
 
   <entry id="MPI_GPU_WRAPPER_SCRIPT">
@@ -818,7 +836,7 @@
     <group>build_def</group>
     <file>env_build.xml</file>
     <desc>If set will attach this script to the MPI run command, mapping
-    different MPI ranks to different GPUs within the same compute node</desc>
+    different MPI ranks to different GPUs within the same compute node </desc>
   </entry>
 
   <entry id="ESMF_AWARE_THREADING">
@@ -1774,33 +1792,36 @@
   <entry id="MAX_CPUTASKS_PER_GPU_NODE">
     <type>integer</type>
     <default_value>0</default_value>
-    <values>
-      <value compiler="nvhpc">1</value>
-    </values>
     <group>mach_pes_last</group>
     <file>env_mach_pes.xml</file>
-    <desc> Number of CPU cores per GPU node used for simulation </desc>
+    <desc>Number of CPU cores per GPU node used for simulation </desc>
+  </entry>
+
+  <entry id="OVERSUBSCRIBE_GPU">
+    <type>logical</type>
+    <valid_values>TRUE,FALSE</valid_values>
+    <default_value>FALSE</default_value>
+    <group>mach_pes</group>
+    <file>env_mach_pes.xml</file>
+    <desc>False=>assign only one MPI task per GPU; True=>assign multiple MPI tasks per GPU </desc>
   </entry>
 
   <entry id="NGPUS_PER_NODE">
     <type>integer</type>
     <default_value>0</default_value>
-    <values>
-      <value compiler="nvhpc">1</value>
-    </values>
     <group>mach_pes</group>
     <file>env_mach_pes.xml</file>
-    <desc> Number of GPUs per node used for simulation </desc>
+    <desc>Number of GPUs per node used for simulation </desc>
   </entry>
-
+  
   <entry id="MAX_GPUS_PER_NODE">
     <type>integer</type>
     <default_value>0</default_value>
     <group>mach_pes_last</group>
     <file>env_mach_pes.xml</file>
-    <desc>maximum number of GPUs allowed per node </desc>
+    <desc>Maximum number of GPUs allowed per node </desc>
   </entry>
-
+  
   <entry id="COSTPES_PER_NODE">
     <type>integer</type>
     <default_value>$MAX_MPITASKS_PER_NODE</default_value>


### PR DESCRIPTION
As discussed in https://github.com/ESMCI/cime/pull/4687, it is better remove the GPU options from the Python workflow in CIME and use XML files instead to configure them for CESM.

This PR introduces the necessary changes to accomplish this goal.

It should work together with the following PRs:
- CIME: https://github.com/ESMCI/cime/pull/4690
- ccs_config_cesm: https://github.com/ESMCI/ccs_config_cesm/pull/189