### PR TITLE
Bugfix for co2 fluxes comming from land to atmosphere

### DIFF
--- a/mediator/esmFldsExchange_cesm_mod.F90
+++ b/mediator/esmFldsExchange_cesm_mod.F90
@@ -1705,8 +1705,8 @@ contains
        call addfld_from(complnd, 'Fall_fco2_lnd')
        call addfld_to(compatm, 'Fall_fco2_lnd')
     else
-       if ( fldchk(is_local%wrap%FBImp(compocn,compocn), 'Faoo_co2_lnd', rc=rc) .and. &
-            fldchk(is_local%wrap%FBexp(compatm)        , 'Faoo_co2_lnd', rc=rc)) then
+       if ( fldchk(is_local%wrap%FBImp(complnd,complnd), 'Fall_fco2_lnd', rc=rc) .and. &
+            fldchk(is_local%wrap%FBexp(compatm)        , 'Fall_fco2_lnd', rc=rc)) then
           call addmap_from(complnd, 'Fall_fco2_lnd', compatm, mapconsf, 'one', lnd2atm_map)
           call addmrg_to(compatm, 'Fall_fco2_lnd', &
                mrg_from=complnd, mrg_fld='Fall_fco2_lnd', mrg_type='copy_with_weights', mrg_fracname=mrg_fracname_lnd2atm_flux)


### PR DESCRIPTION
(cherry picked from commit ae2d923dc5397a61a921fea8dd8d9dd01f614f93)

### Description of changes

Fixes typo in the field check.

### Specific notes

https://github.com/NorESMhub/CMEPS/pull/37

Contributors other than yourself, if any:

@monsieuralok, @maritsandstad

CMEPS Issues Fixed (include github issue #):

Are changes expected to change answers? (specify if bfb, different at roundoff, more substantial) 

For any compsets with with `clm_co2_type=prognostic`, since atmosphere gets non-zero fluxes now.

Any User Interface Changes (namelist or namelist defaults changes)?

No.

### Testing performed

NorESM SMS tests for compset with `CCSM_BGC=CO2C`.

