### PR TITLE
Fix ERR test.

### DIFF
--- a/cime_config/namelist_definition_drv.xml
+++ b/cime_config/namelist_definition_drv.xml
@@ -2861,6 +2861,7 @@
       <value TESTCASE='ERC'>.false.</value>
       <value TESTCASE='ERP'>.false.</value>
       <value TESTCASE='ERI'>.false.</value>
+      <value TESTCASE='ERR'>.false.</value>
     </values>
   </entry>
 


### PR DESCRIPTION
### Description of changes

ERR test needs to be added back in here so that the correct history files are copied back for the restart.
This was original added in #582, but accidently removed in #597.

### Specific notes

Are changes expected to change answers? bfb

### Testing performed
ERR_Ln9.ne16pg3_ne16pg3_mt232.FHISTC_LTso.derecho_intel.cam-outfrq9s_bwic
ERR_Ld5.ne30pg3_t232.B1850C_LTso.derecho_gnu.allactive-defaultio
ERR_Ld7.f10_f10_mg37.IHistClm60BgcCrop.derecho_gnu.clm-default
ERR_Ld7.f10_f10_mg37.IHistClm60BgcCrop.derecho_gnu.drv-interim_restart
