### PR TITLE
Add CIRRUS and Casper GPU types

### DIFF
--- a/cime_config/config_component.xml
+++ b/cime_config/config_component.xml
@@ -817,6 +817,8 @@
   <entry id="GPU_TYPE">
     <type>char</type>
     <valid_values MACH="derecho">none,a100</valid_values>
+    <valid_values MACH="cirrus">none,a10,a2</valid_values>
+    <valid_values MACH="casper">none,v100,a100,h100</valid_values>
     <default_value>none</default_value>
     <group>build_def</group>
     <file>env_build.xml</file>


### PR DESCRIPTION
### Description of changes
This pull request explicitly adds the GPU types allowed on Casper and CIRRUS cloud at NCAR.

### Specific notes

Contributors other than yourself, if any: N/A

CMEPS Issues Fixed (include github issue #):

Are changes expected to change answers? (specify if bfb, different at roundoff, more substantial) 
No

Any User Interface Changes (namelist or namelist defaults changes)?
No

### Testing performed
Please describe the tests along with the target model and machine(s) 
If possible, please also added hashes that were used in the testing

