### PR TITLE
Only run srt workflow when manually triggered

### DIFF
--- a/.github/workflows/srt.yml
+++ b/.github/workflows/srt.yml
@@ -2,13 +2,11 @@
 
 name: scripts regression tests
 
-# Controls when the action will run. Triggers the workflow on push or pull request
-# events but only for the main branch
+# Controls when the action will run. Only runs when manually triggered. (See
+# https://github.com/escomp/cmeps/issues/646 for discussion regarding why we don't run
+# this automatically.)
 on:
-  push:
-    branches: [ main ]
-  pull_request:
-    branches: [ main ]
+  workflow_dispatch:
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:


### PR DESCRIPTION
### Description of changes

Don't run the CIME scripts_regression_tests workflow on PR and main branch pushes, because it is currently not working.

### Specific notes

Contributors other than yourself, if any:

CMEPS Issues Fixed (include github issue #): Stop-gap that partially addresses #646.

Are changes expected to change answers? (specify if bfb, different at roundoff, more substantial) No - bfb

Any User Interface Changes (namelist or namelist defaults changes)? No

### Testing performed
None