### PR TITLE
[WIP]: Add filenames to cpl.input_data_list, more error messaging, set drv_restart_pointer default to none unless needed

### DIFF
--- a/cesm/driver/esm_time_mod.F90
+++ b/cesm/driver/esm_time_mod.F90
@@ -141,6 +141,7 @@ contains
                 inquire( file=trim(restart_pfile), exist=exists)
                 if (.not. exists) then
                    rc = ESMF_FAILURE
+                   write(logunit,*) " drv_restart_pointer file does NOT exist, correct this and rerun = "//trim(restart_pfile)
                    call ESMF_LogWrite(trim(subname)//' ERROR rpointer file '//trim(restart_pfile)//' not found', &
                         ESMF_LOGMSG_ERROR, line=__LINE__, file=__FILE__)
                    return
@@ -150,6 +151,7 @@ contains
                 open(newunit=unitn, file=restart_pfile, form='FORMATTED', status='old',iostat=ierr)
                 if (ierr < 0) then
                    rc = ESMF_FAILURE
+                   write(logunit,*) " error opening rpointer file "
                    call ESMF_LogWrite(trim(subname)//' ERROR rpointer file open returns error', &
                         ESMF_LOGMSG_ERROR, line=__LINE__, file=__FILE__)
                    return
@@ -157,6 +159,7 @@ contains
                 read(unitn,'(a)', iostat=ierr) restart_file
                 if (ierr < 0) then
                    rc = ESMF_FAILURE
+                   write(logunit,*) " error in read of rpointer file "
                    call ESMF_LogWrite(trim(subname)//' ERROR rpointer file read returns error', &
                         ESMF_LOGMSG_INFO, line=__LINE__, file=__FILE__)
                    return

--- a/cime_config/buildnml
+++ b/cime_config/buildnml
@@ -320,7 +320,7 @@ def _create_drv_namelists(case, infile, confdir, nmlgen, files):
     # Write namelist file drv_in and initial input dataset list.
     # --------------------------------
     namelist_file = os.path.join(confdir, "drv_in")
-    drv_namelist_groups = ["papi_inparm", "prof_inparm", "debug_inparm"]
+    drv_namelist_groups = ["DRIVER_attributes", "MED_attributes", "ALLCOMP_attributes", "ROF_attributes", "WAV_attributes"]
     nmlgen.write_output_file(
         namelist_file, data_list_path=data_list_path, groups=drv_namelist_groups
     )

--- a/cime_config/config_component.xml
+++ b/cime_config/config_component.xml
@@ -404,13 +404,16 @@
 
   <entry id="DRV_RESTART_POINTER">
     <type>char</type>
-    <default_value>rpointer.cpl</default_value>
+    <default_value>rpointer.cpl.${RUN_STARTDATE}-${RUN_REFTOD}</default_value>
     <group>run_begin_stop_restart</group>
     <file>env_run.xml</file>
     <desc>
       Name of the restart pointer file, this can be used to restart from an
       intermediate restart by appending the restart date and time in format YYYY-MM-DD-SSSSS
     </desc>
+    <values>
+       <value>rpointer.cpl.${RUN_STARTDATE}-${RUN_REFTOD}</value>
+    </values>
   </entry>
 
   <entry id="PAUSE_OPTION">

--- a/cime_config/namelist_definition_drv.xml
+++ b/cime_config/namelist_definition_drv.xml
@@ -18,6 +18,14 @@
     </values>
   </entry>
 
+  <entry id="rundir" modify_via_xml="RUNDIR">
+    <type>char</type>
+    <category>nuopc</category>
+    <group>DRIVER_attributes</group>
+    <values>
+      <value>$RUNDIR</value>
+    </values>
+  </entry>
   <entry id="pio_asyncio_ntasks" modify_via_xml="PIO_ASYNCIO_NTASKS">
     <type>integer</type>
     <category>pio</category>
@@ -165,12 +173,16 @@
   <entry id="drv_restart_pointer" modify_via_xml="DRV_RESTART_POINTER">
     <type>char</type>
     <category>expdef</category>
+    <default_value>none</default_value>
+    <!-- IMPORTANT NOTE: The relative path option MUST be used with a version of cime that allows it cime PR#4739 allows this -->
+    <input_pathname>rel:rundir</input_pathname>
     <group>DRIVER_attributes</group>
     <desc>
       Driver restart pointer file to initialize time info
     </desc>
     <values>
-      <value>$DRV_RESTART_POINTER</value>
+      <value>none</value>
+      <value run_type="branch">$DRV_RESTART_POINTER</value>
     </values>
   </entry>
 


### PR DESCRIPTION
### Description of changes

Correct the input groups with filenames to be added to cpl.input_data_list. Add more error messaging to the log files around rpointer errors. Set the drv_restart_pointer by default to none, unless it's needed, and make it a relative path to RUNDIR so will be added to cpl.input_data_list and checked that exists.

### Specific notes

Contributors other than yourself, if any:

CMEPS Issues Fixed (include github issue #):
  Fixes #524
  Fixes #525
  Fixes #526

Are changes expected to change answers? bfb

Any User Interface Changes (namelist or namelist defaults changes)? yes
   drv_restart_pointer gets set to "none" except for cases that need it like branch

### Testing performed. 
   currently only tested with ctsm5.3.020 which uses: ccs_config_cesm1.0.16, and cime from https://github.com/ESMCI/cime/pull/4739
  and for a simple case with a startup and branch type

  will do more testing, and will update the PR and report about what's done.
  Plan to run aux_clm testlist as well as aux_cmeps.

