### PR TITLE
add memory usage variables for use on derecho

### DIFF
--- a/cime_config/config_component.xml
+++ b/cime_config/config_component.xml
@@ -1753,6 +1753,22 @@
     <desc>pes or cores per node for accounting purposes </desc>
   </entry>
 
+  <entry id="MEM_PER_TASK">
+    <type>integer</type>
+    <default_value>0</default_value>
+    <group>mach_pes_last</group>
+    <file>env_mach_pes.xml</file>
+    <desc>minimum memory request per node (currently only used on derecho)</desc>
+  </entry>
+
+  <entry id="MAX_MEM_PER_NODE">
+    <type>integer</type>
+    <default_value>0</default_value>
+    <group>mach_pes_last</group>
+    <file>env_mach_pes.xml</file>
+    <desc>maximum memory request per node (currently only used on derecho)</desc>
+  </entry>
+
   <entry id="MAX_CPUTASKS_PER_GPU_NODE">
     <type>integer</type>
     <default_value>0</default_value>


### PR DESCRIPTION
### Description of changes
Adds variables MEM_PER_TASK and MAX_MEM_PER_NODE for greater control of memory options on derecho - it can also be used elsewhere but initially only on derecho, requires cime and ccs_config changes.

### Specific notes

Contributors other than yourself, if any:

CMEPS Issues Fixed (include github issue #):

Are changes expected to change answers? (specify if bfb, different at roundoff, more substantial) 

Any User Interface Changes (namelist or namelist defaults changes)?

### Testing performed
Please describe the tests along with the target model and machine(s) 
If possible, please also added hashes that were used in the testing

