### PR TITLE
do not write restart at end of erc test

### DIFF
--- a/cime_config/buildnml
+++ b/cime_config/buildnml
@@ -43,6 +43,7 @@ def _create_drv_namelists(case, infile, confdir, nmlgen, files):
     config["MACH"] = case.get_value("MACH")
     config["MPILIB"] = case.get_value("MPILIB")
     config["OS"] = case.get_value("OS")
+    config["TESTCASE"] = case.get_value("TESTCASE")
     config["glc_nec"] = (
         0 if case.get_value("GLC_NEC") == 0 else case.get_value("GLC_NEC")
     )

--- a/cime_config/namelist_definition_drv.xml
+++ b/cime_config/namelist_definition_drv.xml
@@ -2862,12 +2862,13 @@
       forces a restart write at the end of the run in addition to any
       setting associated with rest_option.  default=true.  this setting
       will be set to false if restart_option is none or never.
-      default: false
+      default: true
     </desc>
     <values>
       <value>.true.</value>
       <value rest_option='none'>.false.</value>
       <value rest_option='never'>.false.</value>
+      <value TESTCASE='ERC'>.false.</value>
     </values>
   </entry>
 


### PR DESCRIPTION
### Description of changes
For the erc test to properly copy restarts from case 1 to case 2 the write_restart_at_endofrun must be .false.

### Specific notes

Contributors other than yourself, if any:

CMEPS Issues Fixed (include github issue #):

Are changes expected to change answers? (specify if bfb, different at roundoff, more substantial) 

Any User Interface Changes (namelist or namelist defaults changes)?

### Testing performed
Please describe the tests along with the target model and machine(s) 
If possible, please also added hashes that were used in the testing
Tested on derecho with test ERC_D_Ln9.f19_f19_mg17.QPC6.derecho_intel.cam-outfrq3s_cosp
