### PR TITLE
Fix for DGLC with SLND

### DIFF
--- a/mediator/med_phases_prep_glc_mod.F90
+++ b/mediator/med_phases_prep_glc_mod.F90
@@ -41,7 +41,6 @@ module med_phases_prep_glc_mod
   use med_methods_mod       , only : FB_check_for_nans => med_methods_FB_check_for_nans
   use med_methods_mod       , only : field_getdata2d  => med_methods_Field_getdata2d
   use med_methods_mod       , only : field_getdata1d  => med_methods_Field_getdata1d
-  use med_methods_mod       , only : fldchk           => med_methods_FB_FldChk
   use med_methods_mod       , only : med_methods_FB_check_wtracers
   use med_field_info_mod    , only : med_field_info_type, med_field_info_array_from_state
   use med_utils_mod         , only : chkerr           => med_utils_ChkErr
@@ -640,16 +639,20 @@ contains
 
     ! Average and map data from land (and possibly ocean)
     if (do_avg) then
-       ! Always average import from accumulated land import data
-       if (lndAccum2glc_cnt > 0) then
-          ! If accumulation count is greater than 0, do the averaging
-          call fldbun_average(FB=FBlndAccum2glc_l, count=lndAccum2glc_cnt, rc=rc)
-          if (chkerr(rc,__LINE__,u_FILE_u)) return
-       else
-          ! If accumulation count is 0, then simply set the averaged field bundle values from the land
-          ! to the import field bundle values
-          call fldbun_copy(FBout=FBlndAccum2glc_l, FBin=is_local%wrap%FBImp(complnd,complnd), rc=rc)
-          if (chkerr(rc,__LINE__,u_FILE_u)) return
+       if (ESMF_FieldBundleIsCreated(FBlndAccum2glc_l)) then
+          ! Average import from accumulated land import data as long as the accumulator has
+          ! been created (if accum_lnd2glc is false, the accumulator isn't created, but this
+          ! subroutine may still be called).
+          if (lndAccum2glc_cnt > 0) then
+             ! If accumulation count is greater than 0, do the averaging
+             call fldbun_average(FB=FBlndAccum2glc_l, count=lndAccum2glc_cnt, rc=rc)
+             if (chkerr(rc,__LINE__,u_FILE_u)) return
+          else
+             ! If accumulation count is 0, then simply set the averaged field bundle values from the land
+             ! to the import field bundle values
+             call fldbun_copy(FBout=FBlndAccum2glc_l, FBin=is_local%wrap%FBImp(complnd,complnd), rc=rc)
+             if (chkerr(rc,__LINE__,u_FILE_u)) return
+          end if
        end if
 
        if (is_local%wrap%ocn2glc_coupling) then


### PR DESCRIPTION
### Description of changes

Only average FBlndAccum2glc_l if the field bundle was created

This is needed to fix some failing tests with DGLC and SLND in the aux_cdeps test list:
- SMS_Ly3.f10_f10_ais8gris4_mg37.2000_SATM_SLND_SICE_SOCN_SROF_DGLC%NOEVOLVE_SWAV.derecho_intel
- SMS_Ly3.f10_f10_ais8_mg37.2000_SATM_SLND_SICE_SOCN_SROF_DGLC%NOEVOLVE_SWAV.derecho_intel
- SMS_Ly3.f19_g17_gris4.2000_SATM_SLND_SICE_SOCN_SROF_DGLC%NOEVOLVE_SWAV.derecho_intel

The problem seems to be that med_phases_prep_glc_avg is called unconditionally from med_phases_prep_glc, but FBlndAccum2glc_l is only created if accum_lnd2glc is true. (Note that prep_glc_accum_lnd, which is another place where FBlndAccum2glc_l is used, is called if lnd2glc_coupling or accum_lnd2glc are true.)

(Prior to cmeps1.1.48 the similar code was inside a fldchk conditional, which also had the effect of skipping this code if FBlndAccum2glc_l wasn't created.)

### Specific notes

Contributors other than yourself, if any:

CMEPS Issues Fixed (include github issue #):

Are changes expected to change answers? (specify if bfb, different at roundoff, more substantial) - no: bfb

Any User Interface Changes (namelist or namelist defaults changes)? no

### Testing performed
With cesm at `3ff5aed`:

(1) These failing tests - now pass:

SMS_Ly3.f10_f10_ais8gris4_mg37.2000_SATM_SLND_SICE_SOCN_SROF_DGLC%NOEVOLVE_SWAV.derecho_intel
SMS_Ly3.f10_f10_ais8_mg37.2000_SATM_SLND_SICE_SOCN_SROF_DGLC%NOEVOLVE_SWAV.derecho_intel
SMS_Ly3.f19_g17_gris4.2000_SATM_SLND_SICE_SOCN_SROF_DGLC%NOEVOLVE_SWAV.derecho_intel

(2) These additional tests - pass and baseline comparisons are bfb:

ERS_Ly7.f09_g17_gris4.T1850Gg.derecho_intel
SMS_Lm13.f10_f10_mg37.I1850Clm50SpG.derecho_intel
SMS_D_Ly1.f09_g17_ais8.T1850Ga.derecho_gnu
MULTINOAIS_Ly2.f10_f10_ais8gris4_mg37.I1850Clm50SpRsGag.derecho_intel.cism-change_params

(3) This additional test - passes (no baselines available):

SMS_D_Ld5.f10_f10_ais8gris4_mg37.I1850Clm50SpGag.derecho_intel.cism-test_coupling
