### PR TITLE
moves liblist to driver buildnml making cime more generic

### DIFF
--- a/.github/workflows/srt.yml
+++ b/.github/workflows/srt.yml
@@ -28,7 +28,7 @@ jobs:
       LDFLAGS: "-L/usr/lib/x86_64-linux-gnu -lnetcdf -lnetcdff -lpnetcdf"     
       # Versions of all dependencies can be updated here
       ESMF_VERSION: v8.8.0
-      PARALLELIO_VERSION: pio2_6_5
+      PARALLELIO_VERSION: pio2_6_6
       CIME_MODEL: cesm
       CIME_DRIVER: nuopc
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/cime_config/buildnml
+++ b/cime_config/buildnml
@@ -643,9 +643,9 @@ def cmeps_lib_list(case):
         libs.insert(0, mpilib)
         
     ocn_model = case.get_value("COMP_OCN")
-    
+    # These will be handeled by MOM and CAM, included here for backward compatibility.  
     atm_dycore = case.get_value("CAM_DYCORE")
-    if ocn_model == "mom" or (atm_dycore and atm_dycore == "fv3"):
+    if ocn_model == "mom" or (atm_dycore and atm_dycore == "fv3") and "FMS" not in libs:
         libs.append("FMS")
     return libs
 

--- a/cime_config/buildnml
+++ b/cime_config/buildnml
@@ -628,6 +628,35 @@ def compare_drv_flds_in(first, second, infile1, infile2):
                 % (infile1, infile2),
             )
 
+def cmeps_lib_list(case):
+    ufs_driver = os.environ.get("UFS_DRIVER")
+    mpilib = case.get_value("MPILIB")
+    if ufs_driver:
+        logger.info("UFS_DRIVER is set to {}".format(ufs_driver))
+    if ufs_driver and ufs_driver == "nems" and not cpl_in_complist:
+        libs = []
+    elif case.get_value("MODEL") == "cesm":
+        libs = ["gptl", "pio", "csm_share"]
+    elif case.get_value("MODEL") == "e3sm":
+        libs = ["gptl", "mct", "spio", "csm_share"]
+    else:
+        libs = ["gptl", "mct", "pio", "csm_share"]
+
+    libs.append("FTorch")
+
+    if mpilib == "mpi-serial":
+        libs.insert(0, mpilib)
+
+    # Build shared code of CDEPS nuopc data models
+    if not ufs_driver or ufs_driver != "nems":
+        libs.append("CDEPS")
+        
+    ocn_model = case.get_value("COMP_OCN")
+    
+    atm_dycore = case.get_value("CAM_DYCORE")
+    if ocn_model == "mom" or (atm_dycore and atm_dycore == "fv3"):
+        libs.append("FMS")
+    return libs
 
 ###############################################################################
 def buildnml(case, caseroot, component):
@@ -635,6 +664,9 @@ def buildnml(case, caseroot, component):
     if component != "drv":
         raise AttributeError
 
+    libs = cmeps_lib_list(case)
+    case.set_value("CASE_SUPPORT_LIBRARIES", ",".join(libs))
+    
     esmfmkfile = os.getenv("ESMFMKFILE")
     expect(
         esmfmkfile and os.path.isfile(esmfmkfile),
@@ -725,7 +757,7 @@ def buildnml(case, caseroot, component):
 def _main_func():
     caseroot = parse_input(sys.argv)
 
-    with Case(caseroot) as case:
+    with Case(caseroot, read_only=False) as case:
         buildnml(case, caseroot, "drv")
 
 

--- a/cime_config/buildnml
+++ b/cime_config/buildnml
@@ -631,6 +631,7 @@ def compare_drv_flds_in(first, second, infile1, infile2):
 def cmeps_lib_list(case):
     # provide a list of support libs that must be built for this case
     # should be ordered with dependent libraries listed after those depended on
+    # the library names should match the keys in variable BUILD_LIB_FILE from config_files.xml
     ufs_driver = os.environ.get("UFS_DRIVER")
     mpilib = case.get_value("MPILIB")
     if ufs_driver:

--- a/cime_config/buildnml
+++ b/cime_config/buildnml
@@ -633,12 +633,12 @@ def cmeps_lib_list(case):
     # should be ordered with dependent libraries listed after those depended on
     # the library names should match the keys in variable BUILD_LIB_FILE from config_files.xml
     ufs_driver = os.environ.get("UFS_DRIVER")
-    mpilib = case.get_value("MPILIB")
     if ufs_driver:
         logger.info("UFS_DRIVER is set to {}".format(ufs_driver))
-    # allows for some libs to have been previously set
+
     libs = case.get_values("CASE_SUPPORT_LIBRARIES")
 
+    mpilib = case.get_value("MPILIB")
     if mpilib == "mpi-serial":
         libs.insert(0, mpilib)
         

--- a/cime_config/buildnml
+++ b/cime_config/buildnml
@@ -7,7 +7,7 @@ _CIMEROOT = os.environ.get("CIMEROOT")
 if _CIMEROOT is None:
     raise SystemExit("ERROR: must set CIMEROOT environment variable")
 
-sys.path.append(os.path.join(_CIMEROOT, "scripts", "Tools"))
+sys.path.append(os.path.join(_CIMEROOT, "CIME", "Tools"))
 
 import shutil, glob, itertools
 from standard_script_setup import *
@@ -629,18 +629,22 @@ def compare_drv_flds_in(first, second, infile1, infile2):
             )
 
 def cmeps_lib_list(case):
