### PR TITLE
Correct wave history field units 

### DIFF
--- a/mediator/fd_cesm.yaml
+++ b/mediator/fd_cesm.yaml
@@ -1352,18 +1352,18 @@
      #
      - standard_name: Sw_phs0_avg
        canonical_units: m
-       description: Daily averaged averaged wind sea swh (only needed for mediator history output)
+       description: Daily averaged wind sea swh (only needed for mediator history output)
      #
      - standard_name: Sw_phs1_avg
        canonical_units: m
        description: Daily averaged swell swh (only needed for mediator history output)
      #
      - standard_name: Sw_pdir0_avg
-       canonical_units: degrees
+       canonical_units: radians
        description: Daily averaged wind sea swh (only needed for mediator history output)
      #
      - standard_name: Sw_pdir1_avg
-       canonical_units: degrees
+       canonical_units: radians
        description: Daily averaged swell swh (only needed for mediator history output)
      #
      - standard_name: Sw_pTm10_avg
@@ -1379,11 +1379,11 @@
        description: Daily averaged mean wave period of the first moment (only needed for mediator history output)
      #
      - standard_name: Sw_thm_avg
-       canonical_units: degrees
+       canonical_units: radians
        description: Daily averaged mean wave direction (only needed for mediator history output)
      #
      - standard_name: Sw_thp0_avg
-       canonical_units: degrees
+       canonical_units: radians
        description: Daily averaged peak wave direction (only needed for mediator history output)
      #
      - standard_name: Sw_fp0_avg


### PR DESCRIPTION
The following wave history fields have their units set to "degrees' erroneously. This PR changes the units to radians:

Sw_pdir0_avg, Sw_pdir1_avg, Sw_thm_avg, Sw_thp0_avg

Testing: g.e30.GW_JRA.TL319_t232
