### PR TITLE
add a testmod to test the interim restart feature

### DIFF
--- a/cime_config/testdefs/testmods_dirs/drv/interim_restart/shell_commands
+++ b/cime_config/testdefs/testmods_dirs/drv/interim_restart/shell_commands
@@ -1,0 +1,2 @@
+# use this with the ERR test to test the interim restart capability
+./xmlchange REST_N=2


### PR DESCRIPTION
this mod requires cime PR 4827

### Description of changes
Sets the REST_N value for ERR test to test interim restart feature.  Assumes that the run length of the test is adequate.
Requires https://github.com/ESMCI/cime/pull/4827

### Specific notes

Contributors other than yourself, if any:

CMEPS Issues Fixed (include github issue #):

Are changes expected to change answers? (specify if bfb, different at roundoff, more substantial) 

Any User Interface Changes (namelist or namelist defaults changes)?

### Testing performed
Please describe the tests along with the target model and machine(s) 
If possible, please also added hashes that were used in the testing

