### PR TITLE
Small fixes to address some issues with ESMF managed threading

### DIFF
--- a/cesm/nuopc_cap_share/driver_pio_mod.F90
+++ b/cesm/nuopc_cap_share/driver_pio_mod.F90
@@ -187,7 +187,7 @@ contains
     integer, intent(out) :: rc
 
     type(ESMF_VM) :: vm
-    integer :: i, npets, default_stride
+    integer :: i, npets, default_stride, lpet
     integer :: j, myid
     integer :: k
     integer :: comp_comm, comp_rank
@@ -275,6 +275,17 @@ contains
        if(associated(gcomp)) then
           petlocal(i) = ESMF_GridCompIsPetLocal(gcomp(i), rc=rc)
           if (chkerr(rc,__LINE__,u_FILE_u)) return
+
+          ! Under ESMF-managed threading, PETs whose PEs are lent to another PET's
+          ! threads hold no VM for the child; ESMF_VMGet returns localPet = -1 there
+          ! (NUOPC refdoc sec. 2.7.2), so treat them as non-local for PIO setup.
+          if (petlocal(i)) then
+             call ESMF_GridCompGet(gcomp(i), vm=vm, rc=rc)
+             if (chkerr(rc,__LINE__,u_FILE_u)) return
+             call ESMF_VMGet(vm, localPet=lpet, rc=rc)
+             if (chkerr(rc,__LINE__,u_FILE_u)) return
+             petlocal(i) = (lpet >= 0)
+          end if
 
           call NUOPC_CompAttributeGet(gcomp(i), name="pio_async_interface", value=cval, rc=rc)
           if (chkerr(rc,__LINE__,u_FILE_u)) return


### PR DESCRIPTION
### Description of changes

In CESM, ESMF_AWARE_THREADING (ESMF's managed threading) results in hangs because of issues with how PEs that are threads are treated like full PETs in CMEPS & NUOPC at the moment, but they can't do things like query the component VM.  Also, connectors built on PE lists (vs PET lists) would hang during RouteHandle creation.

The primary addition here is a small helper function that identifies PET-owning PEs (via a strided ID through an array of all PEs).  This might be better done inside ESMF, and if so, this code can be simplified in the future, but should be able to co-exist with those changes too.

### Specific notes

This is not a codebase I'm very familiar with, and a lot of this was aided by Claude.  I have run some test with it, but not an exhaustive CESM testlist yet.  I'd love feedback and to better understand the process for testing this in full, if not just via a new CESM tag pulling this in.

Contributors other than yourself, if any:
Claude AI

CMEPS Issues Fixed (include github issue #):
#701 
Potentially #483 but this was done independently and related to needing threaded runs for CMIP7 with CESM3.  No additional issue was created for that yet, as this is still a work in progress.

Are changes expected to change answers? (specify if bfb, different at roundoff, more substantial) 
No

Any User Interface Changes (namelist or namelist defaults changes)?
No

### Testing performed
Simple tests with a FHISTC_MTt4s case only for now, on Derecho -- expecting to do a coupled case later today.