### PR TITLE
replace esmf_logmsg_error with calls to shr_abort

### DIFF
--- a/cesm/driver/esm_time_mod.F90
+++ b/cesm/driver/esm_time_mod.F90
@@ -1,6 +1,7 @@
 module esm_time_mod
 
   use shr_kind_mod        , only : cx=>shr_kind_cx, cs=>shr_kind_cs, cl=>shr_kind_cl, r8=>shr_kind_r8
+  use shr_sys_mod         , only : shr_sys_abort
   use ESMF                , only : ESMF_GridComp, ESMF_GridCompGet, ESMF_GridCompSet
   use ESMF                , only : ESMF_Clock, ESMF_ClockCreate, ESMF_ClockGet, ESMF_ClockSet
   use ESMF                , only : ESMF_ClockAdvance
@@ -9,7 +10,7 @@ module esm_time_mod
   use ESMF                , only : ESMF_CALKIND_NOLEAP, ESMF_CALKIND_GREGORIAN
   use ESMF                , only : ESMF_Time, ESMF_TimeGet, ESMF_TimeSet
   use ESMF                , only : ESMF_TimeInterval, ESMF_TimeIntervalSet, ESMF_TimeIntervalGet
-  use ESMF                , only : ESMF_SUCCESS, ESMF_LogWrite, ESMF_LOGMSG_INFO, ESMF_FAILURE, ESMF_LOGMSG_ERROR
+  use ESMF                , only : ESMF_SUCCESS, ESMF_LogWrite, ESMF_LOGMSG_INFO, ESMF_FAILURE
   use ESMF                , only : ESMF_VM, ESMF_VMGet, ESMF_VMBroadcast
   use ESMF                , only : ESMF_VMAllReduce, ESMF_REDUCE_MAX, ESMF_ClockGetAlarm
   use ESMF                , only : ESMF_LOGMSG_INFO, ESMF_FAILURE, ESMF_GridCompIsPetLocal
@@ -140,26 +141,20 @@ contains
                 write(logunit,*) " read rpointer file = "//trim(restart_pfile)
                 inquire( file=trim(restart_pfile), exist=exists)
                 if (.not. exists) then
-                   rc = ESMF_FAILURE
-                   call ESMF_LogWrite(trim(subname)//' ERROR rpointer file '//trim(restart_pfile)//' not found', &
-                        ESMF_LOGMSG_ERROR, line=__LINE__, file=__FILE__)
-                   return
+                   call shr_sys_abort(trim(subname)//' ERROR rpointer file '//trim(restart_pfile)//' not found',&
+                        line=__LINE__, file=__FILE__)
                 endif
                 call ESMF_LogWrite(trim(subname)//" read rpointer file = "//trim(restart_pfile), &
                      ESMF_LOGMSG_INFO)
                 open(newunit=unitn, file=restart_pfile, form='FORMATTED', status='old',iostat=ierr)
                 if (ierr < 0) then
-                   rc = ESMF_FAILURE
-                   call ESMF_LogWrite(trim(subname)//' ERROR rpointer file open returns error', &
-                        ESMF_LOGMSG_ERROR, line=__LINE__, file=__FILE__)
-                   return
+                   call shr_sys_abort(trim(subname)//' ERROR rpointer file open returns error', &
+                        line=__LINE__, file=__FILE__)
                 end if
                 read(unitn,'(a)', iostat=ierr) restart_file
                 if (ierr < 0) then
-                   rc = ESMF_FAILURE
-                   call ESMF_LogWrite(trim(subname)//' ERROR rpointer file read returns error', &
-                        ESMF_LOGMSG_INFO, line=__LINE__, file=__FILE__)
-                   return
+                   call shr_sys_abort(trim(subname)//' ERROR rpointer file read returns error', &
+                        line=__LINE__, file=__FILE__)
                 end if
                 close(unitn)
                 if (maintask) then
@@ -372,68 +367,58 @@ contains
    rc = ESMF_SUCCESS
    status = nf90_open(restart_file, NF90_NOWRITE, ncid)
    if (status /= nf90_NoErr) then
