### PR TITLE
Copy shr_lnd2rof_tracers_mod from noresm branch

### DIFF
--- a/cesm/nuopc_cap_share/shr_lnd2rof_tracers_mod.F90
+++ b/cesm/nuopc_cap_share/shr_lnd2rof_tracers_mod.F90
@@ -1,0 +1,95 @@
+module shr_lnd2rof_tracers_mod
+
+  !========================================================================
+  ! read lnd2rof_tracers_inparm namelist and sets up driver list of fields for
+  ! lnd -> river communications
+  !========================================================================
+
+  use ESMF         , only : ESMF_VMGetCurrent, ESMF_VM, ESMF_VMGet
+  use ESMF         , only : ESMF_LogFoundError, ESMF_LOGERR_PASSTHRU, ESMF_SUCCESS
+  use shr_sys_mod  , only : shr_sys_abort
+  use shr_log_mod  , only : shr_log_getLogUnit
+  use shr_kind_mod , only : r8 => shr_kind_r8, cs => shr_kind_cs
+  use shr_nl_mod   , only : shr_nl_find_group_name
+  use shr_mpi_mod  , only : shr_mpi_bcast
+
+  implicit none
+  private
+
+  ! !PUBLIC MEMBER FUNCTIONS
+  public :: shr_lnd2rof_tracers_readnl       ! Read namelist
+
+  character(len=*), parameter :: &
+       u_FILE_u=__FILE__
+
+!====================================================================================
+CONTAINS
+!====================================================================================
+
+  subroutine shr_lnd2rof_tracers_readnl(NLFilename, lnd2rof_tracer_list)
+
+    ! input/output variables
+    character(len=*), intent(in)  :: NLFilename          ! Namelist filename
+    character(len=*), intent(out) :: lnd2rof_tracer_list ! Colon delimited string of liquid lnd2rof tracers
+
+    !----- local -----
+    type(ESMF_VM)      :: vm
+    integer            :: i                      ! Indices
+    integer            :: unitn                  ! namelist unit number
+    integer            :: ierr                   ! error code
+    logical            :: exists                 ! if file exists or not
+    integer            :: rc
+    integer            :: localpet
+    integer            :: mpicom
+    integer            :: logunit
+    character(len=CS)  :: lnd2rof_tracers
+    character(*),parameter :: subName = '(shr_lnd2rof_tracers_readnl) '
+    ! ------------------------------------------------------------------
+
+    namelist /lnd2rof_tracers_inparm/ lnd2rof_tracers
+
+    !-----------------------------------------------------------------------------
+    ! Read namelist and figure out the lnd2rof_tracers field list to pass
+    ! First check if file exists and if not, n_lnd2rof_tracers will be zero
+    !-----------------------------------------------------------------------------
+
+    rc = ESMF_SUCCESS
+
+    !--- Open and read namelist ---
+    if ( len_trim(NLFilename) == 0 ) then
+       call shr_sys_abort( subName//'ERROR: nlfilename not set' )
+    end if
+    call shr_log_getLogUnit(logunit)
+
+    lnd2rof_tracers = ' '
+    lnd2rof_tracer_list = ' '
+
+    call ESMF_VMGetCurrent(vm, rc=rc)
+    if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) return
+    call ESMF_VMGet(vm, localPet=localPet, mpiCommunicator=mpicom, rc=rc)
+    if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) return
+
+    if (localpet==0) then
+       inquire(file=trim(NLFileName), exist=exists)
+       if ( exists ) then
+          open(newunit=unitn, file=trim(NLFilename), status='old' )
+          call shr_nl_find_group_name(unitn, 'lnd2rof_tracers_inparm', ierr)
+          if (ierr == 0) then
+             ! Note that if ierr /= 0, no namelist is present.
+             read(unitn, lnd2rof_tracers_inparm, iostat=ierr)
+             if (ierr > 0) then
+                call shr_sys_abort(trim(subName) //'problem of read of lnd2rof_tracers_inparm ')
+             endif
+          endif
+          close( unitn )
+       end if
+    end if
+    call shr_mpi_bcast( lnd2rof_tracers, mpicom )
+
+    if (lnd2rof_tracers /= ' ') then
+       lnd2rof_tracer_list = trim(lnd2rof_tracers)
+    end if
+
+  end subroutine shr_lnd2rof_tracers_readnl
+
+end module shr_lnd2rof_tracers_mod


### PR DESCRIPTION
### Description of changes

Copying from noresm branch at NorESMhub/CMEPS@6539501e

This is needed for https://github.com/ESCOMP/CDEPS/pull/364

We should soon try to bring in all of the changes from the noresm branch, but that will take more work.

### Specific notes

Contributors other than yourself, if any: @mvertens 

CMEPS Issues Fixed (include github issue #):

Are changes expected to change answers? (specify if bfb, different at roundoff, more substantial) : no

Any User Interface Changes (namelist or namelist defaults changes)? none

### Testing performed
Please describe the tests along with the target model and machine(s) 
If possible, please also added hashes that were used in the testing

Ran `SMS_Ld3_D_P8x1.f10_f10_mg37.X.green_gnu` with the changes from https://github.com/ESCOMP/CDEPS/pull/364
