### PR TITLE
added new coupling mode for noresm

### DIFF
--- a/cime_config/buildnml
+++ b/cime_config/buildnml
@@ -134,9 +134,16 @@ def _create_drv_namelists(case, infile, confdir, nmlgen, files):
     elif case.get_value("RUN_TYPE") == "branch":
         config["run_type"] = "branch"
 
-    if config['COMP_WAV'] == 'ww3' and config['COMP_ICE'] == 'cice':
-        config["wav_ice_coupling"] = "on"
+    # determine coupling mode
+    config["coupling_mode"] = case.get_value("COUPLING_MODE")
 
+    # determine wav_ice_coupling
+    config["wav_ice_coupling"] = "off"
+    if config["coupling_mode"] == "cesm" or config["coupling_mode"] == "noresm":
+        if config['COMP_WAV'] == 'ww3' and config['COMP_ICE'] == 'cice':
+            config["wav_ice_coupling"] = "on"
+
+    # determine dms_from_ocn if ocn component is blom
     if config["COMP_OCN"] == "blom":
         if "ecosys" in case.get_value("BLOM_TRACER_MODULES"):
             config["dms_from_ocn"] = "on"

--- a/cime_config/config_component.xml
+++ b/cime_config/config_component.xml
@@ -37,7 +37,7 @@
 
   <entry id="COUPLING_MODE">
     <type>char</type>
-    <valid_values>cesm</valid_values>
+    <valid_values>cesm,noresm</valid_values>
     <default_value>cesm</default_value>
     <group>run_coupling</group>
     <file>env_run.xml</file>

--- a/cime_config/namelist_definition_drv.xml
+++ b/cime_config/namelist_definition_drv.xml
@@ -952,16 +952,13 @@
     <group>MED_attributes</group>
     <desc>
       If true, use shr_wv_sat_mod to calculate qsat for atm-ocn flux calculations.
-
       If false, use the older inline calculation of qsat, which uses a different
       formulation.
-
       (Currently only relevant for ocn_surface_flux_scheme = 0 or 1.)
     </desc>
     <values>
-      <!-- Once CIME_MODEL distinguishes between NorESM and CESM, this value will differ
-      between these two. -->
-      <value>.true.</value>
+      <value coupling_mode="noresm">.false.</value>
+      <value coupling_mode="cesm">.true.</value>
     </values>
   </entry>
   <entry id="add_gusts">
@@ -2116,7 +2113,8 @@
     <group>ALLCOMP_attributes</group>
     <values>
       <value>.false.</value>
-      <value COMP_WAV='ww3'>.true.</value>
+      <value coupling_mode="noresm" COMP_WAV='ww3'>.true.</value>
+      <value coupling_mode="cesm" COMP_WAV='ww3'>.true.</value>
     </values>
     <desc>Auxiliary mediator wav2med average history output every day.
     Note that ww3dev will use this configuration variable and send
@@ -2127,8 +2125,8 @@
     <category>aux_hist</category>
     <group>MED_attributes</group>
     <values>
-      <value>Sw_hs_avg:Sw_Tm1_avg:Sw_thm_avg:Sw_u_avg:Sw_v_avg:Sw_ustokes_avg:Sw_vstokes_avg:Sw_tusx_avg:Sw_tusy_avg:Sw_thp0_avg:Sw_fp0_avg:Sw_phs0_avg:Sw_phs1_avg:Sw_pdir0_avg:Sw_pdir1_avg:Sw_pTm10_avg:Sw_pTm11_avg</value>
-      <value COMP_WAV='ww3'>Sw_Hs:Sw_t01:Sw_t0m1:Sw_thm:Sw_lamult:Sw_ustokes:Sw_vstokes</value>
+      <value coupling_mode="noresm" COMP_WAV="ww3">Sw_hs_avg:Sw_Tm1_avg:Sw_thm_avg:Sw_u_avg:Sw_v_avg:Sw_ustokes_avg:Sw_vstokes_avg:Sw_tusx_avg:Sw_tusy_avg:Sw_thp0_avg:Sw_fp0_avg:Sw_phs0_avg:Sw_phs1_avg:Sw_pdir0_avg:Sw_pdir1_avg:Sw_pTm10_avg:Sw_pTm11_avg</value>
+      <value coupling_mode="cesm" COMP_WAV='ww3'>Sw_Hs:Sw_t01:Sw_t0m1:Sw_thm:Sw_lamult:Sw_ustokes:Sw_vstokes</value>
     </values>
     <desc>Auxiliary mediator wav2med file1 colon delimited output
     fields. NOTE: these are assumed to be time averaged over a day in
@@ -2160,7 +2158,8 @@
     <group>MED_attributes</group>
     <values>
       <value>.false.</value>
