### PR TITLE
fix temp arg created

### DIFF
--- a/mediator/med_phases_restart_mod.F90
+++ b/mediator/med_phases_restart_mod.F90
@@ -348,7 +348,7 @@ contains
              call med_io_enddef(io_file)
           end if
 
-          tbnds = days_since
+          tbnds = (/days_since,days_since/)
           call ESMF_LogWrite(trim(subname)//": time "//trim(time_units), ESMF_LOGMSG_INFO)
           if (whead(m)) then
              call ESMF_ClockGet(clock, calendar=calendar, rc=rc)
@@ -356,7 +356,7 @@ contains
              call med_io_define_time(io_file, time_units, calendar, rc=rc)
              if (ChkErr(rc,__LINE__,u_FILE_u)) return
           else
-             call med_io_write_time(io_file, days_since, tbnds=(/days_since,days_since/), nt=1, rc=rc)
+             call med_io_write_time(io_file, days_since, tbnds=tbnds, nt=1, rc=rc)
              if (ChkErr(rc,__LINE__,u_FILE_u)) return
           end if
 


### PR DESCRIPTION
### Description of changes

Fixes an error when building with `-check all`


> forrtl: warning (406): fort: (1): In call to MED_IO_WRITE_TIME, an array temporary was created for argument #3

### Testing performed
Please describe the tests along with the target model and machine(s) 
If possible, please also added hashes that were used in the testing

