### PR TITLE
Add one more barrier at end of run

### DIFF
--- a/cesm/driver/esm.F90
+++ b/cesm/driver/esm.F90
@@ -9,7 +9,7 @@ module ESM
   use shr_mem_mod  , only : shr_mem_init
   use shr_log_mod  , only : shr_log_setLogunit, shr_log_error
   use esm_utils_mod, only : logunit, maintask, dbug_flag, chkerr
-  use esmf         , only : ESMF_FAILURE
+  use esmf         , only : ESMF_FAILURE, ESMF_VMBARRIER
   implicit none
   private
 
@@ -1555,6 +1555,9 @@ contains
     call ESMF_GridCompGet(driver, vm=vm, rc=rc)
     if (chkerr(rc,__LINE__,u_FILE_u)) return
     call ESMF_VMGet(vm, mpiCommunicator=mpicomm, rc=rc)
+    if (chkerr(rc,__LINE__,u_FILE_u)) return
+
+    call ESMF_VMBarrier(vm, rc=rc)
     if (chkerr(rc,__LINE__,u_FILE_u)) return
 
     call NUOPC_CompAttributeGet(driver, name="timing_dir",value=timing_dir, rc=rc)


### PR DESCRIPTION
### Description of changes
In CESM we ran into a funny issue where the ocean component was taking significantly longer to write output at the end of the run than the other components, and somehow the other components convinced the mediator that the model had finished successfully even though the ocean component was still doing stuff. This barrier makes everyone wait to catch up.

### Specific notes

Contributors other than yourself, if any: @jedwards4b wrote the code, @gustavo-marques ran it (I have nothing to do with it but Gustavo is on PTO)

CMEPS Issues Fixed (include github issue #): None

Are changes expected to change answers? this should be bfb unless the baseline run did not write out the last MOM6 history file

Any User Interface Changes (namelist or namelist defaults changes)? No

### Testing performed
Gustavo reran some cases where his last monthly history files from MOM6 were not being written out because the mediator was exiting successfully before FMS finished; I believe he verified the 47 months of output he got from both runs were bit-for-bit, plus he got the elusive 48th month of MOM6 output. AFAIK nobody has run any CESM tests with this.

