### PR TITLE
Remove incorrect single_column logic

### DIFF
--- a/cime_config/buildnml
+++ b/cime_config/buildnml
@@ -93,18 +93,6 @@ def _create_drv_namelists(case, infile, confdir, nmlgen, files):
     config["samegrid_lnd_rof"] = "true" if lnd_mesh == rof_mesh else "false"
     config["samegrid_wav_ocn"] = "true" if ocn_mesh == wav_mesh else "false"
 
-    # determine if need to set atm_domainfile
-    scol_lon = float(case.get_value("PTS_LON"))
-    scol_lat = float(case.get_value("PTS_LAT"))
-    if (
-        scol_lon > -999.0
-        and scol_lat > -999.0
-        and case.get_value("ATM_DOMAIN_FILE") != "UNSET"
-    ):
-        config["single_column"] = "true"
-    else:
-        config["single_column"] = "false"
-
     # needed for determining the run sequence
     config["COMP_ATM"] = case.get_value("COMP_ATM")
     config["COMP_ICE"] = case.get_value("COMP_ICE")

--- a/cime_config/namelist_definition_drv.xml
+++ b/cime_config/namelist_definition_drv.xml
@@ -360,7 +360,6 @@
     </desc>
     <values>
       <value>$MASK_MESH</value>
-      <value single_column='true'>null</value>
     </values>
   </entry>
   <entry id="ATM_model" modify_via_xml="COMP_ATM">


### PR DESCRIPTION
### Description of changes

This logic was incorrect, I think leading to mesh_mask sometimes being set to null when it shouldn't have been.

Based on Mariana's analysis of the CESM code, it seems like this didn't cause any incorrect behavior, but it was confusing and unnecessary. So we decided to simply remove this unnecessary logic.

Resolves ESCOMP/CMEPS#676

### Specific notes

Contributors other than yourself, if any: @mvertens 

