### PR TITLE
Keep glc-derived runoff as separate fields to ocn if possible

### DIFF
--- a/mediator/esmFldsExchange_cesm_mod.F90
+++ b/mediator/esmFldsExchange_cesm_mod.F90
@@ -144,6 +144,8 @@ contains
     character(len=CS)   :: mrgfld_source
     logical             :: wav_coupling_to_cice
     logical             :: ocn2glc_coupling
+    logical             :: forr_rofl_glc_merged_to_ocn
+    logical             :: forr_rofi_glc_merged_to_ocn
     character(len=*) , parameter   :: subname=' (esmFldsExchange_cesm) '
     !--------------------------------------
 
@@ -2419,12 +2421,21 @@ contains
       end if
 
       ! Liquid runoff from land and glc - merging
+      forr_rofl_glc_merged_to_ocn = .false.
+      if ( fldchk(is_local%wrap%FBExp(compocn), 'Forr_rofl_glc', rc=rc) .and. &
+           fldchk(is_local%wrap%FBImp(comprof, comprof), 'Forr_rofl_glc', rc=rc)) then
+        ! If the ocean is prepared to handle Forr_rofl_glc as a separate field, then keep
+        ! it as a separate field rather than merging it to Foxx_rofl
+        call addmrg_to(compocn, 'Forr_rofl_glc', mrg_from=comprof, mrg_fld='Forr_rofl_glc', mrg_type='copy')
+        forr_rofl_glc_merged_to_ocn = .true.
+      end if
       if ( fldchk(is_local%wrap%FBExp(compocn), 'Foxx_rofl' , rc=rc)) then
         mrgfld_source = 'Forr_rofl'
         if (fldchk(is_local%wrap%FBImp(comprof, comprof), 'Flrr_flood', rc=rc)) then
           mrgfld_source = trim(mrgfld_source) //':Flrr_flood'
         end if
-        if (fldchk(is_local%wrap%FBImp(comprof, comprof), 'Forr_rofl_glc', rc=rc)) then
+        if (fldchk(is_local%wrap%FBImp(comprof, comprof), 'Forr_rofl_glc', rc=rc) .and. &
+            .not. forr_rofl_glc_merged_to_ocn) then
           mrgfld_source = trim(mrgfld_source) //':Forr_rofl_glc'
         end if
         call addmrg_to(compocn, 'Foxx_rofl', mrg_from=comprof, mrg_fld=trim(mrgfld_source), mrg_type='sum')
@@ -2452,9 +2463,18 @@ contains
       end if
 
       ! Frozen runoff from land and glc - merging
+      forr_rofi_glc_merged_to_ocn = .false.
+      if ( fldchk(is_local%wrap%FBExp(compocn), 'Forr_rofi_glc', rc=rc) .and. &
+           fldchk(is_local%wrap%FBImp(comprof, comprof), 'Forr_rofi_glc', rc=rc)) then
+        ! If the ocean is prepared to handle Forr_rofi_glc as a separate field, then keep
+        ! it as a separate field rather than merging it to Foxx_rofi
+        call addmrg_to(compocn, 'Forr_rofi_glc', mrg_from=comprof, mrg_fld='Forr_rofi_glc', mrg_type='copy')
+        forr_rofi_glc_merged_to_ocn = .true.
+      end if
       if ( fldchk(is_local%wrap%FBExp(compocn), 'Foxx_rofi' , rc=rc)) then
         mrgfld_source = 'Forr_rofi'
-        if (fldchk(is_local%wrap%FBImp(comprof, comprof), 'Forr_rofi_glc', rc=rc)) then
+        if (fldchk(is_local%wrap%FBImp(comprof, comprof), 'Forr_rofi_glc', rc=rc) .and. &
+            .not. forr_rofi_glc_merged_to_ocn) then
           mrgfld_source = trim(mrgfld_source) //':Forr_rofi_glc'
         end if
         call addmrg_to(compocn, 'Foxx_rofi', mrg_from=comprof, mrg_fld=trim(mrgfld_source), mrg_type='sum')


### PR DESCRIPTION
### Description of changes

