### PR TITLE
Remove unused Faxa_ vars

### DIFF
--- a/mediator/esmFldsExchange_cesm_mod.F90
+++ b/mediator/esmFldsExchange_cesm_mod.F90
@@ -1814,7 +1814,6 @@ contains
     ! to ocn: merged sensible heat flux
     ! ---------------------------------------------------------------------
     if (phase == 'advertise') then
-       call addfld_from(compatm , 'Faxa_sen')
        call addfld_aoflux('Faox_sen')
        call addfld_from(compice , 'Fioi_melth')
        call addfld_to(compocn , 'Foxx_sen')
@@ -1830,7 +1829,6 @@ contains
     ! to ocn: surface latent heat flux and evaporation water flux
     ! ---------------------------------------------------------------------
     if (phase == 'advertise') then
-       call addfld_from(compatm, 'Faxa_lat' )
        call addfld_aoflux( 'Faox_lat' )
        call addfld_aoflux( 'Faox_evap')
        call addfld_to(compocn, 'Foxx_lat' )

--- a/mediator/fd_cesm.yaml
+++ b/mediator/fd_cesm.yaml
@@ -433,16 +433,6 @@
        canonical_units: N m-2
        description: atm import to med - meridional component of momentum flux
      #
-     - standard_name: Faxa_lat
-       alias: mean_laten_heat_flx_atm
-       canonical_units: W m-2
-       description: atm import to med
-     #
-     - standard_name: Faxa_sen
-       alias: mean_sensi_heat_flx_atm
-       canonical_units: W m-2
-       description: atm import to med
-     #
      #-----------------------------------
      # section: atm export from med (computed in med)
      #-----------------------------------

--- a/mediator/fd_cesm.yaml
+++ b/mediator/fd_cesm.yaml
@@ -433,6 +433,16 @@
        canonical_units: N m-2
        description: atm import to med - meridional component of momentum flux
      #
+     - standard_name: Faxa_lat
+       alias: mean_laten_heat_flx_atm
+       canonical_units: W m-2
+       description: atm import to med
+     #
+     - standard_name: Faxa_sen
+       alias: mean_sensi_heat_flx_atm
+       canonical_units: W m-2
+       description: atm import to med
+     #
      #-----------------------------------
      # section: atm export from med (computed in med)
      #-----------------------------------


### PR DESCRIPTION
### Description of changes

Removes some unused fields from the CESM fields exchange module, 

### Specific notes



CMEPS Issues Fixed (include github issue #): closes https://github.com/ESCOMP/CMEPS/issues/644

Are changes expected to change answers? (specify if bfb, different at roundoff, more substantial) 
bfb

Any User Interface Changes (namelist or namelist defaults changes)? None

### Testing performed


Adhoc tests show no impact from this change, results are bfb with previous results.

