### PR TITLE
Make check of ROF_NCPL pass by updating default

### DIFF
--- a/cime_config/config_component_cesm.xml
+++ b/cime_config/config_component_cesm.xml
@@ -379,7 +379,7 @@
     <type>integer</type>
     <default_value>8</default_value>
     <values match="last">
-      <value compset="_DATM.*_MOM6.*_DROF"        >$ATM_NCPL</value>
+      <value compset="_DATM.*_MOM6.*_DROF"        >$OCN_NCPL</value>
       <value compset="_DATM.*_BLOM.*_DROF"        >$ATM_NCPL</value>
       <value compset="_DATM.*_DOCN%SOM"           >$ATM_NCPL</value>
       <value compset="_DATM.*_SLND.*_DICE.*_DOCN" >$ATM_NCPL</value>


### PR DESCRIPTION
### Description of changes
Components with "_DATM.\*_MOM6.\*_DROF" in their names have ROF_NCPL set to $ATM_NCPL by default, which can fail the check against $OCN_NCPL.  Changed ATM to OCN.

### Specific notes

Contributors other than yourself, if any:

CMEPS Issues Fixed (include github issue #):
#551

Are changes expected to change answers? (specify if bfb, different at roundoff, more substantial) 
No

Any User Interface Changes (namelist or namelist defaults changes)?
No

### Testing performed
Please describe the tests along with the target model and machine(s) 
If possible, please also added hashes that were used in the testing
This change enables a resolution TL319_t232 in compset G_JRA_RYF in cesm3.0_alphabranch (recently merged into master) to build.  Tests with cesm3_0_beta05 showed that this change does not prevent running.
