### PR TITLE
Wrap buildnml call of Case.set_value() in non-readonly context

### DIFF
--- a/cime_config/buildnml
+++ b/cime_config/buildnml
@@ -657,7 +657,8 @@ def buildnml(case, caseroot, component):
         raise AttributeError
 
     libs = cmeps_lib_list(case)
-    case.set_value("CASE_SUPPORT_LIBRARIES", ",".join(libs))
+    with Case(case.get_value("CASEROOT"), read_only=False) as case_tmp:
+        case_tmp.set_value("CASE_SUPPORT_LIBRARIES", ",".join(libs))
     
     esmfmkfile = os.getenv("ESMFMKFILE")
     expect(


### PR DESCRIPTION
### Description of changes

### Specific notes

Contributors other than yourself, if any:

**CMEPS Issues Fixed (include github issue #):**
- Resolves #598

**Are changes expected to change answers?** No; bfb

**Any User Interface Changes (namelist or namelist defaults changes)?** No

### Testing performed
A CTSM test was failing and now passes.

