### PR TITLE
Update ATM_NCPL for MPAS Compsets

### DIFF
--- a/cime_config/config_component_cesm.xml
+++ b/cime_config/config_component_cesm.xml
@@ -220,6 +220,7 @@
     <type>integer</type>
     <default_value>48</default_value>
     <values match="last">
+      <value compset="_MPAS">2</value> <!-- Couple every half-hour, but with NCPL_BASE_PERIOD=hour -->
       <value compset="_CAM\d+%WCBC">144</value>
       <value compset="_CAM\d+%WCMX">288</value>
       <value compset="_CAM\d+%WCXI">288</value>

--- a/cime_config/config_component_cesm.xml
+++ b/cime_config/config_component_cesm.xml
@@ -279,6 +279,23 @@
       <value compset=".+" grid="a%T42"                      >72</value>
       <value compset=".+" grid="a%T85"                      >144</value>
       <value compset=".+" grid="a%T341"                     >288</value>
+      <value compset=".+" grid="a%mpasa480"                   >48</value>
+      <value compset=".+" grid="a%mpasa240"                   >48</value>
+      <value compset=".+" grid="a%mpasa120"                   >48</value>
+      <value compset=".+" grid="a%mpasa60"                    >96</value>
+      <value compset=".+" grid="a%mpasa30"                    >192</value>
+      <value compset=".+" grid="a%mpasa15"                    >360</value>
+      <value compset=".+" grid="a%mpasa7p5"                   >720</value>
+      <value compset=".+" grid="a%mpasa3p75"                  >1440</value>
+      <!-- _MPAS compsets get NCPL_BASE_PERIOD=hour above, these settings are equivalent to the mpasa grids above -->
+      <value compset="_MPAS" grid="a%mpasa480"                >2</value>
+      <value compset="_MPAS" grid="a%mpasa240"                >2</value>
+      <value compset="_MPAS" grid="a%mpasa120"                >2</value>
+      <value compset="_MPAS" grid="a%mpasa60"                 >4</value>
+      <value compset="_MPAS" grid="a%mpasa30"                 >8</value>
+      <value compset="_MPAS" grid="a%mpasa15"                 >15</value>
+      <value compset="_MPAS" grid="a%mpasa7p5"                >30</value>
+      <value compset="_MPAS" grid="a%mpasa3p75"               >60</value>
       <!-- =================================================== -->
       <!-- TG compsets -->
       <!-- =================================================== -->
@@ -289,22 +306,6 @@
       <!-- =================================================== -->
       <value compset="_DATM.*_BLOM">24</value>
       <value compset="_BLOM" grid="oi%tnx0.25v">48</value>
-      <value compset=".+" grid="a%mpasa480"                   >48</value>
-      <value compset=".+" grid="a%mpasa240"                   >48</value>
-      <value compset=".+" grid="a%mpasa120"                   >48</value>
-      <value compset=".+" grid="a%mpasa60"                    >96</value>
-      <value compset=".+" grid="a%mpasa30"                    >192</value>
-      <value compset=".+" grid="a%mpasa15"                    >360</value>
-      <value compset=".+" grid="a%mpasa7p5"                   >720</value>
-      <value compset=".+" grid="a%mpasa3p75"                  >1440</value>
-      <value compset="_MPAS" grid="a%mpasa480"                >2</value>
-      <value compset="_MPAS" grid="a%mpasa240"                >2</value>
-      <value compset="_MPAS" grid="a%mpasa120"                >2</value>
-      <value compset="_MPAS" grid="a%mpasa60"                 >4</value>
-      <value compset="_MPAS" grid="a%mpasa30"                 >8</value>
-      <value compset="_MPAS" grid="a%mpasa15"                 >15</value>
-      <value compset="_MPAS" grid="a%mpasa7p5"                >30</value>
-      <value compset="_MPAS" grid="a%mpasa3p75"               >60</value>
     </values>
     <group>run_coupling</group>
     <file>env_run.xml</file>


### PR DESCRIPTION
### Description of changes

Ensure that compsets involving MPAS-O and MPAS-SI maintain reasonable settings for ATM_NCPL.

Normally this defaults to ATM_NCPL=48 with NCPL_BASE_PERIOD=day leading to 1 atm coupling interval every 30 simulated minutes. When the compset long name contains '_MPAS', there's a change to NCPL_BASE_PERIOD=hour.

These changes should help ATM_NCPL stay consistent when the resolution description doesn't contain something like 'a%mpasa...' (e.g. T62_oQU120 grid).

### Specific notes

Contributors other than yourself, if any:

CMEPS Issues Fixed (include github issue #): 
N/A

Are changes expected to change answers? 
No

Any User Interface Changes (namelist or namelist defaults changes)? 
Yes, should require less steps or knowledge to run MPAS-O and MPAS-SI compsets. Modifies env_run.xml in a case, does not modify namelists.

### Testing performed
Please describe the tests along with the target model and machine(s) 
If possible, please also added hashes that were used in the testing

Spotcheck tests were performed using the branch within [EarthWorksOrg/EarthWorks PR#133](https://github.com/EarthWorksOrg/EarthWorks/pull/133), which uses this branch. The tests were those described in PR#133 for the ew-pr category. No answer changes or other issues were noticed.
