### PR TITLE
Fix ERS tests for compsets with WW3

### DIFF
--- a/cime_config/namelist_definition_drv.xml
+++ b/cime_config/namelist_definition_drv.xml
@@ -2182,6 +2182,8 @@
     <desc>Number of time samples per file.</desc>
     <values>
       <value>30</value>
+      <value TESTCASE='ERS'>1</value>
+      <value TESTCASE='ERI'>1</value>
     </values>
   </entry>
 

--- a/cime_config/namelist_definition_drv.xml
+++ b/cime_config/namelist_definition_drv.xml
@@ -2182,6 +2182,8 @@
     <desc>Number of time samples per file.</desc>
     <values>
       <value>30</value>
+      <!-- Generate daily WW3 hist files for ERS/ERI tests to prevent mismatched filenames
+        and contents between initial and restart runs.-->
       <value TESTCASE='ERS'>1</value>
       <value TESTCASE='ERI'>1</value>
     </values>


### PR DESCRIPTION
### Description of changes

Set `histaux_wav2med_file1_ntperfile` to 1 for ERS and ERI test cases.

### Specific notes

No answer changes

### Testing performed
ERS.TL319_t232_wg37.GW_JRA.derecho_intel