-      <value COMP_WAV='ww3'>.true.</value>
+      <value coupling_mode="noresm" COMP_WAV='ww3'>.false.</value>
+      <value coupling_mode="cesm" COMP_WAV='ww3'>.true.</value>
     </values>
     <desc>Auxiliary mediator wav2med file1 time averaged flag for file output.
     If this flag is set to .false. only instantaneous output will be created in the auxiliary file.</desc>
@@ -2171,7 +2170,7 @@
     <group>MED_attributes</group>
     <values>
       <value>wav.24h.avg</value>
-      <value COMP_WAV='ww3'>ww3</value>
+      <value coupling_mode="cesm" COMP_WAV='ww3'>ww3</value>
     </values>
   </entry>
   <entry id="histaux_wav2med_file1_ntperfile">

--- a/mediator/med.F90
+++ b/mediator/med.F90
@@ -852,7 +852,7 @@ contains
     ! advertise phase
     call med_fldlist_init1(ncomps)
 
-    if (trim(coupling_mode) == 'cesm') then
+    if (trim(coupling_mode) == 'cesm' .or. trim(coupling_mode) == 'noresm') then
        call esmFldsExchange_cesm(gcomp, phase='advertise', rc=rc)
        if (ChkErr(rc,__LINE__,u_FILE_u)) return
     else if (coupling_mode(1:3) == 'ufs') then
@@ -1890,7 +1890,7 @@ contains
       ! Initialize memory for fldlistFr(:)%flds(:) and fldlistTo(:)%flds(:) - this is needed for
       ! call below for the initialize phase
 
-      if (trim(coupling_mode) == 'cesm') then
+      if (trim(coupling_mode) == 'cesm' .or. trim(coupling_mode) == 'noresm') then
          call esmFldsExchange_cesm(gcomp, phase='initialize', rc=rc)
          if (ChkErr(rc,__LINE__,u_FILE_u)) return
       else if (coupling_mode(1:3) == 'ufs') then

--- a/mediator/med_internalstate_mod.F90
+++ b/mediator/med_internalstate_mod.F90
@@ -47,7 +47,8 @@ module med_internalstate_mod
   character(len=CS), public :: glc_name = ''
 
   ! Coupling mode
-  character(len=CS), public :: coupling_mode ! valid values are [cesm,ufs.nfrac,ufs.frac,ufs.nfrac.aoflux,ufs.frac.aoflux,hafs]
+  ! valid values are [cesm,noresm,ufs.nfrac,ufs.frac,ufs.nfrac.aoflux,ufs.frac.aoflux,hafs,hafs.mom6]
+  character(len=CS), public :: coupling_mode 
 
   ! Atmosphere-ocean flux algorithm
   character(len=CS), public :: aoflux_code   ! valid values are [cesm,ccpp]
@@ -70,10 +71,10 @@ module med_internalstate_mod
   integer , public, parameter :: mapnstod_consf    = 8  ! nearest source to destination followed by conservative frac
   integer , public, parameter :: mappatch_uv3d     = 9  ! rotate u,v to 3d cartesian space, map from src->dest, then rotate back
   integer , public, parameter :: mapbilnr_uv3d     = 10 ! rotate u,v to 3d cartesian space, map from src->dest, then rotate back
-  integer , public, parameter :: map_rof2ocn_ice   = 11 ! custom smoothing map to map ice from rof->ocn (cesm only)
-  integer , public, parameter :: map_rof2ocn_liq   = 12 ! custom smoothing map to map liq from rof->ocn (cesm only)
-  integer , public, parameter :: map_glc2ocn_liq   = 13 ! custom smoothing map to map liq from glc->ocn (cesm only)
-  integer , public, parameter :: map_glc2ocn_ice   = 14 ! custom smoothing map to map ice from glc->ocn (cesm only)
+  integer , public, parameter :: map_rof2ocn_ice   = 11 ! custom smoothing map to map ice from rof->ocn (cesm/noresm only)
+  integer , public, parameter :: map_rof2ocn_liq   = 12 ! custom smoothing map to map liq from rof->ocn (cesm/noresm only)
+  integer , public, parameter :: map_glc2ocn_liq   = 13 ! custom smoothing map to map liq from glc->ocn (cesm/noresm only)
+  integer , public, parameter :: map_glc2ocn_ice   = 14 ! custom smoothing map to map ice from glc->ocn (cesm/noresm only)
   integer , public, parameter :: mapfillv_bilnr    = 15 ! fill value followed by bilinear
   integer , public, parameter :: mapbilnr_nstod    = 16 ! bilinear with nstod extrapolation
   integer , public, parameter :: mapconsf_aofrac   = 17 ! conservative with aofrac normalization (ufs only)
