### PR TITLE
turn this debug alarm off by default

### DIFF
--- a/mediator/med_phases_history_mod.F90
+++ b/mediator/med_phases_history_mod.F90
@@ -126,7 +126,7 @@ module med_phases_history_mod
 
   character(CL) :: case_name = 'unset'  ! case name
   character(CS) :: inst_tag = 'unset'   ! instance tag
-  logical       :: debug_alarms = .true.
+  logical       :: debug_alarms = .false.
   character(*), parameter :: u_FILE_u  = &
        __FILE__
 


### PR DESCRIPTION
### Description of changes
turn off debug_alarm in history module
### Specific notes

Contributors other than yourself, if any:

CMEPS Issues Fixed (include github issue #):
#630 
Are changes expected to change answers? (specify if bfb, different at roundoff, more substantial) no

Any User Interface Changes (namelist or namelist defaults changes)? no

### Testing performed
Please describe the tests along with the target model and machine(s) 
If possible, please also added hashes that were used in the testing

Ran with and without the flag enabled.