### PR TITLE
Roundoff-level mods of prep_glc_map_lnd2glc

### DIFF
--- a/mediator/med_phases_prep_glc_mod.F90
+++ b/mediator/med_phases_prep_glc_mod.F90
@@ -924,8 +924,8 @@ contains
                          data_ice_covered_g(n) = dataptr2d(ec-1,n) * 0.5_r8 &
                               + dataptr2d(ec  ,n) * 0.5_r8
                       else
-                         data_ice_covered_g(n) =  dataptr2d(ec-1,n) * (elev_u - topoglc_g(n)) / d_elev  &
-                              + dataptr2d(ec  ,n) * (topoglc_g(n) - elev_l) / d_elev
+                         data_ice_covered_g(n) =  dataptr2d(ec-1,n) * ((elev_u - topoglc_g(n)) / d_elev)  &
+                              + dataptr2d(ec  ,n) * ((topoglc_g(n) - elev_l) / d_elev)
                       end if
                       exit
                    end if


### PR DESCRIPTION
### Description of changes

Two roundoff-level modifications of prep_glc_map_lnd2glc to pave the way for a larger set of changes. I wanted to demonstrate that the larger set of changes is bit-for-bit, so here I have implemented the minimal set of answer-changing mods needed to get bit-for-bit results when running tests on my upcoming PR.

### Specific notes

Contributors other than yourself, if any:

CMEPS Issues Fixed (include github issue #):

Are changes expected to change answers? (specify if bfb, different at roundoff, more substantial) - Single-precision-roundoff-level changes in configurations with CISM or DGLC (though diffs only show up in a small number of tests with DGLC)

Any User Interface Changes (namelist or namelist defaults changes)? No

### Testing performed

In the context of cesm3_0_alpha08e, ran aux_glc plus these additional tests:

```
SMS_Ly2.f09_g17_gris20.T1850Gg.derecho_intel
SMS_Ld5.f10_f10_ais8gris4_mg37.I1850Clm50SpGag.derecho_intel.cism-test_coupling
SMS_Lm13.f10_f10_mg37.I1850Clm50SpG.derecho_intel
ERS_Ld5.ne30pg3_t232.B1850C_LTso.derecho_intel.allactive-decstart
ERS_Ld5.ne30pg3_t232.BHISTC_LTso.derecho_intel.allactive-decstart
```

Tests passed (other than `FAIL NCK_Ly3.f09_g17_gris20.T1850Gg.derecho_gnu COMPARE_base_multiinst` which is documented as failing in the CISM ChangeLog). I didn't perform baseline comparisons for most tests, but I expect baseline comparisons to fail for most / all of these tests.

I did look at baseline comparisons for `ERS_Ly7.f09_g17_gris4.T1850Gg.derecho_intel` and `SMS_D_Ly1.f09_g17_ais8.T1850Ga.derecho_gnu`. Looking at the cpl hist files, these had just single-precision-roundoff-level diffs, as expected. For `ERS_Ly7.f09_g17_gris4.T1850Gg.derecho_intel`, for example, these were:

```
 RMS glc1Imp_Fgrg_rofi                7.8623E-16            NORMALIZED  6.3141E-09
 RMS glc1Imp_Fgrg_rofl                9.8952E-18            NORMALIZED  1.0419E-07
 RMS glc1Imp_Sg_topo                  3.0520E-09            NORMALIZED  3.8516E-12
 RMS glc1Exp_Flgl_qice                8.8304E-14            NORMALIZED  1.3056E-08
 RMS glc1Exp_Sl_tsrf                  4.2529E-06            NORMALIZED  2.5071E-08
```

Based on testing on my upcoming branch - which effectively includes these changes (along with many other changes) - differences only show up in:
- Tests with active CISM
- Tests with DGLC that cross a year boundary (`ERS_Ld5.ne30pg3_t232.B1850C_LTso.derecho_intel.allactive-decstart` and `ERS_Ld5.ne30pg3_t232.BHISTC_LTso.derecho_intel.allactive-decstart`)