### PR TITLE
fix(cmeps): Move CALENDAR to env_run.xml and add lock_on_restart="true"

### DIFF
--- a/cime_config/config_component.xml
+++ b/cime_config/config_component.xml
@@ -738,12 +738,12 @@
     Must be explicitly set in env_build.xml for userdefined machine.</desc>
   </entry>
 
-  <entry id="CALENDAR">
+  <entry id="CALENDAR" lock_on_restart="true">
     <type>char</type>
     <valid_values>NO_LEAP,GREGORIAN</valid_values>
     <default_value>NO_LEAP</default_value>
-    <group>build_def</group>
-    <file>env_build.xml</file>
+    <group>run_begin_stop_restart</group>
+    <file>env_run.xml</file>
     <desc>calendar type</desc>
   </entry>
 

--- a/cime_config/namelist_definition_drv.xml
+++ b/cime_config/namelist_definition_drv.xml
@@ -2736,8 +2736,8 @@
     <group>CLOCK_attributes</group>
     <valid_values>NO_LEAP,GREGORIAN</valid_values>
     <desc>
-      calendar in use.  [NO_LEAP, GREOGORIAN].
-      set by CALENDAR in env_build.xml
+      calendar in use.  [NO_LEAP, GREGORIAN].
+      set by CALENDAR in env_run.xml
     </desc>
     <values>
       <value>$CALENDAR</value>


### PR DESCRIPTION
### Description of changes

Moves `CALENDAR` variable definition from `env_build.xml` (group `build_def`) to `env_run.xml` (group `run_begin_stop_restart`), aligning its XML group with runtime initialization variables like `RUN_TYPE` and `RUN_STARTDATE`. Adds `lock_on_restart="true"` attribute to prevent modifying the calendar type on continuation runs (`CONTINUE_RUN=TRUE`). Also fixes a typo in `namelist_definition_drv.xml` documentation reference.

**Parent PR:** [#5030](https://github.com/ESMCI/cime/pull/5030) (Base branch: `feature/lock-on-restart` on `ESMCI/cime`)

### Specific notes

Contributors other than yourself, if any: None

Linked issues addressed, if any: Resolves [ESCOMP/CTSM#4122](https://github.com/ESCOMP/CTSM/issues/4122)

Are changes expected to change answers? (specify if bfb, different at roundoff, more substantial):
Bit-for-bit (B4B).

Any User Interface Changes (namelist or namelist defaults changes)?
Moves `CALENDAR` variable from `env_build.xml` to `env_run.xml` under group `run_begin_stop_restart`.

### Testing performed
- Tested XML schema validation using `xmllint` against `CIME/data/config/xml_schemas/entry_id.xsd`.
- Verified `CALENDAR` parameter move and locking functionality in case setup and continuation run tests.

### Generative AI usage:
Google Antigravity was used to write the code and tests, followed by human-guided verification.