### PR TITLE
Make sure there are default values for some fields

### DIFF
--- a/cime_config/namelist_definition_drv.xml
+++ b/cime_config/namelist_definition_drv.xml
@@ -957,8 +957,8 @@
       (Currently only relevant for ocn_surface_flux_scheme = 0 or 1.)
     </desc>
     <values>
+      <value>.true.</value>
       <value coupling_mode="noresm">.false.</value>
-      <value coupling_mode="cesm">.true.</value>
     </values>
   </entry>
   <entry id="add_gusts">
@@ -2125,6 +2125,7 @@
     <category>aux_hist</category>
     <group>MED_attributes</group>
     <values>
+      <value></value>
       <value coupling_mode="noresm" COMP_WAV="ww3">Sw_hs_avg:Sw_Tm1_avg:Sw_thm_avg:Sw_u_avg:Sw_v_avg:Sw_ustokes_avg:Sw_vstokes_avg:Sw_tusx_avg:Sw_tusy_avg:Sw_thp0_avg:Sw_fp0_avg:Sw_phs0_avg:Sw_phs1_avg:Sw_pdir0_avg:Sw_pdir1_avg:Sw_pTm10_avg:Sw_pTm11_avg</value>
       <value coupling_mode="cesm" COMP_WAV='ww3'>Sw_Hs:Sw_t01:Sw_t0m1:Sw_thm:Sw_lamult:Sw_ustokes:Sw_vstokes</value>
     </values>


### PR DESCRIPTION
### Description of changes

This is critical for histaux_wav2med_file1_flds (in case we're not running with ww3); for aofluxes_use_shr_wv_sat, this default isn't currently needed, but adding it is helpful for some future-proofing.

### Specific notes

Contributors other than yourself, if any: @mvertens 

CMEPS Issues Fixed (include github issue #):

Are changes expected to change answers? (specify if bfb, different at roundoff, more substantial) bfb

Any User Interface Changes (namelist or namelist defaults changes)? Sets a default for histaux_wav2med_file1_flds when not running with ww3 (to an empty list)

### Testing performed
aux_cime_baselines from cesm3_0_alpha09d (`SMS_Ld2.ne30pg3_t232.B1850C_LTso.derecho_intel.allactive-defaultio` hasn't finished; all others pass and are bit-for-bit)
