### PR TITLE
Fix an NVHPC/25.9 compilation error in the CAM GPU regression test

### DIFF
--- a/mediator/esmFldsExchange_cesm_mod.F90
+++ b/mediator/esmFldsExchange_cesm_mod.F90
@@ -63,6 +63,7 @@ module esmFldsExchange_cesm_mod
   use med_internalstate_mod , only : mrg_fracname_lnd2atm_state, mrg_fracname_lnd2atm_flux, map_fracname_lnd2atm
   use med_internalstate_mod , only : mrg_fracname_lnd2rof, map_fracname_lnd2rof
   use med_internalstate_mod , only : mrg_fracname_lnd2glc, map_fracname_lnd2glc
+  use med_utils_mod         , only : chkerr => med_utils_chkerr
   use shr_log_mod           , only : shr_log_error
   use wtracers_mod          , only : wtracers_present
   use wtracers_mod          , only : WTRACERS_SUFFIX
@@ -121,7 +122,6 @@ contains
     use ESMF
     use NUOPC
     use med_kind_mod          , only : CX=>SHR_KIND_CX, CS=>SHR_KIND_CS, CL=>SHR_KIND_CL, R8=>SHR_KIND_R8
-    use med_utils_mod         , only : chkerr => med_utils_chkerr
     use med_methods_mod       , only : fldchk => med_methods_FB_FldChk
     use med_internalstate_mod , only : InternalState, logunit, maintask
     use med_internalstate_mod , only : compmed, compatm, complnd, compocn


### PR DESCRIPTION
### Description of changes

@cacraigucar identified a compilation error while running the CAM GPU regression test on Derecho. Reported in https://github.com/ESCOMP/CAM/pull/1637. This seemed to be an NVHPC-specific issue but I was able to work around it by changing two lines in the CMEPS source code.

### Specific notes

Contributors other than yourself, if any: N/A

CMEPS Issues Fixed (include github issue #): 

Are changes expected to change answers? (specify if bfb, different at roundoff, more substantial) **bfb**

Any User Interface Changes (namelist or namelist defaults changes)? No

### Testing performed
Please describe the tests along with the target model and machine(s) 
If possible, please also added hashes that were used in the testing

`ERS_Ln9.ne30pg3_ne30pg3_mt232.FHISTC_LTso.derecho_nvhpc.cam-outfrq9s_gpu_default` test on Derecho.
