### PR TITLE
Fix logic for adding psfc to aoflux_in

### DIFF
--- a/mediator/med_phases_aofluxes_mod.F90
+++ b/mediator/med_phases_aofluxes_mod.F90
@@ -1647,6 +1647,8 @@ end subroutine med_aofluxes_map_ogrid2xgrid_input
     if (FB_fldchk(fldbun_a, 'Sa_pslv', rc=rc)) then
        call fldbun_getfldptr(fldbun_a, 'Sa_pslv', aoflux_in%psfc, xgrid=xgrid, rc=rc)
        if (chkerr(rc,__LINE__,u_FILE_u)) return
+    else
+       allocate(aoflux_in%psfc(lsize))
     end if
 
     ! if either density or potential temperature are computed, will need bottom level pressure

--- a/mediator/med_phases_aofluxes_mod.F90
+++ b/mediator/med_phases_aofluxes_mod.F90
@@ -1644,8 +1644,13 @@ end subroutine med_aofluxes_map_ogrid2xgrid_input
        if (chkerr(rc,__LINE__,u_FILE_u)) return
     end if
 
+    ! The following conditional captures the cases where aoflux_in%psfc is needed in calls
+    ! to flux_atmocn / flux_atmocn_ccpp. Note that coupling_mode=='cesm' is equivalent to
+    ! the CESMCOUPLED CPP token, and coupling_mode(1:3)=='ufs' is roughly equivalent to
+    ! the UFS_AOFLUX CPP token (noting that we should only be in this subroutine if using
+    ! one of the aoflux variants of the ufs coupling_mode).
     if ((trim(coupling_mode) == 'cesm') .or. &
-         (trim(coupling_mode) == 'ufs.frac.aoflux' .and. trim(aoflux_code) == 'ccpp')) then
+         (coupling_mode(1:3) == 'ufs' .and. trim(aoflux_code) == 'ccpp')) then
        call fldbun_getfldptr(fldbun_a, 'Sa_pslv', aoflux_in%psfc, xgrid=xgrid, rc=rc)
        if (chkerr(rc,__LINE__,u_FILE_u)) return
     end if

--- a/mediator/med_phases_aofluxes_mod.F90
+++ b/mediator/med_phases_aofluxes_mod.F90
@@ -1644,21 +1644,16 @@ end subroutine med_aofluxes_map_ogrid2xgrid_input
        if (chkerr(rc,__LINE__,u_FILE_u)) return
     end if
 
-    if (FB_fldchk(fldbun_a, 'Sa_pslv', rc=rc)) then
+    if ((trim(coupling_mode) == 'cesm') .or. &
+         (trim(coupling_mode) == 'ufs.frac.aoflux' .and. trim(aoflux_code) == 'ccpp')) then
        call fldbun_getfldptr(fldbun_a, 'Sa_pslv', aoflux_in%psfc, xgrid=xgrid, rc=rc)
        if (chkerr(rc,__LINE__,u_FILE_u)) return
-    else
-       allocate(aoflux_in%psfc(lsize))
     end if
 
     ! if either density or potential temperature are computed, will need bottom level pressure
     if (compute_atm_dens .or. compute_atm_thbot) then
        call fldbun_getfldptr(fldbun_a, 'Sa_pbot', aoflux_in%pbot, xgrid=xgrid, rc=rc)
        if (chkerr(rc,__LINE__,u_FILE_u)) return
-       if (trim(coupling_mode) == 'ufs.frac.aoflux') then
-          call fldbun_getfldptr(fldbun_a, 'Sa_pslv', aoflux_in%psfc, xgrid=xgrid, rc=rc)
-          if (chkerr(rc,__LINE__,u_FILE_u)) return
-       end if
     end if
 
     if (flds_wiso) then


### PR DESCRIPTION
### Description of changes

Fix the logic for adding psfc to aoflux_in, particularly needed for cases using the exchange grid.

This is needed to avoid a segmentation fault in the call to flux_atmocn in SMS_Ld2.ne30pg3_t232.BMT1850.derecho_gnu.allactive-defaultio when running with aoflux_grid=xgrid. (This shows up when running with xgrid because the FB_fldchk can't be used in this situation - see details in my [comment below](https://github.com/ESCOMP/CMEPS/pull/514#issuecomment-2427645256).)

### Specific notes

Contributors other than yourself, if any:

CMEPS Issues Fixed (include github issue #):

Are changes expected to change answers? No

Any User Interface Changes (namelist or namelist defaults changes)? No

### Testing performed

SMS_Ld2.ne30pg3_t232.BMT1850.derecho_gnu.allactive-defaultio with aoflux_grid="xgrid", from cesm3_0_beta03

Also ran many other tests from the CESM prealpha and prebeta test suite.
