### PR TITLE
Convert count to r8 rather than r4 in prep_glc_avg

### DIFF
--- a/mediator/med_phases_prep_glc_mod.F90
+++ b/mediator/med_phases_prep_glc_mod.F90
@@ -613,7 +613,7 @@ contains
              if (chkerr(rc,__LINE__,u_FILE_u)) return
              if (lndAccum2glc_cnt > 0) then
                 ! If accumulation count is greater than 0, do the averaging
-                data2d(:,:) = data2d(:,:) / real(lndAccum2glc_cnt)
+                data2d(:,:) = data2d(:,:) / real(lndAccum2glc_cnt, R8)
              else
                 ! If accumulation count is 0, then simply set the averaged field bundle values from the land
                 ! to the import field bundle values
@@ -631,7 +631,7 @@ contains
              if (chkerr(rc,__LINE__,u_FILE_u)) return
              if (ocnAccum2glc_cnt > 0) then
                 ! If accumulation count is greater than 0, do the averaging
-                data2d(:,:) = data2d(:,:) / real(ocnAccum2glc_cnt)
+                data2d(:,:) = data2d(:,:) / real(ocnAccum2glc_cnt, R8)
              else
                 ! If accumulation count is 0, then simply set the averaged field bundle values from the ocn
                 ! to the import field bundle values


### PR DESCRIPTION
### Description of changes

Convert count to r8 rather than r4 in prep_glc_avg. This makes this averaging consistent with what's done in med_methods_FB_average, so we can switch to the latter (in an upcoming PR) without changing answers.

### Specific notes

Contributors other than yourself, if any:

CMEPS Issues Fixed (include github issue #):

Are changes expected to change answers? (specify if bfb, different at roundoff, more substantial) - probably bfb but has a slight potential to change answers in cases with lnd2glc coupling. Since integers up to about 16 million can be represented exactly in r4, I don't expect answer changes, but it's possible that there will be answer changes from this with some compilers.

Any User Interface Changes (namelist or namelist defaults changes)?

### Testing performed

Just tested the build (`SMS_Ld2_D_P8x1.f10_g37.X.green_gnu`).