-      call ESMF_LogWrite(trim(subname)//' ERROR: nf90_open: '//trim(restart_file), ESMF_LOGMSG_ERROR)
-      rc = ESMF_FAILURE
-      return
+      call shr_sys_abort(trim(subname)//' ERROR: nf90_open: '//trim(restart_file),&
+           file=__FILE__, line=__LINE__)
    endif
 
    status = nf90_inq_varid(ncid, 'start_ymd', varid)
    if (status /= nf90_NoErr) then
-      call ESMF_LogWrite(trim(subname)//' ERROR: nf90_inq_varid start_ymd', ESMF_LOGMSG_ERROR)
-      rc = ESMF_FAILURE
-      return
+      call shr_sys_abort(trim(subname)//' ERROR: nf90_inq_varid start_ymd', &
+           file=__FILE__, line=__LINE__)
    end if
    status = nf90_get_var(ncid, varid, start_ymd)
    if (status /= nf90_NoErr) then
-      call ESMF_LogWrite(trim(subname)//' ERROR: nf90_get_var start_ymd', ESMF_LOGMSG_ERROR)
-      rc = ESMF_FAILURE
-      return
+      call shr_sys_abort(trim(subname)//' ERROR: nf90_get_var start_ymd', &
+           file=__FILE__, line=__LINE__)
    end if
 
    status = nf90_inq_varid(ncid, 'start_tod', varid)
    if (status /= nf90_NoErr) then
-      call ESMF_LogWrite(trim(subname)//' ERROR: nf90_inq_varid start_tod', ESMF_LOGMSG_ERROR)
-      rc = ESMF_FAILURE
-      return
+      call shr_sys_abort(trim(subname)//' ERROR: nf90_inq_varid start_tod', &
+           file=__FILE__, line=__LINE__)
    end if
    status = nf90_get_var(ncid, varid, start_tod)
    if (status /= nf90_NoErr) then
-      call ESMF_LogWrite(trim(subname)//' ERROR: nf90_get_var start_tod', ESMF_LOGMSG_ERROR)
-      rc = ESMF_FAILURE
-      return
+      call shr_sys_abort(trim(subname)//' ERROR: nf90_get_var start_tod', &
+           file=__FILE__, line=__LINE__)
    end if
 
    status = nf90_inq_varid(ncid, 'curr_ymd', varid)
    if (status /= nf90_NoErr) then
-      call ESMF_LogWrite(trim(subname)//' ERROR: nf90_inq_varid curr_ymd', ESMF_LOGMSG_ERROR)
-      rc = ESMF_FAILURE
-      return
+      call shr_sys_abort(trim(subname)//' ERROR: nf90_inq_varid curr_ymd', &
+           file=__FILE__, line=__LINE__)
    end if
    status = nf90_get_var(ncid, varid, curr_ymd)
    if (status /= nf90_NoErr) then
-      call ESMF_LogWrite(trim(subname)//' ERROR: nf90_get_var curr_ymd', ESMF_LOGMSG_ERROR)
-      rc = ESMF_FAILURE
-      return
+      call shr_sys_abort(trim(subname)//' ERROR: nf90_get_var curr_ymd', &
+           file=__FILE__, line=__LINE__)
    end if
 
    status = nf90_inq_varid(ncid, 'curr_tod', varid)
    if (status /= nf90_NoErr) then
-      call ESMF_LogWrite(trim(subname)//' ERROR: nf90_inq_varid curr_tod', ESMF_LOGMSG_ERROR)
-      rc = ESMF_FAILURE
-      return
+      call shr_sys_abort(trim(subname)//' ERROR: nf90_inq_varid curr_tod', &
+           file=__FILE__, line=__LINE__)
    end if
    status = nf90_get_var(ncid, varid, curr_tod)
    if (status /= nf90_NoErr) then
-      call ESMF_LogWrite(trim(subname)//' ERROR: nf90_get_var curr_tod', ESMF_LOGMSG_ERROR)
-      rc = ESMF_FAILURE
-      return
+      call shr_sys_abort(trim(subname)//' ERROR: nf90_get_var curr_tod', &
+           file=__FILE__, line=__LINE__)
    end if
 
    status = nf90_close(ncid)
    if (status /= nf90_NoErr) then
-      call ESMF_LogWrite(trim(subname)//' ERROR: nf90_close', ESMF_LOGMSG_ERROR)
-      rc = ESMF_FAILURE
-      return
+      call shr_sys_abort(trim(subname)//' ERROR: nf90_close', &
+           file=__FILE__, line=__LINE__)
    end if
 
    write(tmpstr,*) trim(subname)//" read start_ymd = ",start_ymd

--- a/cime_config/testdefs/testlist_drv.xml
+++ b/cime_config/testdefs/testlist_drv.xml
@@ -43,43 +43,10 @@
   </test>
 
   <!-- ======================================= -->
-  <!-- X compsets -->
-  <!-- ======================================= -->
-
-  <test compset="X" grid="f19_g17" name="SMS">
-    <machines>
-      <machine name="derecho" compiler="gnu" category="aux_cmeps"/>
-      <machine name="izumi" compiler="intel" category="aux_cmeps"/>
-    </machines>
-    <options>
-      <option name="wallclock"> 00:20:00 </option>
-    </options>
-  </test>
-  <test compset="X" grid="f19_g17" name="ERS_Ln9">
-    <machines>
-      <machine name="derecho" compiler="intel" category="aux_cmeps"/>
-      <machine name="izumi" compiler="intel" category="aux_cmeps"/>
-    </machines>
-    <options>
-      <option name="wallclock"> 00:40:00 </option>
-    </options>
-  </test>
-
-  <test compset="X" grid="f19_g17" name="ERS_D_Ln9" testmods="drv/aoflux_ogrid">
-    <machines>
-      <machine name="derecho" compiler="intel" category="aux_cmeps"/>
-    </machines>
-    <options>
-      <option name="wallclock"> 00:40:00 </option>
-      <option name="comment">The default aoflux_grid is now xgrid; include a debug test with different atm/ocn grids with aoflux_grid=ogrid to make sure that option continues to work.</option>
-    </options>
-  </test>
-
-  <!-- ======================================= -->
   <!-- B compsets -->
   <!-- ======================================= -->
 
-  <test compset="B1850MOM" grid="f09_t061" name="ERR_Ld5" testmods="allactive/defaultio">
+  <test compset="BMT1850" grid="ne30pg3_t232" name="ERR_Ld5" testmods="allactive/defaultio">
     <machines>
       <machine name="derecho" compiler="intel" category="aux_cmeps"/>
       <machine name="izumi" compiler="intel" category="aux_cmeps"/>
@@ -88,7 +55,7 @@
       <option name="wallclock"> 00:40:00 </option>
     </options>
   </test>
-  <test compset="BLT1850_v0c" grid="ne30pg3_t232" name="ERS_Ld5" testmods="allactive/defaultio">
+  <test compset="BLT1850" grid="ne30pg3_t232" name="ERS_Ld5" testmods="allactive/defaultio">
     <machines>
       <machine name="derecho" compiler="intel" category="aux_cmeps"/>
       <machine name="izumi" compiler="intel" category="aux_cmeps"/>
@@ -102,7 +69,7 @@
   <!-- C compsets -->
   <!-- ======================================= -->
 
-  <test compset="CMOM" grid="T62_g17" name="ERS_Ld5">
+  <test compset="C" grid="T62_g17" name="ERS_Ld5">
     <machines>
       <machine name="derecho" compiler="gnu" category="aux_cmeps"/>
       <machine name="izumi" compiler="intel" category="aux_cmeps"/>
@@ -111,7 +78,7 @@
       <option name="wallclock"> 00:40:00 </option>
     </options>
   </test>
-  <test compset="CMOM_JRA" grid="T62_t061" name="SMS_Ld5">
+  <test compset="C_JRA" grid="T62_t232" name="SMS_Ld5">
     <machines>
       <machine name="derecho" compiler="intel" category="aux_cmeps"/>
       <machine name="izumi" compiler="intel" category="aux_cmeps"/>
@@ -120,7 +87,7 @@
       <option name="wallclock"> 00:40:00 </option>
     </options>
   </test>
-  <test compset="CMOM" grid="T62_t061" name="ERS_Ld5">
+  <test compset="C" grid="T62_t232" name="ERS_Ld5">
     <machines>
       <machine name="derecho" compiler="intel" category="aux_cmeps"/>
       <machine name="izumi" compiler="intel" category="aux_cmeps"/>
@@ -134,7 +101,7 @@
   <!-- G compsets -->
   <!-- ======================================= -->
 
-  <test compset="GMOM_JRA" grid="T62_g17" name="ERS_Ld5">
+  <test compset="G_JRA" grid="T62_g17" name="ERS_Ld5">
     <machines>
       <machine name="derecho" compiler="nvhpc" category="aux_cmeps"/>
       <machine name="izumi" compiler="intel" category="aux_cmeps"/>
@@ -143,7 +110,7 @@
       <option name="wallclock"> 00:10:00 </option>
     </options>
   </test>
-  <test compset="GMOM" grid="T62_t061" name="SMS_Ld5">
+  <test compset="G" grid="T62_t232" name="SMS_Ld5">
     <machines>
       <machine name="derecho" compiler="gnu" category="aux_cmeps"/>
       <machine name="izumi" compiler="intel" category="aux_cmeps"/>
@@ -152,7 +119,7 @@
       <option name="wallclock"> 00:10:00 </option>
     </options>
   </test>
-  <test compset="GMOM" grid="T62_t061" name="ERS_Ld5">
+  <test compset="G" grid="T62_t232" name="ERS_Ld5">
     <machines>
       <machine name="derecho" compiler="intel" category="aux_cmeps"/>
       <machine name="izumi" compiler="intel" category="aux_cmeps"/>
@@ -210,7 +177,7 @@
   <!-- I compsets -->
   <!-- ======================================= -->
 
-  <test compset="I2000Clm51Bgc" grid="f19_g17" name="ERS_Ld5" testmods="clm/default">
+  <test compset="I2000Clm60Bgc" grid="f19_g17" name="ERS_Ld5" testmods="clm/default">
     <machines>
       <machine name="derecho" compiler="intel" category="aux_cmeps"/>
       <machine name="izumi" compiler="intel" category="aux_cmeps"/>
@@ -292,7 +259,7 @@
     </machines>
   </test>
 
-  <test name="ERS_Ld5" grid="ne30pg3_t061" compset="B1850MOM" testmods="allactive/defaultio--drv/asyncio1node">
+  <test name="ERS_Ld5" grid="ne30pg3_t232" compset="BLT1850" testmods="allactive/defaultio--drv/asyncio1node">
     <machines>
       <machine name="derecho" compiler="gnu" category="prealpha">
         <options>

--- a/mediator/esmFlds.F90
+++ b/mediator/esmFlds.F90
@@ -1,9 +1,10 @@
 module esmflds
-  use ESMF, only                  : ESMF_SUCCESS, ESMF_FAILURE, ESMF_LOGMSG_ERROR, ESMF_LOGWRITE
+  use ESMF, only                  : ESMF_SUCCESS, ESMF_FAILURE, ESMF_LOGWRITE
   use med_kind_mod, only          : CX=>SHR_KIND_CX, CS=>SHR_KIND_CS, CL=>SHR_KIND_CL, R8=>SHR_KIND_R8
   use med_internalstate_mod, only : compname, compocn, compatm, compice, comprof
   use med_internalstate_mod, only : mapfcopy, mapnames, mapunset
   use med_utils_mod        , only : chkerr => med_utils_ChkErr
+  use shr_sys_mod          , only : shr_sys_abort
   implicit none
   private
 
@@ -313,9 +314,7 @@ contains
   !================================================================================
 
   function med_fldList_GetFld(fields, fldname, rc) result(newfld)
-    use ESMF, only : ESMF_LogWrite, ESMF_LOGMSG_ERROR, ESMF_LOGMSG_INFO
-    use ESMF, only : ESMF_FINALIZE, ESMF_END_ABORT
-
+    use ESMF, only : ESMF_LogWrite, ESMF_LOGMSG_INFO
 
     type(med_fldList_entry_type) , intent(in), target :: fields
     character(len=*)                  , intent(in)    :: fldname
@@ -336,8 +335,7 @@ contains
           write(6,*) trim(subname)//' input flds entry is ',trim(newfld%stdname)
           newfld => newfld%next
        end do
-       call ESMF_LogWrite(subname // 'ERROR: fldname '// trim(fldname) // ' not found in input flds', ESMF_LOGMSG_ERROR)
-       call ESMF_Finalize(endflag=ESMF_END_ABORT)
+       call shr_sys_abort(subname // 'ERROR: fldname '// trim(fldname) // ' not found in input flds')
     endif
 
   end function med_fldList_GetFld
@@ -385,9 +383,6 @@ contains
   !================================================================================
 
   subroutine med_fldList_AddMap(fields, fldname, destcomp, maptype, mapnorm, mapfile)
-
-    use ESMF, only : ESMF_LOGMSG_ERROR, ESMF_FAILURE, ESMF_LogWrite, ESMF_LOGMSG_INFO
-
     ! intput/output variables
     type(med_fldList_entry_type) , intent(in), target :: fields
     character(len=*)                  , intent(in)    :: fldname
@@ -439,7 +434,7 @@ contains
     use ESMF              , only : ESMF_MeshLoc_Element, ESMF_FieldCreate, ESMF_TYPEKIND_R8
     use ESMF              , only : ESMF_MAXSTR, ESMF_Field, ESMF_State, ESMF_Grid, ESMF_Mesh
     use ESMF              , only : ESMF_StateGet, ESMF_LogFoundError
-    use ESMF              , only : ESMF_LogWrite, ESMF_LOGMSG_ERROR, ESMF_FAILURE, ESMF_LOGERR_PASSTHRU
+    use ESMF              , only : ESMF_LogWrite, ESMF_FAILURE, ESMF_LOGERR_PASSTHRU
     use ESMF              , only : ESMF_LOGMSG_INFO, ESMF_StateRemove, ESMF_SUCCESS
     use ESMF              , only : ESMF_STATEINTENT_IMPORT, ESMF_STATEINTENT_EXPORT, ESMF_StateIntent_Flag
     use ESMF              , only : ESMF_RC_ARG_BAD, ESMF_LogSetError, operator(==)
@@ -472,10 +467,8 @@ contains
     rc = ESMF_SUCCESS
 
     if (present(grid) .and. present(mesh)) then
-       call ESMF_LogWrite(trim(subname)//trim(tag)//": ERROR both grid and mesh not allowed", &
-            ESMF_LOGMSG_ERROR, line=__LINE__, file=u_FILE_u, rc=rc)
-       rc = ESMF_FAILURE
-       return
+       call shr_sys_abort(trim(subname)//trim(tag)//": ERROR both grid and mesh not allowed", &
+            line=__LINE__, file=u_FILE_u, rc=rc)
     endif
 
     nullify(StandardNameList)
@@ -575,10 +568,8 @@ contains
                 field = ESMF_FieldCreate(mesh, ESMF_TYPEKIND_R8, name=shortname, meshloc=ESMF_MESHLOC_ELEMENT, rc=rc)
                 if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=u_FILE_u)) return
              else
-                call ESMF_LogWrite(trim(subname)//trim(tag)//": ERROR grid or mesh expected", &
-                     ESMF_LOGMSG_ERROR, line=__LINE__, file=u_FILE_u)
-                rc = ESMF_FAILURE
-                return
+                call shr_sys_abort(trim(subname)//trim(tag)//": ERROR grid or mesh expected", &
+                     line=__LINE__, file=u_FILE_u)
              endif
 
              ! NOW call NUOPC_Realize
@@ -676,9 +667,7 @@ contains
        newfld => newfld%next
     enddo
     if( .not. associated(newfld)) then
-       call ESMF_LogWrite(subname//' No field found', ESMF_LOGMSG_ERROR)
-       if(present(rc)) rc = ESMF_FAILURE
-       return
+       call shr_sys_abort(subname//' No field found')
     endif
     call med_fld_GetFldInfo(newfld, compsrc, stdname, shortname, mapindex, mapFile, mapnorm, merge_fields, merge_type, merge_fracname, rc)
 
@@ -719,39 +708,31 @@ contains
     endif
 
     if(present(mapindex)) then
-       if(lcompsrc < 0) call med_fldList_compsrcerror(lrc)
+       if(lcompsrc < 0) call shr_sys_abort("In med_fld_GetFldInfo mapindex requiring compsrc was requested but compsrc was not provided. ")
        mapindex    = newfld%mapindex(lcompsrc)
     endif
     if(present(mapfile)) then
-       if(lcompsrc < 0) call med_fldList_compsrcerror(lrc)
+       if(lcompsrc < 0) call shr_sys_abort("In med_fld_GetFldInfo mapfile requiring compsrc was requested but compsrc was not provided. ")
        mapfile    = newfld%mapfile(lcompsrc)
     endif
     if(present(mapnorm)) then
-       if(lcompsrc < 0) call med_fldList_compsrcerror(lrc)
+       if(lcompsrc < 0) call shr_sys_abort("In med_fld_GetFldInfo mapnorm requiring compsrc was requested but compsrc was not provided. ")
        mapnorm    = newfld%mapnorm(lcompsrc)
     endif
     if(present(merge_fields)) then
-       if(lcompsrc < 0) call med_fldList_compsrcerror(lrc)
+       if(lcompsrc < 0) call shr_sys_abort("In med_fld_GetFldInfo merge_fields requiring compsrc was requested but compsrc was not provided. ")
        merge_fields    = newfld%merge_fields(lcompsrc)
     endif
     if(present(merge_type)) then
-       if(lcompsrc < 0) call med_fldList_compsrcerror(lrc)
+       if(lcompsrc < 0) call shr_sys_abort("In med_fld_GetFldInfo merge_type requiring compsrc was requested but compsrc was not provided. ")
        merge_type     = newfld%merge_types(lcompsrc)
     endif
     if(present(merge_fracname)) then
-       if(lcompsrc < 0) call med_fldList_compsrcerror(lrc)
+       if(lcompsrc < 0) call shr_sys_abort("In med_fld_GetFldInfo merge_fracname requiring compsrc was requested but compsrc was not provided. ")
        merge_fracname = newfld%merge_fracnames(lcompsrc)
     endif
     if(present(rc)) rc=lrc
 
-  contains
-    subroutine med_fldList_compsrcerror(rc)
-      integer, intent(out) :: rc
-      call ESMF_LogWrite("In med_fld_GetFldInfo a field requiring compsrc was requested but compsrc was not provided. ", &
-           ESMF_LOGMSG_ERROR)
-      rc = ESMF_FAILURE
-      return
-    end subroutine med_fldList_compsrcerror
   end subroutine med_fld_GetFldInfo
 
   !================================================================================
@@ -778,7 +759,7 @@ contains
 
   subroutine med_fldList_GetFldNames(fields, fldnames, rc)
 
-    use ESMF, only : ESMF_LOGMSG_ERROR, ESMF_FAILURE, ESMF_SUCCESS, ESMF_LogWrite
+    use ESMF, only : ESMF_SUCCESS
 
     ! input/output variables
     type(med_fldList_entry_type) , intent(in), target     :: fields
@@ -794,9 +775,7 @@ contains
     if(present(rc)) rc = ESMF_SUCCESS
     if (.not. associated(fldnames) .or. .not. allocated(fields%mapindex)) then
        write(msg, *) "med_fldList_GetFldNames: ERROR either fields or fldnames have not been allocated. ",associated(fldnames), allocated(fields%mapindex)
-       call ESMF_LogWrite(msg, ESMF_LOGMSG_ERROR)
-       if(present(rc)) rc = ESMF_FAILURE
-       return
+       call shr_sys_abort(msg)
     endif
     n = 0
     newfld => fields

--- a/mediator/med_diag_mod.F90
+++ b/mediator/med_diag_mod.F90
@@ -17,8 +17,7 @@ module med_diag_mod
 
   use NUOPC                 , only : NUOPC_CompAttributeGet, NUOPC_CompAttributeSet, NUOPC_CompAttributeAdd
   use NUOPC_Mediator        , only : NUOPC_MediatorGet
-  use ESMF                  , only : ESMF_LogWrite, ESMF_LOGMSG_INFO, ESMF_SUCCESS
-  use ESMF                  , only : ESMF_FAILURE,  ESMF_LOGMSG_ERROR
+  use ESMF                  , only : ESMF_SUCCESS
   use ESMF                  , only : ESMF_GridComp, ESMF_Clock, ESMF_Time
   use ESMF                  , only : ESMF_VM, ESMF_VMReduce, ESMF_REDUCE_SUM
   use ESMF                  , only : ESMF_GridCompGet, ESMF_ClockGet, ESMF_TimeGet, ESMF_ClockGetNextTime
@@ -33,7 +32,8 @@ module med_diag_mod
   use med_methods_mod       , only : fldbun_fldChk    => med_methods_FB_FldChk
   use med_utils_mod         , only : chkerr           => med_utils_ChkErr
   use perf_mod              , only : t_startf, t_stopf
-
+  use shr_sys_mod           , only : shr_sys_abort
+  
   implicit none
   private
 
@@ -513,11 +513,9 @@ contains
        budget_counter(:,:,period_inst) = 0.0_r8
        budget_counter(:,:,period_inst+1:) = 1.0_r8
     else
-       call ESMF_LogWrite(trim(subname)//' mode '//trim(mode)//&
+       call shr_sys_abort(trim(subname)//' mode '//trim(mode)//&
             ' not recognized', &
-            ESMF_LOGMSG_ERROR, line=__LINE__, file=u_FILE_u)
-       rc = ESMF_FAILURE
-       return
+            line=__LINE__, file=u_FILE_u)
     endif
   end subroutine med_diag_zero_mode
 

--- a/mediator/med_fraction_mod.F90
+++ b/mediator/med_fraction_mod.F90
@@ -166,9 +166,8 @@ contains
 
     ! Initialize FBFrac(:) field bundles
 
-    use ESMF                  , only : ESMF_LogWrite, ESMF_LOGMSG_INFO, ESMF_LOGMSG_ERROR
-    use ESMF                  , only : ESMF_SUCCESS, ESMF_FAILURE
-    use ESMF                  , only : ESMF_LogSetError, ESMF_RC_NOT_VALID
+    use ESMF                  , only : ESMF_LogWrite, ESMF_LOGMSG_INFO
+    use ESMF                  , only : ESMF_SUCCESS
     use ESMF                  , only : ESMF_GridComp, ESMF_GridCompGet, ESMF_StateIsCreated
     use ESMF                  , only : ESMF_FieldBundle, ESMF_FieldBundleIsCreated, ESMF_FieldBundleDestroy
     use ESMF                  , only : ESMF_FieldBundleGet

--- a/mediator/med_io_mod.F90
+++ b/mediator/med_io_mod.F90
@@ -7,8 +7,8 @@ module med_io_mod
   use med_kind_mod          , only : CX=>SHR_KIND_CX, CS=>SHR_KIND_CS, CL=>SHR_KIND_CL, I8=>SHR_KIND_I8, R8=>SHR_KIND_R8
   use med_kind_mod          , only : R4=>SHR_KIND_R4
   use med_constants_mod     , only : fillvalue => SHR_CONST_SPVAL
-  use ESMF                  , only : ESMF_VM, ESMF_LogWrite, ESMF_LOGMSG_INFO, ESMF_LogFoundError, ESMF_LOGMSG_ERROR
-  use ESMF                  , only : ESMF_SUCCESS, ESMF_FAILURE, ESMF_END_ABORT, ESMF_LOGERR_PASSTHRU
+  use ESMF                  , only : ESMF_VM, ESMF_LogWrite, ESMF_LOGMSG_INFO, ESMF_LogFoundError
+  use ESMF                  , only : ESMF_SUCCESS, ESMF_LOGERR_PASSTHRU
   use ESMF                  , only : ESMF_VMGetCurrent, ESMF_VMGet, ESMF_VMBroadCast, ESMF_Finalize
   use NUOPC                 , only : NUOPC_FieldDictionaryGetEntry
   use NUOPC                 , only : NUOPC_FieldDictionaryHasEntry
@@ -19,7 +19,7 @@ module med_io_mod
   use med_methods_mod       , only : FB_getFldPtr => med_methods_FB_getFldPtr
   use med_methods_mod       , only : FB_getNameN  => med_methods_FB_getNameN
   use med_utils_mod         , only : chkerr       => med_utils_ChkErr
-
+  use shr_sys_mod           , only : shr_sys_abort
   implicit none
   private
 
@@ -195,9 +195,7 @@ contains
        else if (trim(cvalue) .eq. '64BIT_DATA') then
          pio_ioformat = PIO_64BIT_DATA
        else
-         call ESMF_LogWrite(trim(subname)//': need to provide valid option for pio_ioformat (CLASSIC|64BIT_OFFSET|64BIT_DATA)', ESMF_LOGMSG_ERROR)
-         rc = ESMF_FAILURE
-         return
+          call shr_sys_abort(trim(subname)//': need to provide valid option for pio_ioformat (CLASSIC|64BIT_OFFSET|64BIT_DATA)')
        end if
     else
        cvalue = '64BIT_OFFSET'
@@ -220,9 +218,7 @@ contains
        else if (trim(cvalue) .eq. 'NETCDF4P') then
          pio_iotype = PIO_IOTYPE_NETCDF4P
        else
-         call ESMF_LogWrite(trim(subname)//': need to provide valid option for pio_typename (NETCDF|PNETCDF|NETCDF4C|NETCDF4P)', ESMF_LOGMSG_ERROR)
-         rc = ESMF_FAILURE
-         return
+         call shr_sys_abort(trim(subname)//': need to provide valid option for pio_typename (NETCDF|PNETCDF|NETCDF4C|NETCDF4P)')
        end if
     else
        cvalue = 'NETCDF'
@@ -331,9 +327,7 @@ contains
        else if (trim(cvalue) .eq. 'SUBSET') then
          pio_rearranger = PIO_REARR_SUBSET
        else
-         call ESMF_LogWrite(trim(subname)//': need to provide valid option for pio_rearranger (BOX|SUBSET)', ESMF_LOGMSG_ERROR)
-         rc = ESMF_FAILURE
-         return
+         call shr_sys_abort(trim(subname)//': need to provide valid option for pio_rearranger (BOX|SUBSET)')
        end if
     else
        cvalue = 'SUBSET'
@@ -354,9 +348,7 @@ contains
     if (isPresent .and. isSet) then
        read(cvalue,*) pio_debug_level
        if (pio_debug_level < 0 .or. pio_debug_level > 6) then
-         call ESMF_LogWrite(trim(subname)//': need to provide valid option for pio_debug_level (0-6)', ESMF_LOGMSG_ERROR)
-         rc = ESMF_FAILURE
-         return
+         call shr_sys_abort(trim(subname)//': need to provide valid option for pio_debug_level (0-6)')
        end if
     else
        pio_debug_level = 0
@@ -378,9 +370,7 @@ contains
        else if (trim(cvalue) .eq. 'COLL') then
           pio_rearr_comm_type = PIO_REARR_COMM_COLL
        else
-         call ESMF_LogWrite(trim(subname)//': need to provide valid option for pio_rearr_comm_type (P2P|COLL)', ESMF_LOGMSG_ERROR)
-         rc = ESMF_FAILURE
-         return
+         call shr_sys_abort(trim(subname)//': need to provide valid option for pio_rearr_comm_type (P2P|COLL)')
        end if
     else
        cvalue = 'P2P'
@@ -403,9 +393,7 @@ contains
        else if (trim(cvalue) .eq. '2DDISABLE') then
           pio_rearr_comm_fcd = PIO_REARR_COMM_FC_2D_DISABLE
        else
-         call ESMF_LogWrite(trim(subname)//': need to provide valid option for pio_rearr_comm_fcd (2DENABLE|IO2COMP|COMP2IO|2DDISABLE)', ESMF_LOGMSG_ERROR)
-         rc = ESMF_FAILURE
-         return
+         call shr_sys_abort(trim(subname)//': need to provide valid option for pio_rearr_comm_fcd (2DENABLE|IO2COMP|COMP2IO|2DDISABLE)')
        end if
     else
        cvalue = '2DENABLE'
@@ -662,15 +650,13 @@ contains
     integer :: hours     ! hours of hh:mm:ss
     integer :: minutes   ! minutes of hh:mm:ss
     integer :: secs      ! seconds of hh:mm:ss
+    character(len=CS) :: msg
     !----------------------------------------------------------------------
 
     rc = ESMF_SUCCESS
 
     if (seconds < 0 .or. seconds > 86400) then
-       write(logunit,*)'med_io_sec2hms: bad input seconds:', seconds
-       call ESMF_LogWrite('med_io_sec2hms: bad input seconds', ESMF_LOGMSG_INFO)
-       rc = ESMF_FAILURE
-       return
+       call shr_sys_abort('med_io_sec2hms: bad input seconds')
     end if
 
     hours   = seconds / 3600
@@ -678,17 +664,13 @@ contains
     secs    = (seconds - hours*3600 - minutes*60)
 
     if (minutes < 0 .or. minutes > 60) then
-       write(logunit,*)'med_io_sec2hms: bad minutes = ',minutes
-       call ESMF_LogWrite('med_io_sec2hms: bad minutes', ESMF_LOGMSG_INFO)
-       rc = ESMF_FAILURE
-       return
+       write(msg,*)'med_io_sec2hms: bad minutes = ',minutes
+       call shr_sys_abort(msg)
     end if
 
     if (secs < 0 .or. secs > 60) then
-       write(logunit,*)'med_io_sec2hms: bad secs = ',secs
-       call ESMF_LogWrite('med_io_sec2hms: bad secs', ESMF_LOGMSG_INFO)
-       rc = ESMF_FAILURE
-       return
+       write(msg,*)'med_io_sec2hms: bad secs = ',secs
+       call shr_sys_abort(msg)
     end if
 
     write(med_io_sec2hms,80) hours, minutes, secs
@@ -705,7 +687,7 @@ contains
     !---------------
 
     use ESMF,  only : operator(==)
-    use ESMF , only : ESMF_LogWrite, ESMF_LOGMSG_INFO, ESMF_SUCCESS, ESMF_FAILURE, ESMF_END_ABORT
+    use ESMF , only : ESMF_LogWrite, ESMF_LOGMSG_INFO, ESMF_SUCCESS
     use ESMF , only : ESMF_FieldBundleIsCreated, ESMF_FieldBundle, ESMF_Mesh, ESMF_DistGrid
     use ESMF , only : ESMF_FieldBundleGet, ESMF_FieldGet, ESMF_MeshGet, ESMF_DistGridGet
     use ESMF , only : ESMF_Field, ESMF_FieldGet, ESMF_AttributeGet
@@ -880,8 +862,7 @@ contains
        call ESMF_LogWrite(trim(tmpstr), ESMF_LOGMSG_INFO)
        if (lnx*lny*lntile /= ng) then
           write(tmpstr,*) subname,' ERROR: grid size not consistent ',ng,lnx,lny,lntile
-          call ESMF_LogWrite(trim(tmpstr), ESMF_LOGMSG_INFO)
-          call ESMF_Finalize(endflag=ESMF_END_ABORT)
+          call shr_sys_abort(trim(tmpstr))
        end if
     else
        lnx = ng
@@ -1375,7 +1356,6 @@ contains
     use ESMF, only : ESMF_CALKIND_360DAY, ESMF_CALKIND_GREGORIAN
     use ESMF, only : ESMF_CALKIND_JULIAN, ESMF_CALKIND_JULIANDAY, ESMF_CALKIND_MODJULIANDAY
     use ESMF, only : ESMF_CALKIND_NOCALENDAR, ESMF_CALKIND_NOLEAP
-    use ESMF, only : ESMF_LOGMSG_ERROR, ESMF_FAILURE
     use pio , only : var_desc_t, PIO_UNLIMITED
     use pio , only : pio_double, pio_def_dim, pio_def_var, pio_put_att
     use pio , only : pio_inq_varid, pio_put_var
@@ -1398,10 +1378,8 @@ contains
     rc = ESMF_SUCCESS
 
     if (.not. ESMF_CalendarIsCreated(calendar)) then
-       call ESMF_LogWrite(trim(subname)//' ERROR: calendar is not created ', &
-            ESMF_LOGMSG_ERROR, line=__LINE__, file=u_FILE_u)
-       rc = ESMF_FAILURE
-       return
+       call shr_sys_abort(trim(subname)//' ERROR: calendar is not created ', &
+            line=__LINE__, file=u_FILE_u)
     end if
 
     ! define time and add calendar attribute
@@ -1480,7 +1458,6 @@ contains
 
     use ESMF , only : ESMF_FieldBundle, ESMF_Field, ESMF_Mesh, ESMF_DistGrid
     use ESMF , only : ESMF_LogWrite, ESMF_LOGMSG_INFO, ESMF_SUCCESS
-    use ESMF , only : ESMF_LOGMSG_ERROR, ESMF_FAILURE
     use ESMF , only : ESMF_FieldBundleIsCreated, ESMF_FieldBundleGet
     use ESMF , only : ESMF_FieldGet, ESMF_MeshGet, ESMF_DistGridGet
     use pio  , only : file_desc_T, var_desc_t, io_desc_t, pio_nowrite, pio_openfile
@@ -1562,10 +1539,8 @@ contains
        call ESMF_LogWrite(trim(subname)//' open file '//trim(filename), ESMF_LOGMSG_INFO)
        if (chkerr(rc,__LINE__,u_FILE_u)) return
     else
-       call ESMF_LogWrite(trim(subname)//' ERROR: file invalid '//trim(filename), &
-            ESMF_LOGMSG_ERROR, line=__LINE__, file=u_FILE_u)
-       rc = ESMF_FAILURE
-       return
+       call shr_sys_abort(trim(subname)//' ERROR: file invalid '//trim(filename), &
+            line=__LINE__, file=u_FILE_u)
     endif
 
     call pio_seterrorhandling(pioid, PIO_BCAST_ERROR)
@@ -1683,7 +1658,7 @@ contains
   !===============================================================================
   subroutine med_io_read_init_iodesc(FB, name1, pioid, iodesc, rc)
 
-    use ESMF , only : ESMF_LogWrite, ESMF_LOGMSG_INFO, ESMF_SUCCESS, ESMF_FAILURE
+    use ESMF , only : ESMF_LogWrite, ESMF_LOGMSG_INFO, ESMF_SUCCESS
     use ESMF , only : ESMF_FieldBundleIsCreated, ESMF_FieldBundle, ESMF_Mesh, ESMF_DistGrid
     use ESMF , only : ESMF_FieldBundleGet, ESMF_FieldGet, ESMF_MeshGet, ESMF_DistGridGet
     use ESMF , only : ESMF_Field, ESMF_FieldGet, ESMF_AttributeGet
@@ -1758,9 +1733,7 @@ contains
        if (ng > maxval(maxIndexPTile)) then
           write(tmpstr,*) subname,' WARNING: dimensions do not match', lnx, lny, maxval(maxIndexPTile)
           call ESMF_LogWrite(trim(tmpstr), ESMF_LOGMSG_INFO)
-          !TODO: this should not be an error for say CTSM which does not send a global grid
-          !rc = ESMF_Failure
-          !return
+          ! This should not be an error for say CTSM which does not send a global grid
        endif
 
        call ESMF_DistGridGet(distgrid, localDE=0, elementCount=ns, rc=rc)
@@ -1776,9 +1749,7 @@ contains
 
        deallocate(minIndexPTile, maxIndexPTile)
     else
-       if(maintask) write(logunit,'(a)') trim(subname)//' ERROR: '//trim(name1)//' is not present, aborting '
-       call ESMF_LogWrite(trim(subname)//' ERROR: '//trim(name1)//' is not present, aborting ', ESMF_LOGMSG_ERROR)
-       rc = ESMF_FAILURE
+       call shr_sys_abort(trim(subname)//' ERROR: '//trim(name1)//' is not present, aborting ')
     end if ! end if rcode check
 
   end subroutine med_io_read_init_iodesc
@@ -1851,10 +1822,7 @@ contains
        rcode = pio_get_att(pioid,pio_global,"file_version",lversion)
        call pio_seterrorhandling(pioid,PIO_INTERNAL_ERROR)
     else
-       if(iam==0) write(logunit,*) subname,' ERROR: file invalid ',trim(filename),' ',trim(dname)
-       call ESMF_LogWrite(trim(subname)//'ERROR: file invalid '//trim(filename)//' '//trim(dname), ESMF_LOGMSG_INFO)
-       rc = ESMF_FAILURE
-       return
+       call shr_sys_abort(trim(subname)//'ERROR: file invalid '//trim(filename)//' '//trim(dname))
     endif
 
     if (trim(lversion) == trim(version)) then
@@ -1936,10 +1904,7 @@ contains
        rcode = pio_get_att(pioid,pio_global,"file_version",lversion)
        call pio_seterrorhandling(pioid,PIO_INTERNAL_ERROR)
     else
-       if(iam==0) write(logunit,*) subname,' ERROR: file invalid ',trim(filename),' ',trim(dname)
-       call ESMF_LogWrite(trim(subname)//'ERROR: file invalid '//trim(filename)//' '//trim(dname), ESMF_LOGMSG_INFO)
-       rc = ESMF_FAILURE
-       return
+       call shr_sys_abort(trim(subname)//'ERROR: file invalid '//trim(filename)//' '//trim(dname))
     endif
 
     if (trim(lversion) == trim(version)) then
@@ -1996,10 +1961,7 @@ contains
        rcode = pio_get_att(pioid,pio_global,"file_version",lversion)
        call pio_seterrorhandling(pioid,PIO_INTERNAL_ERROR)
     else
-       if(iam==0) write(logunit,*) subname,' ERROR: file invalid ',trim(filename),' ',trim(dname)
-       call ESMF_LogWrite(trim(subname)//'ERROR: file invalid '//trim(filename)//' '//trim(dname), ESMF_LOGMSG_INFO)
-       rc = ESMF_FAILURE
-       return
+       call shr_sys_abort(trim(subname)//'ERROR: file invalid '//trim(filename)//' '//trim(dname))
     endif
 
     if (trim(lversion) == trim(version)) then

--- a/mediator/med_map_mod.F90
+++ b/mediator/med_map_mod.F90
@@ -2,14 +2,15 @@ module med_map_mod
 
   use med_kind_mod          , only : CX=>SHR_KIND_CX, CS=>SHR_KIND_CS, CL=>SHR_KIND_CL, R8=>SHR_KIND_R8
   use med_kind_mod          , only : I4=>SHR_KIND_I4
-  use ESMF                  , only : ESMF_SUCCESS, ESMF_FAILURE
-  use ESMF                  , only : ESMF_LOGMSG_ERROR, ESMF_LOGMSG_INFO, ESMF_LogWrite
+  use ESMF                  , only : ESMF_SUCCESS
+  use ESMF                  , only : ESMF_LOGMSG_INFO, ESMF_LogWrite
   use ESMF                  , only : ESMF_Field
   use med_internalstate_mod , only : InternalState, logunit, maintask
   use med_constants_mod     , only : dbug_flag => med_constants_dbug_flag
   use med_utils_mod         , only : chkerr    => med_utils_ChkErr
   use perf_mod              , only : t_startf, t_stopf
-
+  use shr_sys_mod           , only : shr_sys_abort
+  
   implicit none
   private
 
@@ -144,10 +145,8 @@ contains
 
                 ! Check number of fields in source FB on destination mesh and get destination field
                 if (.not. ESMF_FieldBundleIsCreated(is_local%wrap%FBImp(n1,n2))) then
-                   call ESMF_LogWrite(trim(subname)//'FBImp('//trim(compname(n1))//','//trim(compname(n2))//')'// &
-                        ' has not been created', ESMF_LOGMSG_ERROR, line=__LINE__, file=u_FILE_u)
-                   rc = ESMF_FAILURE
-                   return
+                   call shr_sys_abort(trim(subname)//'FBImp('//trim(compname(n1))//','//trim(compname(n2))//')'// &
+                        ' has not been created', line=__LINE__, file=u_FILE_u)
                 end if
                 call ESMF_FieldBundleGet(is_local%wrap%FBImp(n1,n2), fieldCount=fieldCount, rc=rc)
                 if (chkerr(rc,__LINE__,u_FILE_u)) return
@@ -583,13 +582,8 @@ contains
           if (chkerr(rc,__LINE__,u_FILE_u)) return
        end if
     else
-       if (maintask) then
-          write(logunit,'(A)') trim(subname)//' mapindex '//trim(mapname)//' not supported for '//trim(string)
-       end if
-       call ESMF_LogWrite(trim(subname)//' mapindex '//trim(mapname)//' not supported ', &
-            ESMF_LOGMSG_ERROR, line=__LINE__, file=u_FILE_u)
-       rc = ESMF_FAILURE
-       return
+       call shr_sys_abort(trim(subname)//' mapindex '//trim(mapname)//' not supported for '//trim(string), &
+            line=__LINE__, file=u_FILE_u)
     end if
 
     ! consd_nstod method requires a second routehandle
@@ -816,8 +810,8 @@ contains
                         //',  mapnorm '//trim(mapnorm_mapindex) &
                         //' set; cannot set mapnorm to '//trim(packed_data(mapindex)%mapnorm) &
                         //'  '//trim(fieldnamelist(nf))
-                     call ESMF_LogWrite(trim(tmpstr), ESMF_LOGMSG_ERROR)
-                     call ESMF_Finalize(endflag=ESMF_END_ABORT)
+                     call shr_sys_abort(trim(tmpstr))
+
                    end if
                 end if
              end if
@@ -1372,7 +1366,7 @@ contains
     !---------------------------------------------------
 
     use ESMF                  , only : ESMF_LogWrite, ESMF_LOGMSG_INFO, ESMF_SUCCESS
-    use ESMF                  , only : ESMF_LOGMSG_ERROR, ESMF_FAILURE, ESMF_MAXSTR
+    use ESMF                  , only : ESMF_MAXSTR
     use ESMF                  , only : ESMF_Field, ESMF_FieldRegrid
     use ESMF                  , only : ESMF_TERMORDER_SRCSEQ, ESMF_Region_Flag
     use ESMF                  , only : ESMF_REGION_TOTAL, ESMF_REGION_SELECT

--- a/mediator/med_merge_mod.F90
+++ b/mediator/med_merge_mod.F90
@@ -16,7 +16,8 @@ module med_merge_mod
   use esmFlds               , only : med_fldList_entry_type
   use esmFlds               , only : med_fldList_findName
   use perf_mod              , only : t_startf, t_stopf
-
+  use shr_sys_mod           , only : shr_sys_abort
+  
   implicit none
   private
 
@@ -45,8 +46,8 @@ contains
 
     use ESMF , only : ESMF_FieldBundle, ESMF_FieldBundleIsCreated, ESMF_FieldBundleGet
     use ESMF , only : ESMF_Field, ESMF_FieldGet
-    use ESMF , only : ESMF_SUCCESS, ESMF_FAILURE
-    use ESMF , only : ESMF_LogWrite, ESMF_LOGMSG_INFO, ESMF_LOGMSG_ERROR, ESMF_LogSetError
+    use ESMF , only : ESMF_SUCCESS
+    use ESMF , only : ESMF_LogWrite, ESMF_LOGMSG_INFO, ESMF_LogSetError
 
     ! ----------------------------------------------
     ! Auto merge based on fldListTo info
@@ -203,8 +204,8 @@ contains
 
     use ESMF , only : ESMF_FieldBundle, ESMF_FieldBundleIsCreated, ESMF_FieldBundleGet
     use ESMF , only : ESMF_Field, ESMF_FieldGet
-    use ESMF , only : ESMF_SUCCESS, ESMF_FAILURE
-    use ESMF , only : ESMF_LogWrite, ESMF_LOGMSG_INFO, ESMF_LOGMSG_ERROR
+    use ESMF , only : ESMF_SUCCESS
+    use ESMF , only : ESMF_LogWrite, ESMF_LOGMSG_INFO
     use ESMF , only : ESMF_LogSetError
     ! input/output variables
     integer                , intent(in)    :: compsrc
@@ -309,7 +310,7 @@ contains
   subroutine med_merge_auto_field(merge_type, field_out, ungriddedUBound_out,  &
        FB, FBfld, FBw, fldw, rc)
 
-    use ESMF , only : ESMF_SUCCESS, ESMF_FAILURE, ESMF_LogMsg_Error
+    use ESMF , only : ESMF_SUCCESS
     use ESMF , only : ESMF_FieldBundle, ESMF_FieldBundleGet
     use ESMF , only : ESMF_LogWrite, ESMF_LogMsg_Info
     use ESMF , only : ESMF_FieldGet, ESMF_Field
@@ -344,16 +345,12 @@ contains
 
     if (merge_type == 'copy_with_weights' .or. merge_type == 'merge') then
        if (trim(fldw) == 'unset') then
-          call ESMF_LogWrite(trim(subname)//": error required merge_fracname is not set", &
-               ESMF_LOGMSG_ERROR, line=__LINE__, file=u_FILE_u)
-          rc = ESMF_FAILURE
-          return
+          call shr_sys_abort(trim(subname)//": error required merge_fracname is not set", &
+               line=__LINE__, file=u_FILE_u)
        end if
        if (.not. FB_FldChk(FBw, trim(fldw), rc=rc)) then
-          call ESMF_LogWrite(trim(subname)//": error "//trim(fldw)//"is not in FBw", &
-               ESMF_LOGMSG_ERROR, line=__LINE__, file=u_FILE_u)
-          rc = ESMF_FAILURE
-          return
+          call shr_sys_abort(trim(subname)//": error "//trim(fldw)//"is not in FBw", &
+               line=__LINE__, file=u_FILE_u)
        end if
     end if
 
@@ -418,10 +415,8 @@ contains
           dp1(:) = dp1(:) + dpf1(:)
        endif
     else
-       call ESMF_LogWrite(trim(subname)//": merge type "//trim(merge_type)//" not supported", &
-            ESMF_LOGMSG_ERROR, line=__LINE__, file=u_FILE_u)
-       rc = ESMF_FAILURE
-       return
+       call shr_sys_abort(trim(subname)//": merge type "//trim(merge_type)//" not supported", &
+            line=__LINE__, file=u_FILE_u)
     end if
 
   end subroutine med_merge_auto_field
@@ -432,8 +427,8 @@ contains
 
     use ESMF , only : ESMF_FieldBundle, ESMF_FieldBundleIsCreated, ESMF_FieldBundleGet
     use ESMF , only : ESMF_Field, ESMF_FieldGet
-    use ESMF , only : ESMF_SUCCESS, ESMF_FAILURE
-    use ESMF , only : ESMF_LogWrite, ESMF_LOGMSG_INFO, ESMF_LOGMSG_ERROR
+    use ESMF , only : ESMF_SUCCESS
+    use ESMF , only : ESMF_LogWrite, ESMF_LOGMSG_INFO
     use ESMF , only : ESMF_LogSetError, ESMF_RC_OBJ_NOT_CREATED
 
     ! input/output variables
@@ -475,10 +470,8 @@ contains
              call ESMF_FieldBundleGet(FBMed2, trim(merge_fldname), field=field_in, rc=rc)
              if (chkerr(rc,__LINE__,u_FILE_u)) return
           else
-             call ESMF_LogWrite(trim(subname)//": ERROR merge_fldname = "//trim(merge_fldname)//" not found", &
-                  ESMF_LOGMSG_ERROR, rc=rc)
-             rc = ESMF_FAILURE
-             if (ChkErr(rc,__LINE__,u_FILE_u)) return
+             call shr_sys_abort(trim(subname)//": ERROR merge_fldname = "//trim(merge_fldname)//" not found", &
+                  rc=rc)
           end if
        end if
     endif
@@ -492,9 +485,8 @@ contains
        write(errmsg,*) trim(subname),' input field ungriddedUbound ',ungriddedUbound_in(1),&
             ' for '//trim(merge_fldname), &
             ' not equal to output field ungriddedUbound ',ungriddedUbound_out,' for '//trim(fldname_out)
-       call ESMF_LogWrite(errmsg, ESMF_LOGMSG_ERROR)
-       rc = ESMF_FAILURE
-       return
+      
+       call shr_sys_abort(errmsg)
    endif
 
   end subroutine med_merge_auto_errcheck
@@ -508,7 +500,7 @@ contains
                                 FBinE, fnameE, wgtE, rc)
 
     use ESMF , only : ESMF_FieldBundle, ESMF_LogWrite
-    use ESMF , only : ESMF_SUCCESS, ESMF_FAILURE, ESMF_LOGMSG_ERROR
+    use ESMF , only : ESMF_SUCCESS
     use ESMF , only : ESMF_LOGMSG_WARNING, ESMF_LOGMSG_INFO
 
     ! ----------------------------------------------
@@ -555,11 +547,8 @@ contains
         (present(FBinC) .and. .not.present(fnameC)) .or. &
         (present(FBinD) .and. .not.present(fnameD)) .or. &
         (present(FBinE) .and. .not.present(fnameE))) then
-
-       call ESMF_LogWrite(trim(subname)//": ERROR fname not present with FBin", &
-            ESMF_LOGMSG_ERROR, line=__LINE__, file=u_FILE_u, rc=dbrc)
-       rc = ESMF_FAILURE
-       return
+       call shr_sys_abort(trim(subname)//": ERROR fname not present with FBin", &
+            line=__LINE__, file=u_FILE_u, rc=dbrc)
     endif
 
     if (.not. FB_FldChk(FBout, trim(fnameout), rc=rc)) then
@@ -647,17 +636,14 @@ contains
 
        if (FBinfound) then
           if (lbound(dataPtr,1) /= lbound(dataOut,1) .or. ubound(dataPtr,1) /= ubound(dataOut,1)) then
-             call ESMF_LogWrite(trim(subname)//": ERROR FBin wrong size", &
-                  ESMF_LOGMSG_ERROR, line=__LINE__, file=u_FILE_u, rc=dbrc)
-             rc = ESMF_FAILURE
-             return
+             call shr_sys_abort(trim(subname)//": ERROR FBin wrong size", &
+                  line=__LINE__, file=u_FILE_u, rc=dbrc)
           endif
           if (wgtfound) then
              if (lbound(dataPtr,1) /= lbound(wgt,1) .or. ubound(dataPtr,1) /= ubound(wgt,1)) then
-                call ESMF_LogWrite(trim(subname)//": ERROR wgt wrong size", &
-                     ESMF_LOGMSG_ERROR, line=__LINE__, file=u_FILE_u, rc=dbrc)
-                rc = ESMF_FAILURE
-                return
+                
+                call shr_sys_abort(trim(subname)//": ERROR wgt wrong size", &
+                     line=__LINE__, file=u_FILE_u, rc=dbrc)
              endif
              do i = lb1,ub1
                 dataOut(i) = dataOut(i) + dataPtr(i) * wgt(i)
@@ -707,7 +693,7 @@ contains
 
     ! Get name of k-th field in colon deliminted list
 
-    use ESMF, only : ESMF_SUCCESS, ESMF_FAILURE, ESMF_LogWrite, ESMF_LOGMSG_INFO
+    use ESMF, only : ESMF_SUCCESS, ESMF_LogWrite, ESMF_LOGMSG_INFO
 
     ! input/output variables
     character(len=*)  ,intent(in)  :: list    ! list/string
@@ -745,20 +731,13 @@ contains
        return
     end if
     if (.not. valid_list) then
-       write(logunit,*) "ERROR: invalid list = ",trim(list)
-       call ESMF_LogWrite("ERROR: invalid list = "//trim(list), ESMF_LOGMSG_INFO)
-       rc = ESMF_FAILURE
-       return
+       call shr_sys_abort("ERROR: invalid list = "//trim(list))
     end if
 
     !--- check that this is a valid index ---
     kFlds = merge_listGetNum(list)
     if (k<1 .or. kFlds<k) then
-       write(logunit,*) "ERROR: invalid index = ",k
-       write(logunit,*) "ERROR:          list = ",trim(list)
-       call ESMF_LogWrite("ERROR: invalid index = "//trim(list), ESMF_LOGMSG_INFO)
-       rc = ESMF_FAILURE
-       return
+       call shr_sys_abort("ERROR: invalid index = "//trim(list))
     end if
 
     ! start with whole list, then remove fields before and after desired field ---

--- a/mediator/med_methods_mod.F90
+++ b/mediator/med_methods_mod.F90
@@ -15,7 +15,7 @@ module med_methods_mod
   use med_constants_mod  , only : czero => med_constants_czero
   use med_constants_mod  , only : spval_init => med_constants_spval_init
   use med_utils_mod      , only : ChkErr => med_utils_ChkErr
-
+  use shr_sys_mod        , only : shr_sys_abort
   implicit none
   private
 
@@ -167,10 +167,8 @@ contains
                   purpose="Instance", itemCount=ungriddedCount,  isPresent=isPresent, rc=rc)
              if (chkerr(rc,__LINE__,u_FILE_u)) return
              if (ungriddedCount /= 1) then
-                call ESMF_LogWrite(trim(subname)//": ERROR ungriddedCount for "// &
-                     trim(lfieldnamelist(n))//" must be 1 if rank is 2 ", ESMF_LOGMSG_INFO)
-                rc = ESMF_FAILURE
-                return
+                call shr_sys_abort(trim(subname)//": ERROR ungriddedCount for "// &
+                     trim(lfieldnamelist(n))//" must be 1 if rank is 2 ")
              end if
 
              ! set ungridded dimensions for field
@@ -203,12 +201,7 @@ contains
              if (chkerr(rc,__LINE__,u_FILE_u)) return
 
           else
-
-             call ESMF_LogWrite(trim(subname)//": ERROR only rank1 and rank2 are supported for rank of fields ", &
-                  ESMF_LOGMSG_INFO)
-             rc = ESMF_FAILURE
-             return
-
+             call shr_sys_abort(trim(subname)//": ERROR only rank1 and rank2 are supported for rank of fields ")
           end if
 
           ! Add new field to FBout
@@ -284,24 +277,15 @@ contains
     !---------------------------------
 
     if (present(fieldNameList) .and. present(FBflds) .and. present(STflds)) then
-      call ESMF_LogWrite(trim(subname)//": ERROR only fieldNameList, FBflds, or STflds can be an argument", &
-            ESMF_LOGMSG_INFO)
-      rc = ESMF_FAILURE
-      return
+      call shr_sys_abort(trim(subname)//": ERROR only fieldNameList, FBflds, or STflds can be an argument")
     endif
 
     if (present(FBgeom) .and. present(STgeom)) then
-       call ESMF_LogWrite(trim(subname)//": ERROR FBgeom and STgeom cannot both be arguments", &
-            ESMF_LOGMSG_INFO)
-      rc = ESMF_FAILURE
-      return
+       call shr_sys_abort(trim(subname)//": ERROR FBgeom and STgeom cannot both be arguments")
     endif
 
     if (.not.present(FBgeom) .and. .not.present(STgeom)) then
-       call ESMF_LogWrite(trim(subname)//": ERROR FBgeom or STgeom must be an argument", &
-            ESMF_LOGMSG_INFO)
-      rc = ESMF_FAILURE
-      return
+       call shr_sys_abort(trim(subname)//": ERROR FBgeom or STgeom must be an argument")
     endif
 
     if (present(FBgeom)) then
@@ -311,9 +295,7 @@ contains
       call ESMF_StateGet(STgeom, itemCount=fieldCountGeom, rc=rc)
       if (chkerr(rc,__LINE__,u_FILE_u)) return
     else
-      call ESMF_LogWrite(trim(subname)//": ERROR FBgeom or STgeom must be passed", ESMF_LOGMSG_INFO)
-      rc = ESMF_FAILURE
-      return
+      call shr_sys_abort(trim(subname)//": ERROR FBgeom or STgeom must be passed")
     endif
 
     !---------------------------------
@@ -364,10 +346,7 @@ contains
          call ESMF_LogWrite(trim(subname)//":"//trim(lname)//" fieldNameList from STgeom", ESMF_LOGMSG_INFO)
       end if
     else
-       call ESMF_LogWrite(trim(subname)//": ERROR fieldNameList, FBflds, STflds, FBgeom, or STgeom must be passed", &
-            ESMF_LOGMSG_INFO)
-      rc = ESMF_FAILURE
-      return
+       call shr_sys_abort(trim(subname)//": ERROR fieldNameList, FBflds, STflds, FBgeom, or STgeom must be passed")
     endif
 
     !---------------------------------
@@ -406,19 +385,15 @@ contains
            call ESMF_LogWrite(trim(subname)//":"//trim(lname)//" mesh from STgeom", ESMF_LOGMSG_INFO)
         end if
       else
-        call ESMF_LogWrite(trim(subname)//": ERROR FBgeom or STgeom must be passed", ESMF_LOGMSG_INFO)
-        rc = ESMF_FAILURE
-        return
+        call shr_sys_abort(trim(subname)//": ERROR FBgeom or STgeom must be passed")
       endif
 
-      ! Make sure the field is not empty - if it is return with an error
+      ! Make sure the field is not empty - if it is abort with an error
       call ESMF_FieldGet(lfield, status=status, rc=rc)
       if (chkerr(rc,__LINE__,u_FILE_u)) return
       if (status == ESMF_FIELDSTATUS_EMPTY) then
-         call ESMF_LogWrite(trim(subname)//":"//trim(lname)//": ERROR field does not have a geom yet ", &
-              ESMF_LOGMSG_ERROR, line=__LINE__, file=u_FILE_u)
-        rc = ESMF_FAILURE
-        return
+         call shr_sys_abort(trim(subname)//":"//trim(lname)//": ERROR field does not have a geom yet ", &
+              line=__LINE__, file=u_FILE_u)
       endif
 
       ! Assume field is on mesh
@@ -549,9 +524,7 @@ contains
     call ESMF_FieldBundleGet(FB, fieldCount=fieldCount, rc=rc)
     if (chkerr(rc,__LINE__,u_FILE_u)) return
     if (fieldnum > fieldCount) then
-      call ESMF_LogWrite(trim(subname)//": ERROR fieldnum > fieldCount ", ESMF_LOGMSG_ERROR)
-      rc = ESMF_FAILURE
-      return
+      call shr_sys_abort(trim(subname)//": ERROR fieldnum > fieldCount ")
     endif
     allocate(lfieldnamelist(fieldCount))
     call ESMF_FieldBundleGet(FB, fieldNameList=lfieldnamelist, rc=rc)
@@ -633,9 +606,7 @@ contains
     call ESMF_StateGet(State, itemCount=fieldCount, rc=rc)
     if (chkerr(rc,__LINE__,u_FILE_u)) return
     if (fieldnum > fieldCount) then
-      call ESMF_LogWrite(trim(subname)//": ERROR fieldnum > fieldCount ", ESMF_LOGMSG_ERROR)
-      rc = ESMF_FAILURE
-      return
+      call shr_sys_abort(trim(subname)//": ERROR fieldnum > fieldCount ")
     endif
     allocate(lfieldnamelist(fieldCount))
     call ESMF_StateGet(State, itemNameList=lfieldnamelist, rc=rc)
@@ -750,10 +721,8 @@ contains
        elseif (lrank == 2) then
           fldptr2 = lvalue
        else
-          call ESMF_LogWrite(trim(subname)//": ERROR in rank "//trim(lfieldnamelist(n)), &
-               ESMF_LOGMSG_ERROR, line=__LINE__, file=u_FILE_u)
-          rc = ESMF_FAILURE
-          return
+          call shr_sys_abort(trim(subname)//": ERROR in rank "//trim(lfieldnamelist(n)), &
+                line=__LINE__, file=u_FILE_u)
        endif
     enddo
 
@@ -822,10 +791,8 @@ contains
        elseif (lrank == 2) then
           fldptr2 = lvalue
        else
-          call ESMF_LogWrite(trim(subname)//": ERROR in rank "//trim(lfieldnamelist(n)), &
-               ESMF_LOGMSG_ERROR, line=__LINE__, file=u_FILE_u)
-          rc = ESMF_FAILURE
-          return
+          call shr_sys_abort(trim(subname)//": ERROR in rank "//trim(lfieldnamelist(n)), &
+               line=__LINE__, file=u_FILE_u)
        endif
     enddo
     deallocate(lfieldnamelist)
@@ -901,9 +868,7 @@ contains
           enddo
           enddo
         else
-          call ESMF_LogWrite(trim(subname)//": ERROR rank not supported ", ESMF_LOGMSG_ERROR)
-          rc = ESMF_FAILURE
-          return
+          call shr_sys_abort(trim(subname)//": ERROR rank not supported ")
         endif
       enddo
       deallocate(lfieldnamelist)
@@ -985,9 +950,7 @@ contains
           endif
 
        else
-          call ESMF_LogWrite(trim(subname)//": ERROR rank not supported ", ESMF_LOGMSG_ERROR)
-          rc = ESMF_FAILURE
-          return
+          call shr_sys_abort(trim(subname)//": ERROR rank not supported ")
        endif
        call ESMF_LogWrite(trim(msgString), ESMF_LOGMSG_INFO)
     enddo
@@ -1052,9 +1015,7 @@ contains
           call ESMF_FieldWriteVTK(lfield, trim(lfieldnamelist(n))//'_'//trim(lstring), rc=rc)
           if (chkerr(rc,__LINE__,u_FILE_u)) return
        else
-          call ESMF_LogWrite(trim(subname)//": ERROR rank not supported ", ESMF_LOGMSG_ERROR)
-          rc = ESMF_FAILURE
-          return
+          call shr_sys_abort(trim(subname)//": ERROR rank not supported ")
        endif
     end do
 
@@ -1179,9 +1140,7 @@ contains
                   " no data"
           endif
        else
-          call ESMF_LogWrite(trim(subname)//": ERROR rank not supported ", ESMF_LOGMSG_ERROR)
-          rc = ESMF_FAILURE
-          return
+          call shr_sys_abort(trim(subname)//": ERROR rank not supported ")
        endif
 
        call ESMF_LogWrite(trim(msgString), ESMF_LOGMSG_INFO)
@@ -1320,9 +1279,7 @@ contains
           write(msgString,'(A,a)') trim(subname)//' '//trim(lstring)//': '//trim(fieldname)," no data"
        endif
     else
-       call ESMF_LogWrite(trim(subname)//": ERROR rank not supported ", ESMF_LOGMSG_ERROR)
-       rc = ESMF_FAILURE
-       return
+       call shr_sys_abort(trim(subname)//": ERROR rank not supported ")
     endif
     call ESMF_LogWrite(trim(msgString), ESMF_LOGMSG_INFO)
 
@@ -1427,9 +1384,7 @@ contains
         elseif (lranki == 1 .and. lranko == 1) then
 
           if (.not.med_methods_FieldPtr_Compare(dataPtro1, dataPtri1, subname, rc)) then
-            call ESMF_LogWrite(trim(subname)//": ERROR in dataPtr1 size ", ESMF_LOGMSG_ERROR)
-            rc = ESMF_FAILURE
-            return
+            call shr_sys_abort(trim(subname)//": ERROR in dataPtr1 size ")
           endif
 
           if (lcopy) then
@@ -1445,9 +1400,7 @@ contains
         elseif (lranki == 2 .and. lranko == 2) then
 
           if (.not.med_methods_FieldPtr_Compare(dataPtro2, dataPtri2, subname, rc)) then
-            call ESMF_LogWrite(trim(subname)//": ERROR in dataPtr2 size ", ESMF_LOGMSG_ERROR)
-            rc = ESMF_FAILURE
-            return
+            call shr_sys_abort(trim(subname)//": ERROR in dataPtr2 size ")
           endif
 
           if (lcopy) then
@@ -1465,14 +1418,8 @@ contains
           endif
 
         else
-
           write(msgString,'(a,2i8)') trim(subname)//": ranki, ranko = ",lranki,lranko
-          call ESMF_LogWrite(trim(msgString), ESMF_LOGMSG_ERROR)
-          call ESMF_LogWrite(trim(subname)//": ERROR ranki ranko not supported "//trim(lfieldnamelist(n)), &
-               ESMF_LOGMSG_ERROR)
-          rc = ESMF_FAILURE
-          return
-
+          call shr_sys_abort(trim(subname)//": ERROR ranki ranko not supported "//trim(msgstring)//"\n"//trim(lfieldnamelist(n)))
         endif
 
       endif
@@ -1522,9 +1469,7 @@ contains
 
     call ESMF_FieldBundleGet(FB, fieldName=trim(fldname), isPresent=isPresent, rc=rc)
     if (chkerr(rc,__LINE__,u_FILE_u)) then
-       call ESMF_LogWrite(trim(subname)//" Error checking field: "//trim(fldname), &
-            ESMF_LOGMSG_ERROR)
-       return
+       call shr_sys_abort(string=trim(subname)//" Error checking field: "//trim(fldname), line=__LINE__,file=u_FILE_u)
     endif
     if (isPresent) then
        med_methods_FB_FldChk = .true.
@@ -1591,9 +1536,7 @@ contains
     if (status /= ESMF_FIELDSTATUS_COMPLETE) then
       lrank = 0
       if (labort) then
-        call ESMF_LogWrite(trim(subname)//": ERROR data not allocated ", ESMF_LOGMSG_INFO)
-        rc = ESMF_FAILURE
-        return
+         call shr_sys_abort(trim(subname)//": ERROR data not allocated ")
       else
         call ESMF_LogWrite(trim(subname)//": WARNING data not allocated ", ESMF_LOGMSG_INFO)
       endif
@@ -2631,8 +2574,7 @@ contains
        end if
     end do
     if (nanfound) then
-       call ESMF_LogWrite('ABORTING JOB', ESMF_LOGMSG_ERROR, line=__LINE__, file=u_FILE_u)
-       rc = ESMF_FAILURE
+       call shr_sys_abort('ABORTING JOB, see PET file for details', line=__LINE__, file=u_FILE_u)
     end if
     
   end subroutine med_methods_FB_check_for_nans

--- a/mediator/med_phases_aofluxes_mod.F90
+++ b/mediator/med_phases_aofluxes_mod.F90
@@ -22,7 +22,7 @@ module med_phases_aofluxes_mod
   use ESMF                  , only : ESMF_TERMORDER_SRCSEQ, ESMF_REGION_TOTAL, ESMF_MESHLOC_ELEMENT, ESMF_MAXSTR
   use ESMF                  , only : ESMF_XGRIDSIDE_B, ESMF_XGRIDSIDE_A, ESMF_END_ABORT, ESMF_LOGERR_PASSTHRU
   use ESMF                  , only : ESMF_Mesh, ESMF_MeshGet, ESMF_XGrid, ESMF_XGridCreate, ESMF_TYPEKIND_R8
-  use ESMF                  , only : ESMF_LogWrite, ESMF_LOGMSG_INFO, ESMF_SUCCESS, ESMF_LOGMSG_ERROR, ESMF_FAILURE
+  use ESMF                  , only : ESMF_LogWrite, ESMF_LOGMSG_INFO, ESMF_SUCCESS
   use ESMF                  , only : ESMF_Finalize, ESMF_LogFoundError
   use ESMF                  , only : ESMF_XGridGet, ESMF_MeshCreate, ESMF_MeshWrite, ESMF_KIND_R8
   use med_kind_mod          , only : CX=>SHR_KIND_CX, CS=>SHR_KIND_CS, CL=>SHR_KIND_CL, R8=>SHR_KIND_R8
@@ -39,7 +39,7 @@ module med_phases_aofluxes_mod
   use shr_const_mod         , only : rearth => SHR_CONST_REARTH
   use shr_const_mod         , only : pi => SHR_CONST_PI
 #endif
-
+  use shr_sys_mod           , only : shr_sys_abort
   implicit none
   private
 
@@ -667,11 +667,9 @@ contains
     else if (med_map_RH_is_created(is_local%wrap%RH(compocn,compatm,:), mapconsd, rc=rc)) then
        maptype = mapconsd
     else
-       call ESMF_LogWrite(trim(subname)//&
+       call shr_sys_abort(trim(subname)//&
             ": maptype for atm->ocn mapping of So_mask must be either mapfcopy or mapconsd", &
-            ESMF_LOGMSG_ERROR, line=__LINE__, file=u_FILE_u)
-       rc = ESMF_FAILURE
-       return
+            line=__LINE__, file=u_FILE_u)
     end if
 
     ! ------------------------
@@ -1226,11 +1224,9 @@ contains
        else if (med_map_RH_is_created(is_local%wrap%RH(compocn,compatm,:), mapconsd, rc=rc)) then
           maptype = mapconsd
        else
-          call ESMF_LogWrite(trim(subname)//&
+          call shr_sys_abort(trim(subname)//&
                ": maptype for atm->ocn mapping of aofluxes from atm->ocn either mapfcopy or mapconsd", &
-               ESMF_LOGMSG_ERROR, line=__LINE__, file=u_FILE_u)
-          rc = ESMF_FAILURE
-          return
+               line=__LINE__, file=u_FILE_u)
        end if
 
        ! Map ocn->atm conservatively without fractions
@@ -1425,11 +1421,9 @@ end subroutine med_aofluxes_map_ogrid2xgrid_input
        else if (med_map_RH_is_created(is_local%wrap%RH(compatm,compocn,:), mapconsf, rc=rc)) then
           maptype = mapconsf
        else
-          call ESMF_LogWrite(trim(subname)//&
+          call shr_sys_abort(trim(subname)//&
                ": maptype for atm->ocn mapping of aofluxes from atm->ocn either mapfcopy or mapconsf", &
-               ESMF_LOGMSG_ERROR, line=__LINE__, file=u_FILE_u)
-          rc = ESMF_FAILURE
-          return
+               line=__LINE__, file=u_FILE_u)
        end if
        call ESMF_FieldRegrid(field_src, field_dst, &
             routehandle=is_local%wrap%RH(compatm, compocn, maptype), &

--- a/mediator/med_phases_history_mod.F90
+++ b/mediator/med_phases_history_mod.F90
@@ -12,9 +12,8 @@ module med_phases_history_mod
   use ESMF                  , only : ESMF_TimeInterval, ESMF_TimeIntervalGet, ESMF_TimeIntervalSet
   use ESMF                  , only : ESMF_Alarm, ESMF_AlarmIsRinging, ESMF_AlarmRingerOff, ESMF_AlarmGet
   use ESMF                  , only : ESMF_FieldBundle, ESMF_FieldBundleGet
-  use ESMF                  , only : ESMF_LogWrite, ESMF_LOGMSG_INFO, ESMF_LOGMSG_ERROR, ESMF_LogFoundError
-  use ESMF                  , only : ESMF_SUCCESS, ESMF_FAILURE, ESMF_MAXSTR, ESMF_LOGERR_PASSTHRU, ESMF_END_ABORT
-  use ESMF                  , only : ESMF_Finalize
+  use ESMF                  , only : ESMF_LogWrite, ESMF_LOGMSG_INFO
+  use ESMF                  , only : ESMF_SUCCESS, ESMF_MAXSTR, ESMF_LOGERR_PASSTHRU, ESMF_END_ABORT
   use ESMF                  , only : operator(-), operator(+)
   use NUOPC                 , only : NUOPC_CompAttributeGet
   use NUOPC_Model           , only : NUOPC_ModelGet
@@ -24,7 +23,7 @@ module med_phases_history_mod
   use med_io_mod            , only : med_io_write, med_io_wopen, med_io_enddef, med_io_close
   use perf_mod              , only : t_startf, t_stopf
   use pio                   , only : file_desc_t
-
+  use shr_sys_mod           , only : shr_sys_abort
   implicit none
   private
 
@@ -1208,12 +1207,7 @@ contains
                 call ESMF_FieldBundleGet(auxcomp%files(nfcnt)%FBAccum, fieldCount=nfld, rc=rc)
                 if (chkerr(rc,__LINE__,u_FILE_u)) return
                 if (nfld == 0) then
-                   call ESMF_LogWrite(subname//'FBAccum is zero for '//trim(auxcomp%files(nfcnt)%auxname), &
-                        ESMF_LOGMSG_ERROR)
-                   rc = ESMF_FAILURE
-                   if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=u_FILE_u)) then
-                      call ESMF_Finalize(endflag=ESMF_END_ABORT)
-                   end if
+                   call shr_sys_abort(subname//'FBAccum is zero for '//trim(auxcomp%files(nfcnt)%auxname))
                 end if
 
              end if
@@ -1376,10 +1370,7 @@ contains
          valid = .false.
       end if
       if (.not. valid) then
-         if (maintask) write(logunit,*) "ERROR: invalid list = ",trim(str)
-         call ESMF_LogWrite("ERROR: invalid list = "//trim(str), ESMF_LOGMSG_ERROR)
-         rc = ESMF_FAILURE
-         return
+         call shr_sys_abort("ERROR: invalid list = "//trim(str))
       end if
       ! get number of fields in a colon delimited string list
       nflds = 0
@@ -1462,9 +1453,8 @@ contains
        if (chkerr(rc,__LINE__,u_FILE_u)) return
 
        if (ungriddedUBound(1) /= ungriddedUBound_accum(1)) then
-          call ESMF_LogWrite(" upper bounds for field and field_accum do not match", &
-               ESMF_LOGMSG_ERROR, line=__LINE__, file=u_FILE_u)
-          rc = ESMF_FAILURE
+          call shr_sys_abort(" upper bounds for field and field_accum do not match", &
+               line=__LINE__, file=u_FILE_u)
        end if
 
        if (ungriddedUBound(1) > 0) then

--- a/mediator/med_phases_post_glc_mod.F90
+++ b/mediator/med_phases_post_glc_mod.F90
@@ -7,7 +7,7 @@ module med_phases_post_glc_mod
 
   use med_kind_mod          , only : CX=>SHR_KIND_CX, CS=>SHR_KIND_CS, CL=>SHR_KIND_CL, R8=>SHR_KIND_R8
   use NUOPC                 , only : NUOPC_CompAttributeGet
-  use ESMF                  , only : ESMF_LogWrite, ESMF_LOGMSG_INFO, ESMF_LOGMSG_ERROR, ESMF_SUCCESS, ESMF_FAILURE
+  use ESMF                  , only : ESMF_LogWrite, ESMF_LOGMSG_INFO, ESMF_SUCCESS
   use ESMF                  , only : ESMF_FieldBundle, ESMF_FieldBundleGet
   use ESMF                  , only : ESMF_GridComp, ESMF_GridCompGet
   use ESMF                  , only : ESMF_StateGet, ESMF_StateItem_Flag
@@ -30,7 +30,7 @@ module med_phases_post_glc_mod
   use med_map_mod           , only : med_map_field_packed, med_map_field_normalized, med_map_field
   use glc_elevclass_mod     , only : glc_mean_elevation_virtual, glc_get_fractional_icecov
   use perf_mod              , only : t_startf, t_stopf
-
+  use shr_sys_mod           , only : shr_sys_abort
   implicit none
   private
 
@@ -333,10 +333,8 @@ contains
 
     ! Currently cannot map hflx in multiple elevation classes from glc to land
     if (fldbun_fldchk(is_local%wrap%FBExp(complnd), trim(Flgg_hflx), rc=rc)) then
-       call ESMF_LogWrite(trim(subname)//'ERROR: Flgg_hflx to land has not been implemented yet', &
-            ESMF_LOGMSG_ERROR, line=__LINE__, file=__FILE__)
-       rc = ESMF_FAILURE
-       return
+       call shr_sys_abort(trim(subname)//'ERROR: Flgg_hflx to land has not been implemented yet', &
+            line=__LINE__, file=__FILE__)
     end if
 
   end subroutine map_glc2lnd_init

--- a/mediator/med_phases_prep_glc_mod.F90
+++ b/mediator/med_phases_prep_glc_mod.F90
@@ -7,7 +7,7 @@ module med_phases_prep_glc_mod
   use med_kind_mod          , only : CX=>SHR_KIND_CX, CS=>SHR_KIND_CS, CL=>SHR_KIND_CL, R8=>SHR_KIND_R8
   use NUOPC                 , only : NUOPC_CompAttributeGet
   use NUOPC_Model           , only : NUOPC_ModelGet
-  use ESMF                  , only : ESMF_LogWrite, ESMF_LOGMSG_INFO, ESMF_LOGMSG_ERROR, ESMF_SUCCESS, ESMF_FAILURE
+  use ESMF                  , only : ESMF_LogWrite, ESMF_LOGMSG_INFO, ESMF_SUCCESS, ESMF_FAILURE
   use ESMF                  , only : ESMF_VM, ESMF_VMGet, ESMF_VMAllReduce, ESMF_REDUCE_SUM, ESMF_REDUCE_MAX
   use ESMF                  , only : ESMF_Clock, ESMF_ClockCreate, ESMF_ClockIsCreated
   use ESMF                  , only : ESMF_ClockGetAlarm, ESMF_ClockAdvance, ESMF_ClockGet
@@ -44,7 +44,8 @@ module med_phases_prep_glc_mod
   use glc_elevclass_mod     , only : glc_get_elevation_classes
   use glc_elevclass_mod     , only : glc_get_fractional_icecov
   use perf_mod              , only : t_startf, t_stopf
-
+  use shr_sys_mod           , only : shr_sys_abort
+  
   implicit none
   private
 
@@ -222,10 +223,8 @@ contains
 
           ! create route handle if it has not been created
           if (.not. med_map_RH_is_created(is_local%wrap%RH(complnd,compglc(ns),:),mapbilnr,rc=rc)) then
-             call ESMF_LogWrite(trim(subname)//" mapbilnr is not created for lnd->glc mapping", &
-                  ESMF_LOGMSG_ERROR, line=__LINE__, file=u_FILE_u)
-             rc = ESMF_FAILURE
-             return
+             call shr_sys_abort(trim(subname)//" mapbilnr is not created for lnd->glc mapping", &
+                  line=__LINE__, file=u_FILE_u)
           end if
        end do
 
@@ -239,11 +238,8 @@ contains
        case ('off')
           smb_renormalize = .false.
        case default
-          write(logunit,*) subname,' ERROR: unknown value for glc_renormalize_smb: ', trim(glc_renormalize_smb)
-          call ESMF_LogWrite(trim(subname)//' ERROR: unknown value for glc_renormalize_smb: '// trim(glc_renormalize_smb), &
-               ESMF_LOGMSG_ERROR, line=__LINE__, file=__FILE__)
-          rc = ESMF_FAILURE
-          return
+          call shr_sys_abort(trim(subname)//' ERROR: unknown value for glc_renormalize_smb: '// trim(glc_renormalize_smb), &
+               line=__LINE__, file=__FILE__)
        end select
        if (maintask) then
           write(logunit,'(a,l4)') trim(subname)//' smb_renormalize is ',smb_renormalize
@@ -331,10 +327,8 @@ contains
        ! create route handle if it has not been created
        do ns = 1,is_local%wrap%num_icesheets
           if (.not. med_map_RH_is_created(is_local%wrap%RH(compocn,compglc(ns),:),mapbilnr,rc=rc)) then
-             call ESMF_LogWrite(trim(subname)//" mapbilnr is not created for ocn->glc mapping", &
-                  ESMF_LOGMSG_ERROR, line=__LINE__, file=u_FILE_u)
-             rc = ESMF_FAILURE
-             return
+             call shr_sys_abort(trim(subname)//" mapbilnr is not created for ocn->glc mapping", &
+                  line=__LINE__, file=u_FILE_u)
           end if
        end do
 

--- a/mediator/med_phases_prep_rof_mod.F90
+++ b/mediator/med_phases_prep_rof_mod.F90
@@ -26,7 +26,8 @@ module med_phases_prep_rof_mod
   use med_methods_mod       , only : fldbun_fldchk    => med_methods_FB_fldchk
   use med_methods_mod       , only : FB_check_for_nans => med_methods_FB_check_for_nans
   use perf_mod              , only : t_startf, t_stopf
-
+  use shr_sys_mod           , only : shr_sys_abort
+  
   implicit none
   private
 
@@ -471,7 +472,7 @@ contains
     use ESMF        , only : ESMF_FieldBundle, ESMF_FieldBundleGet, ESMF_FieldIsCreated
     use ESMF        , only : ESMF_Mesh, ESMF_TYPEKIND_R8, ESMF_MESHLOC_ELEMENT
     use ESMF        , only : ESMF_SUCCESS, ESMF_FAILURE
-    use ESMF        , only : ESMF_LOGMSG_INFO, ESMF_LogWrite, ESMF_LOGMSG_ERROR
+    use ESMF        , only : ESMF_LOGMSG_INFO, ESMF_LogWrite
     use med_map_mod , only : med_map_rh_is_created, med_map_field, med_map_field_normalized
 
     ! input/output variables
@@ -516,11 +517,8 @@ contains
     else if ( med_map_RH_is_created(is_local%wrap%RH(complnd,comprof,:),mapfcopy, rc=rc)) then
        maptype_lnd2rof = mapfcopy
     else
-       call ESMF_LogWrite(trim(subname)//&
-            ": ERROR conservative or redist route handles not created for lnd->rof mapping", &
-            ESMF_LOGMSG_ERROR)
-       rc = ESMF_FAILURE
-       return
+       call shr_sys_abort(trim(subname)//&
+            ": ERROR conservative or redist route handles not created for lnd->rof mapping")
     end if
 
     if (med_map_RH_is_created(is_local%wrap%RH(comprof,complnd,:),mapconsf, rc=rc)) then
@@ -528,11 +526,8 @@ contains
     else if ( med_map_RH_is_created(is_local%wrap%RH(comprof,complnd,:),mapfcopy, rc=rc)) then
        maptype_rof2lnd = mapfcopy
     else
-       call ESMF_LogWrite(trim(subname)//&
-            ": ERROR conservative or redist route handles not created for rof->lnd mapping", &
-            ESMF_LOGMSG_ERROR)
-       rc = ESMF_FAILURE
-       return
+       call shr_sys_abort(trim(subname)//&
+            ": ERROR conservative or redist route handles not created for rof->lnd mapping")
     end if
 
     ! ------------------------------------------------------------------------


### PR DESCRIPTION
### Description of changes
Replace calls to ESMF_LogWrite that preceed an error exit with calls to shr_sys_abort which will include the error message in both the ESMF pet file and
the component log for the appropriate component.   This requires an update to the cesm_share code as well.

### Specific notes

Contributors other than yourself, if any:

CMEPS Issues Fixed (include github issue #):

Are changes expected to change answers? (specify if bfb, different at roundoff, more substantial) 

Any User Interface Changes (namelist or namelist defaults changes)?

### Testing performed
Please describe the tests along with the target model and machine(s) 
If possible, please also added hashes that were used in the testing

