### PR TITLE
Make qsat calculation consistent with CAM

### DIFF
--- a/cesm/flux_atmocn/shr_flux_mod.F90
+++ b/cesm/flux_atmocn/shr_flux_mod.F90
@@ -9,6 +9,7 @@ module shr_flux_mod
   use shr_const_mod, only : shr_const_latvap, shr_const_latice, shr_const_stebol, shr_const_tkfrz, shr_const_pi, shr_const_spval
   use shr_const_mod, only : shr_const_ocn_ref_sal, shr_const_zsrflyr, shr_const_rgas
   use shr_sys_mod, only : shr_sys_abort   ! shared system routines
+  use shr_wv_sat_mod, only: shr_wv_sat_qsat_liquid  ! use saturation calculation consistent with CAM
   implicit none
 
   private ! default private
@@ -270,8 +271,6 @@ contains
     real(R8)    :: ugust      ! function: gustiness as a function of convective rainfall.  
     real(R8)    :: gprec   ! convective rainfall argument for ugust
 
-    qsat(Tk)   = 640380.0_R8 / exp(5107.4_R8/Tk)
-
     ! Large and Yeager 2009
     cdn(Umps)  =  0.0027_R8 / min(33.0000_R8,Umps) + 0.000142_R8 + &
          0.0000764_R8 * min(33.0000_R8,Umps) - 3.14807e-13_r8 * min(33.0000_R8,Umps)**6
@@ -369,7 +368,8 @@ contains
                 endif
              endif
 
-             ssq    = 0.98_R8 * qsat(ts(n)) / rbot(n)   ! sea surf hum (kg/kg)
+             call shr_wv_sat_qsat_liquid(ts(n), pslv(n), qsat, ssq)
+             ssq    = 0.98_R8 * ssq                     ! sea surf hum (kg/kg)
              delt   = thbot(n) - ts(n)                  ! pot temp diff (K)
              delq   = qbot(n) - ssq                     ! spec hum dif (kg/kg)
              alz    = log(zbot(n)/zref)
@@ -526,7 +526,8 @@ contains
                    vmag=vmag*vscl
                 endif
              endif
-             ssq    = 0.98_R8 * qsat(ts(n)) / rbot(n)   ! sea surf hum (kg/kg)
+             call shr_wv_sat_qsat_liquid(ts(n), pslv(n), qsat, ssq)
+             ssq = 0.98_R8 * ssq                                ! sea surf hum (kg/kg)
 
              call cor30a(ubot(n),vbot(n),tbot(n),qbot(n),rbot(n) &  ! in atm params
                   & ,us(n),vs(n),ts(n),ssq                   &  ! in surf params
@@ -1413,7 +1414,6 @@ contains
     real(R8)    :: tdiff(nMax)               ! tbot - ts
     real(R8)    :: vscl
 
-    qsat(Tk)   = 640380.0_R8 / exp(5107.4_R8/Tk)
     cdn(Umps)  =   0.0027_R8 / Umps + 0.000142_R8 + 0.0000764_R8 * Umps
     psimhu(xd) = log((1.0_R8+xd*(2.0_R8+xd))*(1.0_R8+xd*xd)/8.0_R8) - 2.0_R8*atan(xd) + 1.571_R8
     psixhu(xd) = 2.0_R8 * log((1.0_R8 + xd*xd)/2.0_R8)
@@ -1553,7 +1553,8 @@ contains
              speed(n)   = 0.0_R8
           endif
 
-          ssq    = 0.98_R8 * qsat(tBulk(n)) / rbot(n)   ! sea surf hum (kg/kg)
+          call shr_wv_sat_qsat_liquid(tBulk(n), pslv(n), qsat, ssq)
+          ssq    = 0.98_R8 * ssq                        ! sea surf hum (kg/kg)   
           delt   = thbot(n) - tBulk(n)                  ! pot temp diff (K)
           delq   = qbot(n) - ssq                     ! spec hum dif (kg/kg)
           cp     = shr_const_cpdair*(1.0_R8 + shr_const_cpvir*ssq)
@@ -1696,7 +1697,8 @@ contains
 
              !--need to update ssq,delt,delq as function of tBulk ----
 
-             ssq    = 0.98_R8 * qsat(tBulk(n)) / rbot(n)   ! sea surf hum (kg/kg)
+             call shr_wv_sat_qsat_liquid(tBulk(n), pslv(n), qsat, ssq)
+             ssq    = 0.98_R8 * ssq                        ! sea surf hum (kg/kg)   
              delt   = thbot(n) - tBulk(n)                  ! pot temp diff (K)
              delq   = qbot(n) - ssq                        ! spec hum dif (kg/kg)
 


### PR DESCRIPTION
### Description of changes
Make qsat calculation in shr_flux_mod.F90 consistent with what's used in CAM, which is also more accurate

### Specific notes

Contributors other than yourself, if any: Richard Neale

CMEPS Issues Fixed (include github issue #): 587

Are changes expected to change answers? (specify if bfb, different at roundoff, more substantial) 
Yes. 

Any User Interface Changes (namelist or namelist defaults changes)?
NONE

### Testing performed
Please describe the tests along with the target model and machine(s) 
If possible, please also added hashes that were used in the testing
See discussion here: https://github.com/NCAR/amwg_dev/issues/695
