### PR TITLE
Allow skipping checks of some tracer fields

### DIFF
--- a/cime_config/namelist_definition_drv.xml
+++ b/cime_config/namelist_definition_drv.xml
@@ -2649,6 +2649,22 @@
    </values>
   </entry>
 
+  <entry id="water_tracers_variables_not_checked">
+   <type>char</type>
+   <category>water_tracers</category>
+   <group>ALLCOMP_attributes</group>
+   <desc>
+      Colon-delimited list of variables for which water tracer consistency checks should be skipped.
+
+      Each entry must match the variable name passed to shr_wtracers_check_tracer_ratios.
+      For checks of mediator fields, these are of the form FieldBundleName%FieldName.
+      For example: "FBImpatm%Sa_shum_wtracers:FBExprof%Flrl_irrig_wtracers".
+   </desc>
+   <values>
+      <value></value>
+   </values>
+  </entry>
+
   <!-- =========================== -->
   <!-- CLOCK Attributes            -->
   <!-- =========================== -->

--- a/cime_config/testdefs/testmods_dirs/drv/water_tracers/user_nl_cpl
+++ b/cime_config/testdefs/testmods_dirs/drv/water_tracers/user_nl_cpl
@@ -1,2 +1,6 @@
 water_tracer_initial_ratios = "0.1:2"
 water_tracers_do_checks = .true.