@@ -692,7 +693,7 @@ contains
     if ( coupling_mode(1:3) == 'ufs') then
        if (is_local%wrap%comp_present(compatm)) defaultMasks(compatm,2) = 1
     endif
-    if ( coupling_mode /= 'cesm') then
+    if ( trim(coupling_mode) /= 'cesm' .and. trim(coupling_mode) /= 'noresm' ) then
        if (is_local%wrap%comp_present(compatm) .and. atm_name(1:4) == 'datm') then
           defaultMasks(compatm,1) = 0
        end if

--- a/mediator/med_map_mod.F90
+++ b/mediator/med_map_mod.F90
@@ -421,7 +421,7 @@ contains
     dstMaskValue = defaultMasks(n2,2)
 
     ! override defaults for specific cases
-    if (trim(coupling_mode) == 'cesm') then
+    if (trim(coupling_mode) == 'cesm' .or. trim(coupling_mode) == 'noresm') then
        if (n1 == compwav .and. n2 == compocn) then
          srcMaskValue = 0
          dstMaskValue = ispval_mask
@@ -447,7 +447,7 @@ contains
     call ESMF_LogWrite(trim(string), ESMF_LOGMSG_INFO)
 
     polemethod=ESMF_POLEMETHOD_ALLAVG
-    if (trim(coupling_mode) == 'cesm' .or. coupling_mode(1:3) == 'ufs') then
+    if (trim(coupling_mode) == 'cesm' .or. trim(coupling_mode) == 'noresm' .or. coupling_mode(1:3) == 'ufs') then
        if (n1 == compwav .or. n2 == compwav) then
          polemethod = ESMF_POLEMETHOD_NONE ! todo: remove this when ESMF tripolar mapping fix is in place.
        endif

--- a/mediator/med_phases_aofluxes_mod.F90
+++ b/mediator/med_phases_aofluxes_mod.F90
@@ -908,7 +908,7 @@ contains
     call ESMF_FieldRegridStore(xgrid, field_a, field_x, routehandle=rh_agrid2xgrid_2ndord, &
          regridmethod=ESMF_REGRIDMETHOD_CONSERVE_2ND, srcTermProcessing=srcTermProcessing_Value, rc=rc)
     if (chkerr(rc,__LINE__,u_FILE_u)) return
-    if (trim(coupling_mode) == 'cesm') then
+    if (trim(coupling_mode) == 'cesm' .or. trim(coupling_mode) == 'noresm') then
        call ESMF_FieldRegridStore(field_a, field_x, routehandle=rh_agrid2xgrid_bilinr, &
             regridmethod=ESMF_REGRIDMETHOD_BILINEAR, dstMaskValues=(/0/), &
             srcTermProcessing=srcTermProcessing_Value, rc=rc)
@@ -1306,7 +1306,7 @@ contains
 
        ! Map atm->xgrid
        if (trim(fldnames_atm_in(nf)) == 'Sa_u' .or. (trim(fldnames_atm_in(nf)) == 'Sa_v')) then
-          if (trim(coupling_mode) == 'cesm') then
+          if (trim(coupling_mode) == 'cesm' .or. trim(coupling_mode) == 'noresm') then
              call ESMF_FieldRegrid(field_src, field_dst, routehandle=rh_agrid2xgrid_patch, &
                   termorderflag=ESMF_TERMORDER_SRCSEQ, zeroregion=ESMF_REGION_TOTAL, rc=rc)
           else
@@ -1315,7 +1315,7 @@ contains
           end if
           if (chkerr(rc,__LINE__,u_FILE_u)) return
        else
-          if (trim(coupling_mode) == 'cesm') then
+          if (trim(coupling_mode) == 'cesm' .or. trim(coupling_mode) == 'noresm') then
              call ESMF_FieldRegrid(field_src, field_dst, routehandle=rh_agrid2xgrid_bilinr, &
                   termorderflag=ESMF_TERMORDER_SRCSEQ, zeroregion=ESMF_REGION_TOTAL, rc=rc)
           else
@@ -1648,11 +1648,11 @@ end subroutine med_aofluxes_map_ogrid2xgrid_input
     end if
 
     ! The following conditional captures the cases where aoflux_in%psfc is needed in calls