When @mvertens reworked the GLC -> OCN runoff mapping, she put in place hooks to keep the glc-derived runoff separate from the lnd-derived runoff. However, @gustavo-marques found that these are still being combined into a single merged flux. (That may have been the intent at the time, until ocean models were ready to accept this new flux. I know we had extensive conversations about this, but don't remember all of the details.)

This PR separates these two fluxes so that the ocean can separately account for the lnd vs glc-derived runoff and the associated heat fluxes. I have done this in a way so that, if we're coupled to an ocean model that doesn't expect this separate glc-derived runoff (Forr_rofl_glc and Forr_rofi_glc), then it will continue to be merged into the Foxx_rofl and Foxx_rofi fluxes. (MOM6 is set up to handle the glc-specific fluxes; I'm not sure about BLOM in NorESM.)

### Specific notes

Contributors other than yourself, if any: none

CMEPS Issues Fixed (include github issue #): none

Are changes expected to change answers? YES - substantial diffs in a few fields, and expected to be roundoff-level diffs system-wide.

There are large differences in the fields ocnExp_Foxx_rofi, ocnExp_Forr_rofi_glc, ocnExp_Foxx_hrofi, and ocnExp_Foxx_hrofi_glc due to redistribution of fluxes between these different fields. Beyond that, there will be roundoff-level differences if the separation of these runoff terms is just for diagnostic purposes and the ocean model treats them identically. (The differences then just arise from order of operations differences due to having two separate fluxes in place of a single, combined flux.) In theory an ocean model could do different things with these fluxes, and that would lead to more substantial differences, but I don't think that's currently the case, at least for CESM / MOM.

Any User Interface Changes (namelist or namelist defaults changes)? No

### Testing performed

Tested in the context of cesm3_0_alpha06c.

I ran a few permutations of the test `SMS_Ld5.ne30pg3_t232.BLT1850.derecho_intel.allactive-decstart`.

I confirmed that, with the changes here, ocnExp_Forr_rofi_glc is non-zero, and ocnExp_Foxx_rofi is 0 around Greenland, as expected.

I added hourly coupler history output by making this change:
```
./xmlchange HIST_OPTION=nsteps,HIST_N=1
./xmlchange --file env_test.xml HIST_OPTION=nsteps,HIST_N=1
./xmlchange ROF_NCPL=24,GLC_NCPL=24,OCN_NCPL=24
```

Comparing with a baseline run, the first diffs appear at time `2002-01-01-07200`.

There are diffs in the following fields, as expected:

```
 RMS ocnExp_Forr_rofi_glc             1.2583E-07            NORMALIZED  2.0450E+01
 RMS ocnExp_Foxx_hrofi                3.8657E-04            NORMALIZED  4.2437E-01
 RMS ocnExp_Foxx_hrofi_glc            3.8657E-04            NORMALIZED  2.7026E+01
 RMS ocnExp_Foxx_rofi                 1.2583E-07            NORMALIZED  7.2900E-01
```

I summed ocnExp_Forr_rofi_glc+ocnExp_Foxx_rofi in the new run and the baseline and verified that, in this first time with differences, the sums are identical in the new and baseline. Similarly for ocnExp_Foxx_hrofi+ocnExp_Foxx_hrofi_glc, although there are roundoff-level differences in that sum.

In addition, there are diffs in these fields from the ocean:

```
 RMS ocnImp_Fioo_q                    7.8187E-13            NORMALIZED  7.9219E-18
 RMS ocnImp_So_bldepth                2.4854E-14            NORMALIZED  1.1975E-15
 RMS ocnImp_So_s                      6.7742E-16            NORMALIZED  3.3799E-17
 RMS ocnImp_So_t                      2.7349E-16            NORMALIZED  1.6198E-18
```

Note that those are all roundoff-level different.

After that time, differences grow, but the above analysis makes me comfortable that the changes in this PR only introduce roundoff-level diffs in the system.

I also verified that, if MOM doesn't advertise Forr_rofl_glc and Forr_rofi_glc, the behavior reverts to what it was before the changes in this PR. To do this, I needed to change some code in CMEPS related to the calculation of heat fluxes in addition to the changes in MOM. Full diffs were:

```diff
diff --git a/config_src/drivers/nuopc_cap/mom_cap.F90 b/config_src/drivers/nuopc_cap/mom_cap.F90
index bb7572ed7..2265a0a65 100644
--- a/config_src/drivers/nuopc_cap/mom_cap.F90
+++ b/config_src/drivers/nuopc_cap/mom_cap.F90
@@ -810,10 +810,6 @@ subroutine InitializeAdvertise(gcomp, importState, exportState, clock, rc)
   call fld_list_add(fldsToOcn_num, fldsToOcn, "Sa_pslv"        , "will provide")
   call fld_list_add(fldsToOcn_num, fldsToOcn, "Foxx_rofl"      , "will provide") !-> liquid runoff
   call fld_list_add(fldsToOcn_num, fldsToOcn, "Foxx_rofi"      , "will provide") !-> ice runoff
-  if (cesm_coupled) then
-    call fld_list_add(fldsToOcn_num, fldsToOcn, "Forr_rofl_glc"  , "will provide") !-> liquid glc runoff
-    call fld_list_add(fldsToOcn_num, fldsToOcn, "Forr_rofi_glc"  , "will provide") !-> frozen glc runoff
-  endif
   call fld_list_add(fldsToOcn_num, fldsToOcn, "Si_ifrac"       , "will provide") !-> ice fraction
   call fld_list_add(fldsToOcn_num, fldsToOcn, "So_duu10n"      , "will provide") !-> wind^2 at 10m
   call fld_list_add(fldsToOcn_num, fldsToOcn, "Fioi_meltw"     , "will provide")
diff --git a/config_src/drivers/nuopc_cap/mom_cap_methods.F90 b/config_src/drivers/nuopc_cap/mom_cap_methods.F90
index 180202c7e..fe243f7bf 100644
--- a/config_src/drivers/nuopc_cap/mom_cap_methods.F90
+++ b/config_src/drivers/nuopc_cap/mom_cap_methods.F90
@@ -218,17 +218,11 @@ subroutine mom_import(ocean_public, ocean_grid, importState, ice_ocean_boundary,
   ! liquid glc runoff
   if ( associated(ice_ocean_boundary%lrunoff_glc) ) then
     ice_ocean_boundary%lrunoff_glc (:,:) = 0._ESMF_KIND_R8
-    call state_getimport(importState, 'Forr_rofl_glc',  &
-         isc, iec, jsc, jec, ice_ocean_boundary%lrunoff_glc, areacor=med2mod_areacor, rc=rc)
-    if (ChkErr(rc,__LINE__,u_FILE_u)) return
   endif
 
   ! frozen glc runoff
   if ( associated(ice_ocean_boundary%frunoff_glc) ) then
     ice_ocean_boundary%frunoff_glc (:,:) = 0._ESMF_KIND_R8
-    call state_getimport(importState, 'Forr_rofi_glc',  &
-         isc, iec, jsc, jec, ice_ocean_boundary%frunoff_glc, areacor=med2mod_areacor, rc=rc)
-    if (ChkErr(rc,__LINE__,u_FILE_u)) return
   endif
 
   !----
```

and

```diff
diff --git a/mediator/med_phases_prep_ocn_mod.F90 b/mediator/med_phases_prep_ocn_mod.F90
index e30c4ada..e5222288 100644
--- a/mediator/med_phases_prep_ocn_mod.F90
+++ b/mediator/med_phases_prep_ocn_mod.F90
@@ -171,9 +171,7 @@ contains
          FB_fldchk(is_local%wrap%FBExp(compocn), 'Foxx_hrofl'     , rc=rc) .and. &
          FB_fldchk(is_local%wrap%FBExp(compocn), 'Foxx_rofi'      , rc=rc) .and. &
          FB_fldchk(is_local%wrap%FBExp(compocn), 'Foxx_hrofi'     , rc=rc) .and. &
-         FB_fldchk(is_local%wrap%FBExp(compocn), 'Forr_rofl_glc'  , rc=rc) .and. &
          FB_fldchk(is_local%wrap%FBExp(compocn), 'Foxx_hrofl_glc' , rc=rc) .and. &
-         FB_fldchk(is_local%wrap%FBExp(compocn), 'Forr_rofi_glc'  , rc=rc) .and. &
          FB_fldchk(is_local%wrap%FBExp(compocn), 'Foxx_hrofi_glc' , rc=rc)) then
 
        call FB_GetFldPtr(is_local%wrap%FBImp(compocn,compocn), 'So_t', tocn, rc=rc)
@@ -206,13 +204,9 @@ contains
        call FB_GetFldPtr(is_local%wrap%FBExp(compocn), 'Foxx_hrofi', hrofi, rc=rc)
        if (ChkErr(rc,__LINE__,u_FILE_u)) return
 
-       call FB_GetFldPtr(is_local%wrap%FBExp(compocn), 'Forr_rofl_glc' , rofl_glc, rc=rc)
-       if (ChkErr(rc,__LINE__,u_FILE_u)) return
        call FB_GetFldPtr(is_local%wrap%FBExp(compocn), 'Foxx_hrofl_glc', hrofl_glc, rc=rc)
        if (ChkErr(rc,__LINE__,u_FILE_u)) return
 
-       call FB_GetFldPtr(is_local%wrap%FBExp(compocn), 'Forr_rofi_glc' , rofi_glc, rc=rc)
-       if (ChkErr(rc,__LINE__,u_FILE_u)) return
        call FB_GetFldPtr(is_local%wrap%FBExp(compocn), 'Foxx_hrofi_glc', hrofi_glc, rc=rc)
        if (ChkErr(rc,__LINE__,u_FILE_u)) return
 
@@ -224,8 +218,8 @@ contains
           hcond(n)  = max((tocn(n) - shr_const_tkfrz), 0._r8) * max(evap(n), 0._r8)  * shr_const_cpsw
           hrofl(n)  = max((tocn(n) - shr_const_tkfrz), 0._r8) * rofl(n)  * shr_const_cpsw
           hrofi(n)  = min((tocn(n) - shr_const_tkfrz), 0._r8) * rofi(n)  * shr_const_cpsw
-          hrofl_glc(n) = max((tocn(n) - shr_const_tkfrz), 0._r8) * rofl_glc(n)  * shr_const_cpsw
-          hrofi_glc(n) = min((tocn(n) - shr_const_tkfrz), 0._r8) * rofi_glc(n)  * shr_const_cpsw
+          hrofl_glc(n) = max((tocn(n) - shr_const_tkfrz), 0._r8) * 0._r8  * shr_const_cpsw
+          hrofi_glc(n) = min((tocn(n) - shr_const_tkfrz), 0._r8) * 0._r8  * shr_const_cpsw
        end do
 
        ! Determine enthalpy correction factor that will be added to the sensible heat flux sent to the atm
```


