### PR TITLE
Set MED_model to cmeps, not cesm

### DIFF
--- a/cime_config/namelist_definition_drv.xml
+++ b/cime_config/namelist_definition_drv.xml
@@ -347,7 +347,7 @@
     <category>nuopc</category>
     <group>ALLCOMP_attributes</group>
     <values>
-      <value cime_model="cesm">cesm</value>
+      <value>cmeps</value>
     </values>
   </entry>
   <entry id="mesh_mask" modify_via_xml="MASK_MESH">


### PR DESCRIPTION
### Description of changes

Set MED_model to cmeps, not cesm

This makes more sense given how it's used - in printing the various
component names to the mediator log file. This is also consistent with
what's done for UFS.

This resolves the main point in ESCOMP/CMEPS#680. I have *not* addressed the possibly redundant cime_model that was raised in later discussion in that issue.

### Specific notes

Contributors other than yourself, if any:

CMEPS Issues Fixed (include github issue #):
- Resolves ESCOMP/CMEPS#680

Are changes expected to change answers? (specify if bfb, different at roundoff, more substantial) no

Any User Interface Changes (namelist or namelist defaults changes)? MED_model is cmeps, not cesm

### Testing performed

aux_cime_baselines in the context of cesm3_0_alpha09d. For this testing, I used this branch on top of the fix_noresm_coupling_mode branch. Tests pass (except expected failures) and are bit-for-bit.
