### PR TITLE
Make xgrid the default aoflux_grid when atm and ocn are running on different grids

### DIFF
--- a/cime_config/namelist_definition_drv.xml
+++ b/cime_config/namelist_definition_drv.xml
@@ -925,7 +925,10 @@
       default: ogrid
     </desc>
     <values>
-      <value>ogrid</value>
+      <value>xgrid</value>
+      <!-- xgrid introduces unnecessary cost and complexity if atm & ocn are on the same
+      grid, so fall back to ogrid in that case -->
+      <value samegrid_atm_ocn='true'>ogrid</value>
     </values>
   </entry>
   <entry id="ocn_surface_flux_scheme">

--- a/cime_config/testdefs/testlist_drv.xml
+++ b/cime_config/testdefs/testlist_drv.xml
@@ -65,6 +65,16 @@
     </options>
   </test>
 
+  <test compset="X" grid="f19_g17" name="ERS_D_Ln9" testmods="drv/aoflux_ogrid">
+    <machines>
+      <machine name="derecho" compiler="intel" category="aux_cmeps"/>
+    </machines>
+    <options>
+      <option name="wallclock"> 00:40:00 </option>
+      <option name="comment">The default aoflux_grid is now xgrid; include a debug test with different atm/ocn grids with aoflux_grid=ogrid to make sure that option continues to work.</option>
+    </options>
+  </test>
+
   <!-- ======================================= -->
   <!-- B compsets -->
   <!-- ======================================= -->

--- a/cime_config/testdefs/testmods_dirs/drv/aoflux_ogrid/user_nl_cpl
+++ b/cime_config/testdefs/testmods_dirs/drv/aoflux_ogrid/user_nl_cpl
@@ -1,0 +1,1 @@
+aoflux_grid = "ogrid"


### PR DESCRIPTION
### Description of changes

Use the exchange grid for the atmosphere-ocean flux calculation unless atm & ocn are on the same grid.

Also adds a test of aoflux_grid=ogrid to the aux_cmeps test suite so that that configuration continues to be tested.

### Specific notes

Contributors other than yourself, if any: Consultation with @mvertens on how we should set the default – specifically, continuing to use ogrid when atm & ocn are on the same grid.

CMEPS Issues Fixed (include github issue #):
- Resolves #502 

Are changes expected to change answers? YES - significant answer changes for any configuration where atmosphere-ocean flux calculations are performed and atm & ocn are on different grids.

Any User Interface Changes (namelist or namelist defaults changes)? Changes default value for aoflux_grid

### Testing performed
Please describe the tests along with the target model and machine(s) 
If possible, please also added hashes that were used in the testing

Ran the full CESM prealpha and prebeta test suites on derecho using cesm3_0_beta03, but with the following commits cherry-picked into CMEPS:
- "Use xgrid for aoflux calculation unless atm & ocn are on the same grid" (from this PR)
- "Add a test with aoflux_grid = ogrid" (from this PR)
- "Ensure psfc is always allocated" (from #514)
- "More correct fix to ensure psfc is allocated when needed" (from #514)
- "Merge pull request #501 from billsacks/fix_xgrid_f_compset"
- "Merge pull request #506 from billsacks/fix_xgrid_reproducibility"

I compared my failures with failures in the baselines from @fischer-ncar 's testing. I got a number of additional failures due to tests exceeding walltime limits, which I'm ignoring (7 failures in prealpha and 7 failures in prebeta). I also got a failure in `PET_PM.ne30pg3_t232.BLT1850.derecho_intel.allactive-defaultiomi` and the similar gnu test, `PET_PM.ne30pg3_t232.BLT1850.derecho_gnu.allactive-defaultiomi`, with an error that seems unrelated to the xgrid: "CAM configure: ERROR: The SE dycore does not currently work with threading on." Other than those, tests passed.