CMEPS Issues Fixed (include github issue #):
- Resolves #676 

Are changes expected to change answers? (specify if bfb, different at roundoff, more substantial) bfb

Any User Interface Changes (namelist or namelist defaults changes)? mesh_mask is left at its original value rather than being set to null for single point / single-column cases

### Testing performed

Ran testing on these changes along with CDEPS changes to fix single-column logic (https://github.com/ESCOMP/CDEPS/pull/422). The following test results describe the results from testing these two changes together; note that the changes in dimension sizes referenced below come from the CDEPS changes.

Ran the following, all with baseline comparisons:

(1) aux_cdeps

(2) aux_cime_baselines

(3) The two tests from the test_scam test list (but moved to derecho):
```
SCT_D_Ln7.ne3_ne3_mg37.QPC5.derecho_intel.cam-scm_prep
SCT_D_Ln7.ne3_ne3_mg37.QPC6.derecho_intel.cam-scm_prep_c6
```

(4) A G compset test (since G compsets weren't covered in the other testing):
```
SMS_D.TL319_t232.G_JRA_RYF.derecho_intel
```

(5) A selection of single-point tests from aux_clm - the derecho tests suggested in https://github.com/ESCOMP/CMEPS/issues/676#issuecomment-4972844919 (not the izumi tests from there, though):
```
ERS_D_Ld5_Mmpi-serial.1x1_mexicocityMEX.I1PtClm60SpRs.derecho_gnu.clm-CLM1PTStartDate
ERS_D_Mmpi-serial_Ld5.1x1_brazil.I2000Clm50FatesRs.derecho_gnu.clm-FatesCold
ERS_Ly3_Mmpi-serial.1x1_smallvilleIA.IHistClm50BgcCropQianRs.derecho_gnu.clm-cropMonthOutput
ERS_Ly5_Mmpi-serial.1x1_smallvilleIA.I1850Clm50BgcCrop.derecho_gnu.clm-ciso_monthly
ERS_Ly6_Mmpi-serial.1x1_smallvilleIA.IHistClm50BgcCropQianRs.derecho_intel.clm-cropMonthOutput
SMS_D_Ld1_Mmpi-serial.ne3_ne3_mg37.I2000Clm50SpRs.derecho_gnu.clm-ptsRLA
SMS_D_Ld1_Mmpi-serial.ne3_ne3_mg37.I2000Clm50SpRs.derecho_gnu.clm-ptsROA
SMS_D_Ld1_Mmpi-serial.ne3_ne3_mg37.I2000Clm50SpRs.derecho_intel.clm-ptsRLA
SMS_D_Ly6_Mmpi-serial.1x1_smallvilleIA.IHistClm45BgcCropQianRs.derecho_intel.clm-cropMonthOutput
SMS_Ld10_D_Mmpi-serial.CLM_USRDAT.I1PtClm60Bgc.derecho_gnu.clm-default--clm-NEON-HARV
SMS_Ld10_D_Mmpi-serial.CLM_USRDAT.I1PtClm60Fates.derecho_intel.clm-FatesFireLightningPopDens--clm-NEON-FATES-NIWO
SMS_Ld10_D_Mmpi-serial.CLM_USRDAT.I1PtClm60SpRs.derecho_intel.clm-default--clm-NEON-TOOL--clm-nofireemis
SMS_Lm3_D_Mmpi-serial.1x1_brazil.I2000Clm50FatesCruRsGs.derecho_intel.clm-FatesColdHydro
SMS_Ly3_Mmpi-serial.1x1_numaIA.I2000Clm50BgcDvCropQianRs.derecho_gnu.clm-ignor_warn_cropMonthOutputColdStart
SSPMATRIXCN_Ly5_Mmpi-serial.1x1_numaIA.I2000Clm60BgcCropQianRs.derecho_intel.clm-ciso_monthly
SUBSETDATAPOINT_Ld5_D_Mmpi-serial.CLM_USRDAT.I2000Clm60BgcCropCrujra.derecho_intel.clm-default
SUBSETDATAREGION_Ld5_D_Mmpi-serial.CLM_USRDAT.I2000Clm60BgcCropCrujra.derecho_intel.clm-default
```

All tests passed (other than expected failures) and were bit-for-bit. `SMS_Ln9_P1.T42_T42.2000_DATM%QIA_SLND_SICE_DOCN%DOM_SROF_SGLC_SWAV.derecho_intel.datm-scam` has different dimension sizes in the cpl hist file (as expected), but when I used ncks to extract just point 1 from the baseline cpl hist file, it's bit-for-bit.

For the two SCP tests, in the baseline, I subset the ocn dimensions to take just the first point (keeping the atm dimensions as is because there is apparently still an issue in nx/ny on the atm side when running with CAM), and then compared the atm & cpl files from case2 against baseline (since these aren't normally compared, and these are the important single-column files); these were bit-for-bit.

Differences in NLCOMP (all expected):
- I compset 1x1 tests now have mesh_mask UNSET instead of null
- I1Pt CLM_USRDAT tests now have mesh_mask UNSET instead of null
- I compset pts tests now have mesh_mask set to a file instead of null; datm model_maskfile and model_meshfile null instead of set, and nx_global and ny_global 1 instead of 0
- I compset SUBSETDATAPOINT CLM_USRDAT has mesh_mask UNSET instead of null (no substantive diffs in SUBSETDATAREGION namelists)
- `SMS_Ld5_P1.1x1_mexicocityMEX.2000_DATM%1PT_SLND_SICE_SOCN_SROF_SGLC_SWAV_SESP.derecho_intel.datm-1PT` has mesh_mask UNSET instead of null
- `SMS_Ln9_P1.T42_T42.2000_DATM%QIA_SLND_SICE_DOCN%DOM_SROF_SGLC_SWAV.derecho_intel.datm-scam` has mesh_mask set to a file rather than null; and for both docn_nml and datm_nml, model_maskfile and model_meshfile are now null rather than set, and nx_global and ny_global are 1 rather than 128/64
- `SCT_D_Ln7.ne3_ne3_mg37.QPC6.derecho_intel.cam-scm_prep_c6` and `SCT_D_Ln7.ne3_ne3_mg37.QPC5.derecho_intel.cam-scm_prep`: case2 has diffs: mesh_mask now set to a file instead of null; docn_in has model_meshfile null instnead of a file, and nx_global 1 instead of 488

Hashes used for testing: ctsm5.4.047 for the selected tests from aux_clm; cesm3_0_alpha09d for others