+    # provide a list of support libs that must be built for this case
+    # should be ordered with dependent libraries listed after those depended on
     ufs_driver = os.environ.get("UFS_DRIVER")
     mpilib = case.get_value("MPILIB")
     if ufs_driver:
         logger.info("UFS_DRIVER is set to {}".format(ufs_driver))
+    # allows for some libs to have been previously set
+    libs = case.get_values("CASE_SUPPORT_LIBRARIES")
     if ufs_driver and ufs_driver == "nems" and not cpl_in_complist:
-        libs = []
+        pass
     elif case.get_value("MODEL") == "cesm":
-        libs = ["gptl", "pio", "csm_share"]
+        libs.extend(["gptl", "pio", "csm_share"])
     elif case.get_value("MODEL") == "e3sm":
-        libs = ["gptl", "mct", "spio", "csm_share"]
+        libs.extend(["gptl", "mct", "spio", "csm_share"])
     else:
-        libs = ["gptl", "mct", "pio", "csm_share"]
+        libs.extend(["gptl", "mct", "pio", "csm_share"])
 
     libs.append("FTorch")
 

--- a/cime_config/buildnml
+++ b/cime_config/buildnml
@@ -643,9 +643,9 @@ def cmeps_lib_list(case):
         libs.insert(0, mpilib)
         
     ocn_model = case.get_value("COMP_OCN")
-    # These will be handeled by MOM and CAM, included here for backward compatibility.  
+    # These will be handled by MOM and CAM, included here for backward compatibility.  
     atm_dycore = case.get_value("CAM_DYCORE")
-    if ocn_model == "mom" or (atm_dycore and atm_dycore == "fv3") and "FMS" not in libs:
+    if (ocn_model == "mom" or (atm_dycore and atm_dycore == "fv3")) and "FMS" not in libs:
         libs.append("FMS")
     return libs
 

--- a/cime_config/buildnml
+++ b/cime_config/buildnml
@@ -638,23 +638,9 @@ def cmeps_lib_list(case):
         logger.info("UFS_DRIVER is set to {}".format(ufs_driver))
     # allows for some libs to have been previously set
     libs = case.get_values("CASE_SUPPORT_LIBRARIES")
-    if ufs_driver and ufs_driver == "nems" and not cpl_in_complist:
-        pass
-    elif case.get_value("MODEL") == "cesm":
-        libs.extend(["gptl", "pio", "csm_share"])
-    elif case.get_value("MODEL") == "e3sm":
-        libs.extend(["gptl", "mct", "spio", "csm_share"])
-    else:
-        libs.extend(["gptl", "mct", "pio", "csm_share"])
-
-    libs.append("FTorch")
 
     if mpilib == "mpi-serial":
         libs.insert(0, mpilib)
-
-    # Build shared code of CDEPS nuopc data models
-    if not ufs_driver or ufs_driver != "nems":
-        libs.append("CDEPS")
         
     ocn_model = case.get_value("COMP_OCN")
     

--- a/cime_config/config_component.xml
+++ b/cime_config/config_component.xml
@@ -2522,10 +2522,19 @@
    <desc>Remote git repository used for this case</desc>
  </entry>
 
-<!-- ===================================================================== -->
-  <!-- Include the AOFLUX calculation for this compset -->
-  <!-- ===================================================================== -->
+ <entry id="CASE_SUPPORT_LIBRARIES">
+   <type>char</type>
+   <default_value></default_value>
+   <group>build_def</group>
+   <file>env_build.xml</file>
+   <desc>Support libraries required</desc>
+ </entry>
 
+ 
+ <!-- ===================================================================== -->
+ <!-- Include the AOFLUX calculation for this compset -->
+ <!-- ===================================================================== -->
+ 
  <entry id="ADD_AOFLUX_TO_RUNSEQ">
    <type>logical</type>
    <valid_values>TRUE,FALSE</valid_values>

--- a/cime_config/config_component.xml
+++ b/cime_config/config_component.xml
@@ -2525,6 +2525,9 @@
  <entry id="CASE_SUPPORT_LIBRARIES">
    <type>char</type>
    <default_value></default_value>
+   <values>
+     <value cime_model="cesm">gptl,pio,csm_share,FTorch,CDEPS</value>
+   </values>
    <group>build_def</group>
    <file>env_build.xml</file>
    <desc>Support libraries required</desc>


### PR DESCRIPTION
### Description of changes
Moves some code from cime build.py so that each driver can list its support libraries without messy logic in cime.

### Specific notes
https://github.com/ESMCI/cime/pull/4836
Contributors other than yourself, if any: Jian Sun, Jason Boutte

CMEPS Issues Fixed (include github issue #):

Are changes expected to change answers? (specify if bfb, different at roundoff, more substantial) 

Any User Interface Changes (namelist or namelist defaults changes)?

### Testing performed
Please describe the tests along with the target model and machine(s) 
If possible, please also added hashes that were used in the testing

