### PR TITLE
Make st_archive handle the .hx coupler history files

### DIFF
--- a/cime_config/config_archive.xml
+++ b/cime_config/config_archive.xml
@@ -1,7 +1,7 @@
 <components version="2.0">
   <comp_archive_spec compname="drv" compclass="cpl">
     <rest_file_extension>r</rest_file_extension>
-    <hist_file_extension>hi?\d*.*\.nc$</hist_file_extension>
+    <hist_file_extension>h[ix]?\d*\..*\.nc(\.gz)?$</hist_file_extension>
     <rest_history_varname>unset</rest_history_varname>
     <rpointer>
       <rpointer_file>rpointer.cpl$NINST_STRING</rpointer_file>


### PR DESCRIPTION
### Description of changes
Small change to config_archive.xml to include .hx files in addition to the .hi files.

### Specific notes

CMEPS Issues Fixed (include github issue #):
#560

Are changes expected to change answers? (specify if bfb, different at roundoff, more substantial) 
No.   This only affects the behavior of st_archive.

Any User Interface Changes (namelist or namelist defaults changes)?
No

### Testing performed
Please describe the tests along with the target model and machine(s) 
If possible, please also added hashes that were used in the testing
There should be no machine dependencies.
I built a B-compset case using the tags specified in the .gitmodules file of a recent (2025-4-22) cesm3.0_alphabranch.
I set namelist values to write out the coupler history files (.hx).
I ran st_archive and confirmed that those files ended up in $DOUT_ROOT/archive/cpl/hist.
I checked out a development branch based on main, added the changes to it, and pushed it to my CMEPS fork.
I synced my fork (kdraeder) on 2025-5-6 into this branch.