+
+! Tracers currently aren't mapped properly for irrigation
+! (https://github.com/escomp/cmeps/issues/675), so bypass tracer checks for this field
+water_tracers_variables_not_checked = "FBExprof%Flrl_irrig_wtracers"

--- a/mediator/med_methods_mod.F90
+++ b/mediator/med_methods_mod.F90
@@ -2795,6 +2795,7 @@ contains
     integer :: fieldrank
     logical :: hasSuffix
     logical :: isPresentNonTracer
+    logical :: check_skipped
     type(ESMF_Field) :: fieldTracers
     type(ESMF_Field) :: fieldNonTracer
 
@@ -2831,9 +2832,16 @@ contains
        if (hasSuffix) then
           call ESMF_FieldBundleGet(FB, fieldName=fieldNameNonTracer, isPresent=isPresentNonTracer, rc=rc)
           if (chkerr(rc,__LINE__,u_FILE_u)) return
-          if (isPresentNonTracer) then
+          if (.not. isPresentNonTracer) then
+             ! This is the situation for a small number of fields where we have a tracer
+             ! field without a corresponding non-tracer field.
              if (dbug_flag > 5) then
-                call ESMF_LogWrite(trim(subname)//": Checking <" // trim(fieldNameList(n)) // &
+                call ESMF_LogWrite(trim(subname)//": Skipping check for <" // trim(FBName)//"%"//trim(fieldNameList(n)) // &
+                     "> which has no corresponding non-tracer field", ESMF_LOGMSG_INFO)
+             end if
+          else
+             if (dbug_flag > 5) then
+                call ESMF_LogWrite(trim(subname)//": Checking <" // trim(FBName)//"%"//trim(fieldNameList(n)) // &
                      "> against <" // trim(fieldNameNonTracer) // ">", &
                      ESMF_LOGMSG_INFO)
              end if
@@ -2852,26 +2860,24 @@ contains
                 call ESMF_FieldGet(fieldNonTracer, farrayPtr=dataNonTracer1d, rc=rc)
                 if (chkerr(rc,__LINE__,u_FILE_u)) return
                 call wtracers_check_tracer_ratios(dataTracers2d, dataNonTracer1d, &
-                     trim(FBName)//":"//trim(fieldNameList(n)))
+                     trim(FBName)//"%"//trim(fieldNameList(n)), check_skipped=check_skipped)
              else if (fieldrank == 2) then
                 call ESMF_FieldGet(fieldTracers, farrayPtr=dataTracers3d, rc=rc)
                 if (chkerr(rc,__LINE__,u_FILE_u)) return
                 call ESMF_FieldGet(fieldNonTracer, farrayPtr=dataNonTracer2d, rc=rc)
                 if (chkerr(rc,__LINE__,u_FILE_u)) return
                 call wtracers_check_tracer_ratios(dataTracers3d, dataNonTracer2d, &
-                     trim(FBName)//":"//trim(fieldNameList(n)))
+                     trim(FBName)//"%"//trim(fieldNameList(n)), check_skipped=check_skipped)
              else
                 write(msg,'(a,i0)') subname//": ERROR: unhandled field rank ", fieldrank
                 call shr_log_error(msg, &
                      line=__LINE__, file=u_FILE_u, rc=rc)
                 return
              end if
-          else
-             ! This is the situation for a small number of fields where we have a tracer
-             ! field without a corresponding non-tracer field.
-             if (dbug_flag > 5) then
-                call ESMF_LogWrite(trim(subname)//": Skipping check for <" // trim(fieldNameList(n)) // &
-                     "> which has no corresponding non-tracer field", ESMF_LOGMSG_INFO)
+
+             if (check_skipped .and. dbug_flag > 5) then
+                call ESMF_LogWrite(trim(subname)//": Skipping check for <" // trim(FBName)//"%"//trim(fieldNameList(n)) // &
+                     "> which is in the list of variables not to check", ESMF_LOGMSG_INFO)
              end if
           end if
        end if

--- a/ufs/wtracers_mod.F90
+++ b/ufs/wtracers_mod.F90
@@ -94,7 +94,7 @@ contains
    end subroutine wtracers_get_bulk_fieldname
 
    !-----------------------------------------------------------------------
-   subroutine wtracers_check_tracer_ratios_1d(tracers, bulk, name)
+   subroutine wtracers_check_tracer_ratios_1d(tracers, bulk, variable_name, check_skipped)
       !
       ! !DESCRIPTION:
       ! Check tracer ratios (tracer/bulk) against expectations
@@ -104,14 +104,16 @@ contains
       ! !ARGUMENTS
       real(r8), intent(in) :: tracers(:,:)  ! dimensioned [tracerNum, gridcell]
       real(r8), intent(in) :: bulk(:)
-      character(len=*), intent(in) :: name  ! for diagnostic output
+      character(len=*), intent(in) :: variable_name
+      logical, intent(out) :: check_skipped  ! true if the check was skipped
       !-----------------------------------------------------------------------
 
       ! Do nothing
+      check_skipped = .true.
    end subroutine wtracers_check_tracer_ratios_1d
 
    !-----------------------------------------------------------------------
-   subroutine wtracers_check_tracer_ratios_2d(tracers, bulk, name)
+   subroutine wtracers_check_tracer_ratios_2d(tracers, bulk, variable_name, check_skipped)
       !
       ! !DESCRIPTION:
       ! Check tracer ratios (tracer/bulk) against expectations for 2-d bulk arrays
@@ -121,10 +123,12 @@ contains
       ! !ARGUMENTS
       real(r8), intent(in) :: tracers(:,:,:)  ! dimensioned [ungriddedDim, tracerNum, gridcell]
       real(r8), intent(in) :: bulk(:,:)       ! dimensioned [ungriddedDim, gridcell]
-      character(len=*), intent(in) :: name  ! for diagnostic output
+      character(len=*), intent(in) :: variable_name
+      logical, intent(out) :: check_skipped  ! true if the check was skipped
       !-----------------------------------------------------------------------
 
       ! Do nothing
+      check_skipped = .true.
    end subroutine wtracers_check_tracer_ratios_2d
 
 end module wtracers_mod


### PR DESCRIPTION
### Description of changes

The irrigation tracer field is not yet mapped correctly (see https://github.com/ESCOMP/CMEPS/issues/675). In order to allow both irrigation and volr to be spatially-varying but to still have tracer checks for everything else, we now exclude the irrigation field from these tracer checks.

**This depends on the CESM_share changes in https://github.com/ESCOMP/CESM_share/pull/85**

### Specific notes

Contributors other than yourself, if any:

CMEPS Issues Fixed (include github issue #):

Are changes expected to change answers? (specify if bfb, different at roundoff, more substantial) - no: bfb

Any User Interface Changes (namelist or namelist defaults changes)? Adds water_tracers_variables_not_checked namelist item

### Testing performed
Please describe the tests along with the target model and machine(s) 
If possible, please also added hashes that were used in the testing

`SMS_D_Ld2.f19_g17.X.green_gnu.drv-water_tracers--drv-glc_avg_frequently` in cesm3_0_alpha09d, with share updated to share1.1.21