### PR TITLE
Fix #4122: Move CALENDAR to env_run.xml to allow keepexe with calenda…

### DIFF
--- a/cime_config/config_component.xml
+++ b/cime_config/config_component.xml
@@ -742,8 +742,8 @@
     <type>char</type>
     <valid_values>NO_LEAP,GREGORIAN</valid_values>
     <default_value>NO_LEAP</default_value>
-    <group>build_def</group>
-    <file>env_build.xml</file>
+    <group>run_begin_stop_restart</group>
+    <file>env_run.xml</file>
     <desc>calendar type</desc>
   </entry>
 

--- a/cime_config/namelist_definition_drv.xml
+++ b/cime_config/namelist_definition_drv.xml
@@ -2736,8 +2736,8 @@
     <group>CLOCK_attributes</group>
     <valid_values>NO_LEAP,GREGORIAN</valid_values>
     <desc>
-      calendar in use.  [NO_LEAP, GREOGORIAN].
-      set by CALENDAR in env_build.xml
+      calendar in use.  [NO_LEAP, GREGORIAN].
+      set by CALENDAR in env_run.xml
     </desc>
     <values>
       <value>$CALENDAR</value>


### PR DESCRIPTION
### Description of changes
Moves the `CALENDAR` variable definition in `cime_config/config_component.xml` from `env_build.xml` (group `build_def`) to `env_run.xml` (group `run_begin_stop_restart`). 
This resolves an issue where cloning a case with `--keepexe` and applying usermods that alter the `CALENDAR` variable (such as during PLUMBER2 or NEON site spinups) failed with:
`ERROR: env_build.xml cannot be changed via usermods if keepexe is an option`

### Specific notes
* The `CALENDAR` variable is strictly a runtime configuration parameter used by Python setup and namelist-building scripts (`buildnml`). It is never referenced in preprocessor macros or build system logic.
* Moving `CALENDAR` to `env_run.xml` accurately reflects its runtime nature and allows CIME's `case_clone.py` script to accept calendar modifications under `--keepexe` without requiring a re-compilation.

Contributors other than yourself, if any: Antigravity using Gemini LLMs came up with the fix, looked for any other CALENDAR references, ran the tests below, and wrote this PR (except this one line :))

CMEPS Issues Fixed (include github issue #): Fixes ESCOMP/CTSM#4122

Are changes expected to change answers? (specify if bfb, different at roundoff, more substantial)
BFB (Bit-for-bit). This change only alters the XML file location (`env_run.xml` instead of `env_build.xml`) where the `CALENDAR` variable is stored during case creation.

Any User Interface Changes (namelist or namelist defaults changes)?
No namelist changes. The XML variable `CALENDAR` is now stored in `env_run.xml` instead of `env_build.xml`.

### Testing performed
Please describe the tests along with the target model and machine(s) 
If possible, please also added hashes that were used in the testing
1. Created a base case via `create_newcase` (`--compset IHistClm50BgcCrop`, `--mach ubuntu-latest`) and ran `./case.setup`.
2. Created a usermod directory containing `./xmlchange CALENDAR=GREGORIAN` in `shell_commands`.
3. Tested `create_clone --keepexe --user-mods-dir <usermod_path>` against the base case.
4. **Result:** Before this change, `create_clone` failed with an `env_build.xml` validation error. With this change, `create_clone` completes successfully with `--keepexe`.