### PR TITLE
Fixes to some histaux atm2med xml values

### DIFF
--- a/cime_config/namelist_definition_drv.xml
+++ b/cime_config/namelist_definition_drv.xml
@@ -1552,7 +1552,7 @@
     <group>MED_attributes</group>
     <desc>history option type</desc>
     <values>
-      <value>nhours</value>
+      <value>ndays</value>
     </values>
   </entry>
   <entry id="histaux_atm2med_file5_history_n">
@@ -1561,7 +1561,7 @@
     <group>MED_attributes</group>
     <desc>history option span</desc>
     <values>
-      <value>3</value>
+      <value>1</value>
     </values>
   </entry>
   <entry id="histaux_atm2med_file5_doavg">
@@ -1579,7 +1579,7 @@
     <group>MED_attributes</group>
     <desc>Number of time samples per file.</desc>
     <values>
-      <value>2</value>
+      <value>1</value>
     </values>
   </entry>
   <entry id="histaux_atm2med_file5_auxname">


### PR DESCRIPTION
### Description of changes

There are three separate but related changes here to the histaux atm2med files:

(1) Put Sa_co2prog and Sa_co2diag on a single file each: These two CO2 fields were both being output to both file4 (3-hourly) and file5 (daily). Based on discussion with @mvertens and @klindsay28 I'm keeping prognostic CO2 just on the 3-hourly file and diagnostic CO2 just on the daily file.

(2) Add Faxa_ndep to histaux_atm2med file 5 (daily) (see also https://github.com/escomp/ctsm/issues/1844)

(3) Change atm2med file5 to actually be daily rather than 3-hourly: My sense from the description and file name is that this file is intended to be daily but was accidentally set to 3-hourly. It was changed from daily to 3-hourly in #378 and I think that may have been a mistake, but I'd like to get confirmation of that from @kdraeder and/or @mvertens .

### Specific notes

Contributors other than yourself, if any:

CMEPS Issues Fixed (include github issue #):
- Resolves ESCOMP/CMEPS#375

Are changes expected to change answers? (specify if bfb, different at roundoff, more substantial) No - bfb

Any User Interface Changes (namelist or namelist defaults changes)? Changes some defaults related to atm2med histaux files.

### Testing performed

No testing done yet!

