### PR TITLE
Add RUN_POSTPROCESSING variable to env_run.xml

### DIFF
--- a/cime_config/config_component.xml
+++ b/cime_config/config_component.xml
@@ -568,6 +568,16 @@
     If TRUE, short term archiving will be turned on.</desc>
   </entry>
 
+  <entry id="RUN_POSTPROCESSING">
+    <type>logical</type>
+    <valid_values>TRUE,FALSE</valid_values>
+    <default_value>FALSE</default_value>
+    <group>run_data_archive</group>
+    <file>env_run.xml</file>
+    <desc>Logical to run post-processing analysis tools.
+    If TRUE, post-processing scripts will be run</desc>
+  </entry>
+
   <entry id="SYSLOG_N">
     <type>integer</type>
     <default_value>900</default_value>


### PR DESCRIPTION
### Description of changes
A new variable named `RUN_POSTPROCESSING` has been added to `env_run.xml`. This variable will be `FALSE` by default, but setting it to `TRUE` will (eventually) run some postprocessing scripts as part of the default workflow. In that respect, its behavior will be similar to how `DOUT_S` controls the short-term archiver.

This is part of the CESM push to add [CUPiD](https://github.com/NCAR/CUPiD) to the CESM workflow. @rljacob asked that we keep the name generic (so this is not `RUN_CUPID_ANALYSIS` 😄), and the CUPiD team is definitely willing to change this to something else. It's not entirely clear that CMEPS is the best place to define this variable, as it stands it will show up in `env_case.xml` for all models using CMEPS but setting it to `TRUE` won't do anything in any of them except CESM.


### Specific notes

Contributors other than yourself, if any: @teaganking @billsacks @jedwards4b and @ekluzek all contributed during a recent hackathon

CMEPS Issues Fixed (include github issue #): N/A

Are changes expected to change answers? bfb

Any User Interface Changes (namelist or namelist defaults changes)? None

### Testing performed
Please describe the tests along with the target model and machine(s) 
If possible, please also added hashes that were used in the testing

