### PR TITLE
pass all CO2 fields in CO2 emissions compsets with CAM7

### DIFF
--- a/cime_config/config_component_cesm.xml
+++ b/cime_config/config_component_cesm.xml
@@ -114,6 +114,7 @@
       <value compset="SSP.*_DATM.*_CLM">CO2A</value>
       <value compset="_BGC%BPRP">CO2C</value>
       <value compset="_BGC%BDRD">CO2C</value>
+      <value compset="E_CAM70">CO2C</value>
       <value compset="20TR_DATM%IAF.*_BLOM%ECO">CO2A</value>
       <value compset="20TR_DATM%JRA.*_BLOM%ECO">CO2A</value>
     </values>


### PR DESCRIPTION
### Description of changes
Pass all CO2 fields in CO2 emissions compsets with CAM7.
This is done by setting `CCSM_BGC=CO2C`.

### Specific notes

Contributors other than yourself, if any: none

CMEPS Issues Fixed (include github issue #):
There is not a corresponding CMEPS issue for this.

Are changes expected to change answers? (specify if bfb, different at roundoff, more substantial) 
Answers change in CO2 emissions compsets with CAM7, which are
under development and not in use yet.

Any User Interface Changes (namelist or namelist defaults changes)?
Changes `flds_co2c` to '.true.' in CO2 emissions compsets with CAM7.

### Testing performed

`ERS_Ld5` and `SMS_D_Ld2` tests in an 1850 CO2 emissions compsets with CAM7 pass
on derecho-intel.
Testing was done with branches in development of CAM, CTSM, and MOM6 that enable
CO2 emissions.