### PR TITLE
Enable wave diagnostics for WW3

### DIFF
--- a/cime_config/namelist_definition_drv.xml
+++ b/cime_config/namelist_definition_drv.xml
@@ -2095,6 +2095,7 @@
     <group>ALLCOMP_attributes</group>
     <values>
       <value>.false.</value>
+      <value COMP_WAV='ww3'>.true.</value>
     </values>
     <desc>Auxiliary mediator wav2med average history output every day.
     Note that ww3dev will use this configuration variable and send
@@ -2106,6 +2107,7 @@
     <group>MED_attributes</group>
     <values>
       <value>Sw_hs_avg:Sw_Tm1_avg:Sw_thm_avg:Sw_u_avg:Sw_v_avg:Sw_ustokes_avg:Sw_vstokes_avg:Sw_tusx_avg:Sw_tusy_avg:Sw_thp0_avg:Sw_fp0_avg:Sw_phs0_avg:Sw_phs1_avg:Sw_pdir0_avg:Sw_pdir1_avg:Sw_pTm10_avg:Sw_pTm11_avg</value>
+      <value COMP_WAV='ww3'>Sw_Hs:Sw_t01:Sw_t0m1:Sw_thm:Sw_lamult:Sw_ustokes:Sw_vstokes</value>
     </values>
     <desc>Auxiliary mediator wav2med file1 colon delimited output
     fields. NOTE: these are assumed to be time averaged over a day in
@@ -2137,6 +2139,7 @@
     <group>MED_attributes</group>
     <values>
       <value>.false.</value>
+      <value COMP_WAV='ww3'>.true.</value>
     </values>
     <desc>Auxiliary mediator wav2med file1 time averaged flag for file output.
     If this flag is set to .false. only instantaneous output will be created in the auxiliary file.</desc>
@@ -2147,6 +2150,7 @@
     <group>MED_attributes</group>
     <values>
       <value>wav.24h.avg</value>
+      <value COMP_WAV='ww3'>ww3</value>
     </values>
   </entry>
   <entry id="histaux_wav2med_file1_ntperfile">

--- a/mediator/esmFldsExchange_cesm_mod.F90
+++ b/mediator/esmFldsExchange_cesm_mod.F90
@@ -2342,7 +2342,7 @@ contains
           call addmrg_to(compocn, 'Sw_lamult', mrg_from=compwav, mrg_fld='Sw_lamult', mrg_type='copy')
        end if
     end if
-    if (ocn_name == 'mpaso') then
+    if (ocn_name == 'mpaso' .or. ocn_name == 'mom') then
       !-----------------------------
       ! to ocn:
       !-----------------------------
@@ -2369,6 +2369,45 @@ contains
             call addmrg_to(compocn, 'Sw_Fp', mrg_from=compwav, mrg_fld='Sw_Fp', mrg_type='copy')
          end if
       end if
+      !-----------------------------
+      ! to ocn:
+      !-----------------------------
+      if (phase == 'advertise') then
+         call addfld_from(compwav, 'Sw_t0m1')
+         call addfld_to(compocn, 'Sw_t0m1')
+      else
+         if ( fldchk(is_local%wrap%FBExp(compocn)         , 'Sw_t0m1', rc=rc) .and. &
+              fldchk(is_local%wrap%FBImp(compwav, compwav), 'Sw_t0m1', rc=rc)) then
+            call addmap_from(compwav, 'Sw_t0m1', compocn,  mapbilnr_nstod, 'one', wav2ocn_map)
+            call addmrg_to(compocn, 'Sw_t0m1', mrg_from=compwav, mrg_fld='Sw_t0m1', mrg_type='copy')
+         end if
+      end if    
+      !-----------------------------
+      ! to ocn:
+      !-----------------------------
+      if (phase == 'advertise') then
+         call addfld_from(compwav, 'Sw_t01')
+         call addfld_to(compocn, 'Sw_t01')
+      else
+         if ( fldchk(is_local%wrap%FBExp(compocn)         , 'Sw_t01', rc=rc) .and. &
+              fldchk(is_local%wrap%FBImp(compwav, compwav), 'Sw_t01', rc=rc)) then
+            call addmap_from(compwav, 'Sw_t01', compocn,  mapbilnr_nstod, 'one', wav2ocn_map)
+            call addmrg_to(compocn, 'Sw_t01', mrg_from=compwav, mrg_fld='Sw_t01', mrg_type='copy')
+         end if
+      end if      
+      !-----------------------------
+      ! to ocn:
+      !-----------------------------
+      if (phase == 'advertise') then
+         call addfld_from(compwav, 'Sw_thm')
+         call addfld_to(compocn, 'Sw_thm')
+      else
+         if ( fldchk(is_local%wrap%FBExp(compocn)         , 'Sw_thm', rc=rc) .and. &
+              fldchk(is_local%wrap%FBImp(compwav, compwav), 'Sw_thm', rc=rc)) then
+            call addmap_from(compwav, 'Sw_thm', compocn,  mapbilnr_nstod, 'one', wav2ocn_map)
+            call addmrg_to(compocn, 'Sw_thm', mrg_from=compwav, mrg_fld='Sw_thm', mrg_type='copy')
+         end if
+      end if      
       !-----------------------------
       ! to ocn:
       !-----------------------------

--- a/mediator/fd_cesm.yaml
+++ b/mediator/fd_cesm.yaml
@@ -1104,6 +1104,18 @@
        canonical_units: m
        description: ocean import - Significant wave height
      #
+     - standard_name: Sw_t0m1
+       canonical_units: s
+       description: Wind sea mean wave period (Tm0,-1)
+     #
+     - standard_name: Sw_t01
+       canonical_units: s
+       description: Wind sea mean wave period (Tm0,1)
+     #
+     - standard_name: Sw_thm
+       canonical_units: radians
+       description: Mean wave direction
+     #
      - standard_name: Sw_Fp
        canonical_units: 1
        description: ocean import - Peak wave frequency


### PR DESCRIPTION
This PR enables WW3 diagnostics via CMEPS diagnostics module.
- Introduce new wave diagnostics: HS, T01, T01M, THM
- By default, enable the following WW3 cpl history fields:
  - Sw_Hs (signficant wave height)
  - Sw_t01 (mean wave period)
  - Sw_t0m1 (mean wave period)
  - Sw_thm ((mean wave dir)
  - Sw_lamult (langmuir multiplier(
  - Sw_ustokes (stokes drift in x dir)
  - Sw_vstokes. (stokes drift in y dir)
- These fields are written as daily averages into monthly history files:  (`[CASENAME].cpl.hx.ww3.[DATESTAMP].nc`):

Testing: aux_ww3, beta07. Status: b4b

To be evaluated in conjunction with: https://github.com/ESCOMP/WW3/pull/38