### PR TITLE
replace testcase None in config with unset

### DIFF
--- a/cime_config/buildnml
+++ b/cime_config/buildnml
@@ -44,6 +44,8 @@ def _create_drv_namelists(case, infile, confdir, nmlgen, files):
     config["MPILIB"] = case.get_value("MPILIB")
     config["OS"] = case.get_value("OS")
     config["TESTCASE"] = case.get_value("TESTCASE")
+    if not config["TESTCASE"]:
+        config["TESTCASE"] = "UNSET"
     config["glc_nec"] = (
         0 if case.get_value("GLC_NEC") == 0 else case.get_value("GLC_NEC")
     )

--- a/mediator/med.F90
+++ b/mediator/med.F90
@@ -2603,7 +2603,7 @@ contains
     type(ESMF_Array)     :: maskarray
     integer(I4), pointer :: meshmask(:)
     real(R8), pointer    :: r8ptr(:)
-    integer              :: m,n1,n2
+    integer              :: m,n2
     character(CL)        :: case_name, dststatusfile
     logical              :: elementMaskIsPresent
     logical              :: whead(2) = (/.true. , .false./)
@@ -2641,9 +2641,9 @@ contains
                 if (ChkErr(rc,__LINE__,u_FILE_u)) return
                 ! get mask Array
                 call ESMF_FieldGet(maskfield, array=maskarray, rc=rc)
-		if (ChkErr(rc,__LINE__,u_FILE_u)) return
+                if (ChkErr(rc,__LINE__,u_FILE_u)) return
                 call ESMF_MeshGet(mesh_dst, elemMaskArray=maskarray, rc=rc)
-		if (ChkErr(rc,__LINE__,u_FILE_u)) return
+                if (ChkErr(rc,__LINE__,u_FILE_u)) return
                 call ESMF_FieldGet(maskfield, localDe=0, farrayPtr=meshmask, rc=rc)
                 if (ChkErr(rc,__LINE__,u_FILE_u)) return
                 ! now create an R8 mask for writing

--- a/mediator/med_phases_restart_mod.F90
+++ b/mediator/med_phases_restart_mod.F90
@@ -506,7 +506,6 @@ contains
     character(ESMF_MAXSTR) :: case_name      ! case name
     character(ESMF_MAXSTR) :: restart_file   ! Local path to restart filename
     character(ESMF_MAXSTR) :: restart_pfile  ! Local path to restart pointer filename
-    logical                :: isPresent
     character(len=*), parameter :: subname='(med_phases_restart_read)'
     !---------------------------------------
     call t_startf('MED:'//subname)


### PR DESCRIPTION
### Description of changes
When using create_newcase without create_test TESTCASE will not be defined in the env files and will be set to None.  Change None to 'UNSET' so that xml interpolation works with this value.

### Specific notes

Contributors other than yourself, if any:

CMEPS Issues Fixed (include github issue #):
  Fixes #520

Are changes expected to change answers? (specify if bfb, different at roundoff, more substantial) 

Any User Interface Changes (namelist or namelist defaults changes)?

### Testing performed
  This was failing in run_neon under CTSM. With

``` shell
  cd python
  ./run_sys_tests --sys
```

Which passes with this update

