### PR TITLE
restart at end of run needs to be false for these tests

### DIFF
--- a/.github/workflows/extbuild.yml
+++ b/.github/workflows/extbuild.yml
@@ -24,7 +24,7 @@ jobs:
       PNETCDF_VERSION: checkpoint.1.12.3
       NETCDF_FORTRAN_VERSION: v4.6.1
       PIO_VERSION: pio2_6_3
-      CDEPS_VERSION: cdeps1.0.49
+      CDEPS_VERSION: cdeps1.0.59
     steps:
       - uses: actions/checkout@v4
         # Build the ESMF library, if the cache contains a previous build

--- a/cime_config/namelist_definition_drv.xml
+++ b/cime_config/namelist_definition_drv.xml
@@ -2869,6 +2869,8 @@
       <value rest_option='none'>.false.</value>
       <value rest_option='never'>.false.</value>
       <value TESTCASE='ERC'>.false.</value>
+      <value TESTCASE='ERP'>.false.</value>
+      <value TESTCASE='ERI'>.false.</value>
     </values>
   </entry>
 


### PR DESCRIPTION
### Description of changes
ERI test and ERP test cannot have write_restart_at_endofrun 
### Specific notes

Contributors other than yourself, if any:

CMEPS Issues Fixed (include github issue #):

Are changes expected to change answers? (specify if bfb, different at roundoff, more substantial) 

Any User Interface Changes (namelist or namelist defaults changes)?

### Testing performed
Please describe the tests along with the target model and machine(s) 
If possible, please also added hashes that were used in the testing