-    ! to flux_atmocn / flux_atmocn_ccpp. Note that coupling_mode=='cesm' is equivalent to
+    ! to flux_atmocn / flux_atmocn_ccpp. Note that coupling_mode==['cesm','noresm] is equivalent to
     ! the CESMCOUPLED CPP token, and coupling_mode(1:3)=='ufs' is roughly equivalent to
     ! the UFS_AOFLUX CPP token (noting that we should only be in this subroutine if using
     ! one of the aoflux variants of the ufs coupling_mode).
-    if ((trim(coupling_mode) == 'cesm') .or. &
+    if ( (trim(coupling_mode) == 'cesm' .or. trim(coupling_mode) == 'noresm') .or. &
          (coupling_mode(1:3) == 'ufs' .and. trim(aoflux_code) == 'ccpp')) then
        call fldbun_getfldptr(fldbun_a, 'Sa_pslv', aoflux_in%psfc, xgrid=xgrid, rc=rc)
        if (chkerr(rc,__LINE__,u_FILE_u)) return

--- a/mediator/med_phases_prep_atm_mod.F90
+++ b/mediator/med_phases_prep_atm_mod.F90
@@ -107,7 +107,7 @@ contains
     !---------------------------------------
     !--- map ocean albedos from ocn to atm grid if appropriate
     !---------------------------------------
-    if (trim(coupling_mode) == 'cesm') then
+    if (trim(coupling_mode) == 'cesm' .or. trim(coupling_mode) == 'noresm') then
        call med_map_field_packed( &
             FBSrc=is_local%wrap%FBMed_ocnalb_o, &
             FBDst=is_local%wrap%FBMed_ocnalb_a, &
@@ -121,7 +121,7 @@ contains
     !---------------------------------------
     !--- map atm/ocn fluxes from ocn to atm grid if appropriate
     !---------------------------------------
-    if (trim(coupling_mode) == 'cesm' .or. &
+    if (trim(coupling_mode) == 'cesm' .or. trim(coupling_mode) == 'noresm' .or. &
          trim(coupling_mode) == 'ufs.frac.aoflux') then
        if (is_local%wrap%aoflux_grid == 'ogrid') then
           call med_aofluxes_map_ogrid2agrid_output(gcomp, rc)

--- a/mediator/med_phases_prep_ice_mod.F90
+++ b/mediator/med_phases_prep_ice_mod.F90
@@ -90,7 +90,8 @@ contains
     if (chkerr(rc,__LINE__,u_FILE_u)) return
 
     ! Apply precipitation factor from ocean (that scales atm rain and snow to ice) if appropriate
-    if (trim(coupling_mode) == 'cesm' .and. is_local%wrap%flds_scalar_index_precip_factor /= 0) then
+    if ( (trim(coupling_mode) == 'cesm' .or. trim(coupling_mode) == 'noresm') .and. &
+         is_local%wrap%flds_scalar_index_precip_factor /= 0) then
 
        ! Note that in med_internal_mod.F90 all is_local%wrap%flds_scalar_index_precip_factor
        ! is initialized to 0.

--- a/mediator/med_phases_prep_ocn_mod.F90
+++ b/mediator/med_phases_prep_ocn_mod.F90
@@ -509,7 +509,7 @@ contains
        end do
        ! Compute sw export to ocean bands if required
        if (export_swnet_by_bands) then
-          if (trim(coupling_mode) == 'cesm') then
+          if (trim(coupling_mode) == 'cesm' .or. trim(coupling_mode) == 'noresm') then
              c1 = 0.285; c2 = 0.285; c3 = 0.215; c4 = 0.215
              Foxx_swnet_vdr(:) = c1 * Foxx_swnet(:)
              Foxx_swnet_vdf(:) = c2 * Foxx_swnet(:)
@@ -630,7 +630,8 @@ contains
     end if
 
     ! Apply precipitation factor from ocean (that scales atm rain and snow back to ocn ) if appropriate
-    if (trim(coupling_mode) == 'cesm' .and. is_local%wrap%flds_scalar_index_precip_factor /= 0) then
+    if ((trim(coupling_mode) == 'cesm' .or. trim(coupling_mode) == 'noresm') .and. &
+         is_local%wrap%flds_scalar_index_precip_factor /= 0) then
 
        ! Note that in med_internal_mod.F90 all is_local%wrap%flds_scalar_index_precip_factor
        ! is initialized to 0.


### PR DESCRIPTION
### Description of changes
Added new valid value to noresm to the COUPLING_MODE xml variable

### Specific notes
This change permits namelist values for coupling_mode to now include noresm. Conditionals throughout the code now can test for both noresm and cesm. 
This xml variable can also now be included in CDEPS config variables to distinguish between noresm and cesm settings.
Not that this PR also will need to be included for upcoming WW3 PRs from noresm to cesm.

Contributors other than yourself, if any:

CMEPS Issues Fixed:

Are changes expected to change answers? bfb

Any User Interface Changes (namelist or namelist defaults changes)? None

### Testing performed
`ERS_Ld5.ne30pg3_t232.B1850C_LTso.derecho_intel.allactive-defaultio` from cesm3_0_alpha09d - passes and bit-for-bit. I ran this test both with (a) just the first commit on this branch, and (b) the 3 commits that included Erik's suggested extra parentheses.

