### PR TITLE
always set atmocn grid to ogrid with datm

### DIFF
--- a/cime_config/namelist_definition_drv.xml
+++ b/cime_config/namelist_definition_drv.xml
@@ -910,7 +910,7 @@
     <valid_values>ogrid,agrid,xgrid</valid_values>
     <desc>
       Grid for atm ocn flux calc
-      default: ogrid
+      default: xgrid for fully coupled cases, ogrid for datm
     </desc>
     <values>
       <value>xgrid</value>

--- a/cime_config/namelist_definition_drv.xml
+++ b/cime_config/namelist_definition_drv.xml
@@ -917,6 +917,7 @@
       <!-- xgrid introduces unnecessary cost and complexity if atm & ocn are on the same
       grid, so fall back to ogrid in that case -->
       <value samegrid_atm_ocn='true'>ogrid</value>
+      <value COMP_ATM='datm'>ogrid</value>
     </values>
   </entry>
   <entry id="ocn_surface_flux_scheme">


### PR DESCRIPTION
### Description of changes
Always default to ogrid when atm model is datm.

### Specific notes

Contributors other than yourself, if any:

CMEPS Issues Fixed (include github issue #):

Are changes expected to change answers? (specify if bfb, different at roundoff, more substantial) 

Any User Interface Changes (namelist or namelist defaults changes)?

### Testing performed
Please describe the tests along with the target model and machine(s) 
If possible, please also added hashes that were used in the testing

