### PR TITLE
Add a check that GLC has the coarsest coupling frequency

### DIFF
--- a/cime_config/runseq/runseq_general.py
+++ b/cime_config/runseq/runseq_general.py
@@ -58,10 +58,23 @@ def gen_runseq(case, coupling_times):
     # Note that we do some aspects of the GLC outer loop even if run_glc is False
     # (as long as med_to_glc is True).
     #
-    # Note that, in contrast to the other outer_loop variables, this doesn't check glc_cpl_time.
-    # This is for consistency with the logic that was in place before adding this variable;
-    # this seems to implicitly assume that glc_cpl_time > atm_cpl_time.
+    # Note that, in contrast to the other outer_loop variables, the logic for
+    # glc_outer_loop doesn't check glc_cpl_time. For more generality, we could have some
+    # extra logic determining whether we need a glc outer loop based on the relationship
+    # between glc_cpl_time and other cpl times. However, to avoid adding more complex
+    # logic, for now we just force glc coupling to be the coarsest coupling, and so assume
+    # that we have an outer loop for glc regardless of glc_cpl_time. Note that if
+    # glc_cpl_time is equal to one of the other coupling times, we'll end up with two
+    # loops with the same frequency; this is acceptable.
     glc_outer_loop = med_to_glc
+    if glc_outer_loop:
+        # In the following, we only bother checking glc_cpl_time against the other
+        # cpl_time variables that control the existence of time loops; other cpl_times are
+        # guaranteed to be equal to one of these cpl_time variables (as enforced above).
+        expect(((glc_cpl_time >= rof_cpl_time) and
+                (glc_cpl_time >= ocn_cpl_time) and
+                (glc_cpl_time >= atm_cpl_time)),
+                "glc_cpl_time must be greater than or equal to all other components' coupling times")
 
     inner_loop = ((atm_cpl_time < ocn_cpl_time) or
                   (atm_cpl_time < rof_cpl_time) or


### PR DESCRIPTION
### Description of changes

This was implicitly assumed but not checked.

### Specific notes

Contributors other than yourself, if any:

CMEPS Issues Fixed (include github issue #):
- Resolves ESCOMP/CMEPS#688

Are changes expected to change answers? (specify if bfb, different at roundoff, more substantial) bfb

Any User Interface Changes (namelist or namelist defaults changes)? no

### Testing performed
Just tested namelist generation, since this branch just adds error checking at namelist-generation time, and doesn't change any other behavior.

(1) Created case SMS_Ld2.ne30pg3_t232.B1850C_LTso.green_gnu - confirmed that no error is generated at preview_namelists time

(2) In that test, changed GLC_NCPL=8 (matching ROF_NCPL) - confirmed that no error is generated at preview_namelists time (though there is a duplicate `@10800` loop; this is okay as noted below)

(3) In that test, changed GLC_NCPL=24 - confirmed that an error IS generated

(4) Created an F compset test `SMS.ne30pg3_t232.HIST_CAM60_CLM50%SP_CICE%PRES_DOCN%DOM_MOSART_DGLC%NOEVOLVE_SWAV_SESP.green_gnu` - confirmed that no error is generated at preview_namelists time

(5) Created an I compset test `SMS.ne30pg3_t232.HIST_DATM%GSWP3v1_CLM50%SP_SICE_SOCN_MOSART_DGLC%NOEVOLVE_SWAV_SESP.green_gnu` - confirmed that no error is generated at preview_namelists time

(6) Confirmed that it is okay to have two loops with the same time frequency (as suggested by @mvertens ): Ran test `SMS_Ld2.ne30pg3_t232.B1850C_LTso.derecho_intel.allactive-defaultio` where I changed GLC_NCPL=8. Compared (a) a version with the auto-generated nuopc.runseq against (b) a version where I made this change:

```diff
--- CaseDocs/nuopc.runseq	2026-08-14 14:05:01.000000000 -0600
+++ nuopc.runseq	2026-08-14 14:07:28.000000000 -0600
@@ -1,6 +1,5 @@
 runSeq::
 @10800
-@10800
 @3600
 @1800
   MED med_phases_aofluxes_run
@@ -50,7 +49,6 @@
   ROF
   ROF -> MED :remapMethod=redist
   MED med_phases_post_rof
-@
   MED med_phases_prep_glc
   MED -> GLC :remapMethod=redist
   GLC
```

Both tests pass and are bit-for-bit with each other.