### PR TITLE
Fix monthly averaged med history files

### DIFF
--- a/mediator/med_phases_history_mod.F90
+++ b/mediator/med_phases_history_mod.F90
@@ -1769,7 +1769,7 @@ contains
        timediff(1) = nexttime - starttime - ringinterval
        call ESMF_TimeIntervalGet(timediff(2), d_r8=time_bnds(2), rc=rc)
        if (ChkErr(rc,__LINE__,u_FILE_u)) return
-       call ESMF_TimeIntervalGet(timediff(1), starttime, d_r8=time_bnds(1), rc=rc)
+       call ESMF_TimeIntervalGet(timediff(1), startTimeIn=starttime, d_r8=time_bnds(1), rc=rc)
        if (ChkErr(rc,__LINE__,u_FILE_u)) return
        time_val = 0.5_r8 * (time_bnds(1) + time_bnds(2))
     else


### PR DESCRIPTION
### Description of changes

This PR adds the `startTimeIn` argument to an `ESMF_TimeIntervalGet` call in `med_phases_history_set_timeinfo` to fix monthly history averages.

### Specific notes

Specifically, this PR fixes the following error:

```
20251208 194429.074 ERROR            PET127 ESMCI_TimeInterval.C:708 ESMCI::TimeInterval::get() Cannot get value  - need startTime or endTime to convert -1 months to days on ESMC_CALKIND_NOLEAP calendar, since months are not an integral number of years.
```

encountered when the following user_nl_cpl changes are made:

```
history_option_atm_avg = 'nmonths'
history_n_atm_avg = 1
history_option_ocn_avg = 'nmonths'
history_n_ocn_avg = 1
```


Contributors other than yourself, if any: none

CMEPS Issues Fixed (include github issue #): none

Are changes expected to change answers? (specify if bfb, different at roundoff, more substantial) : bfb

Any User Interface Changes (namelist or namelist defaults changes)? none

### Testing performed
Please describe the tests along with the target model and machine(s) 
If possible, please also added hashes that were used in the testing

A (JRA) compset runs on derecho with cesm3_0_alpha07g.sbx.

