### PR TITLE
Use ice heat capacity and fixed temperature for ice runoff enthalpy

### DIFF
--- a/mediator/med_phases_prep_ocn_mod.F90
+++ b/mediator/med_phases_prep_ocn_mod.F90
@@ -86,6 +86,7 @@ contains
     use ESMF                    , only : ESMF_GridComp, ESMF_FieldBundleGet
     use ESMF                    , only : ESMF_LogWrite, ESMF_LOGMSG_INFO, ESMF_SUCCESS
     use med_constants_mod       , only : shr_const_cpsw, shr_const_tkfrz, shr_const_pi
+    use med_constants_mod       , only : shr_const_cpice
     use med_phases_prep_atm_mod , only : med_phases_prep_atm_enthalpy_correction
 
     ! input/output variables
@@ -230,9 +231,10 @@ contains
           hevap(n)  = (tocn(n) - shr_const_tkfrz) * min(evap(n), 0._r8)   * shr_const_cpsw
           hcond(n)  = max((tocn(n) - shr_const_tkfrz), 0._r8) * max(evap(n), 0._r8)  * shr_const_cpsw
           hrofl(n)  = max((tocn(n) - shr_const_tkfrz), 0._r8) * rofl(n)  * shr_const_cpsw
-          hrofi(n)  = min((tocn(n) - shr_const_tkfrz), 0._r8) * rofi(n)  * shr_const_cpsw
           hrofl_glc(n) = max((tocn(n) - shr_const_tkfrz), 0._r8) * rofl_glc(n)  * shr_const_cpsw
-          hrofi_glc(n) = min((tocn(n) - shr_const_tkfrz), 0._r8) * rofi_glc(n)  * shr_const_cpsw
+          ! −10 C is a reasonable bulk temperature assumption for iceberg/land-ice runoff
+          hrofi(n)  = -10._r8 * rofi(n)  * shr_const_cpice
+          hrofi_glc(n) = -10._r8 * rofi_glc(n)  * shr_const_cpice
        end do
 
        ! Determine enthalpy correction factor that will be added to the sensible heat flux sent to the atm


### PR DESCRIPTION
### Description of changes
Previously, ice runoff enthalpy was computed using ocean temperature and seawater heat capacity. This change:

* Assumes a bulk ice temperature of −10 C
* Uses shr_const_cpice for ice heat capacity

Physically, this is a better approach than using ocean temperature relative to freezing for `hrofi` and `rofi_glc`, since they represent solid land-ice/iceberg freshwater input rather than liquid runoff.

### Specific notes

Contributors other than yourself, if any:

n/a

CMEPS Issues Fixed (include github issue #):

n/a

Are changes expected to change answers? (specify if bfb, different at roundoff, more substantial) 

Yes, this will change the answers for all the tests using MOM6 (B, G, and C compsets)

Any User Interface Changes (namelist or namelist defaults changes)?

No.

### Testing performed

These changes have already been applied to the CESM3 runs, but we have not run additional tests.

cc'ing: @mvertens @billsacks @PeterHjortLauritzen